### PR TITLE
[codex] Fix documentation drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <div align="left">
   <img src="docs/assets/images/jvn_logo.svg" width="460" alt="Java Vector Nexus logo">
   <br>
-  <strong>Current version:</strong> v0.1.3 <em></em>
+  <strong>Current version:</strong> v0.2.0 <em></em>
 </div>
 
 JVN is a young, modular cross-platform Visual Novel engine and 2D animation toolkit written in Java.
@@ -50,7 +50,7 @@ JVN is in heavy continuous development. Engine APIs, editor tooling, generated p
 
 ### Recommended JDK
 
-For local source builds, use [Eclipse Temurin 21 LTS](https://adoptium.net/temurin/releases/?version=21&package=jdk). It is the recommended JDK for JVN because it is a free, cross-platform OpenJDK distribution with long-term Java 21 support. Install the JDK package, then make sure `JAVA_HOME` points at that JDK before running `./jvnw`, `./jvn`, or `gradlew`.
+For local source builds, use [Eclipse Temurin 21 LTS](https://adoptium.net/temurin/releases/?version=21&package=jdk). It is the recommended JDK for JVN because it is a free, cross-platform OpenJDK distribution with long-term Java 21 support. Install the JDK package, then make sure `JAVA_HOME` points at that JDK before running `./jvnw`, `./jvn`, or `./gradlew`.
 
 On Bazzite, `./jvn` and `./jvnw` can automatically enter a Distrobox container with Java 21+ and `javac`, so the hub/editor can use the JDK installed there. Override the container with `JVN_DISTROBOX_CONTAINER=<name>`, force detection on another distro with `JVN_DISTROBOX=1`, or disable this handoff with `JVN_DISTROBOX=0`.
 
@@ -129,10 +129,14 @@ Useful JVN commands:
 ./jvnw check
 ./jvnw clean
 ./jvnw build-info
+./jvnw doctor
+./jvnw jar
 ./jvnw dist -PjvnGameProject=/path/to/game
 ./jvnw dist-all -PjvnGameProject=/path/to/game
 ./jvnw dist-runtime -PjvnGameProject=/path/to/game
 ./jvnw dist-runtime-all -PjvnGameProject=/path/to/game
+./jvnw dist-preflight -PjvnGameProject=/path/to/game
+./jvnw dist-clean
 ./jvnw runtime-cache
 ./jvnw runtime-cache-clear
 ./jvnw native -PjvnGameProject=/path/to/game
@@ -169,10 +173,14 @@ Default wrapper commands:
 ./jvnw compile
 ./jvnw quick
 ./jvnw build-info
+./jvnw doctor
+./jvnw jar
 ./jvnw dist -PjvnGameProject=/path/to/game
 ./jvnw dist-all -PjvnGameProject=/path/to/game
 ./jvnw dist-runtime -PjvnGameProject=/path/to/game
 ./jvnw dist-runtime-all -PjvnGameProject=/path/to/game
+./jvnw dist-preflight -PjvnGameProject=/path/to/game
+./jvnw dist-clean
 ./jvnw runtime-cache
 ./jvnw runtime-cache-clear
 ./jvnw native -PjvnGameProject=/path/to/game
@@ -201,6 +209,8 @@ Use:
 - `./jvnw dist-all -PjvnGameProject=/path/to/game` for cross-target portable zips
 - `./jvnw dist-runtime -PjvnGameProject=/path/to/game` for a self-contained desktop bundle for the current target
 - `./jvnw dist-runtime-all -PjvnGameProject=/path/to/game` for self-contained desktop bundles across all supported desktop targets
+- `./jvnw dist-preflight -PjvnGameProject=/path/to/game` to validate a package plan and write JSON/Markdown reports without packaging
+- `./jvnw dist-clean` to delete packaged game artifacts
 - `./jvnw runtime-cache` to inspect cached prebuilt desktop runtimes
 - `./jvnw runtime-cache-clear` to clear cached prebuilt desktop runtimes
 - `./jvnw native -PjvnGameProject=/path/to/game` for a current-host native package

--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -210,7 +210,7 @@ git commit -m "docs: refresh editor screenshots (May 2026)"
 
 3. **Add to INDEX.md:**
    - Find the relevant section
-   - Add link: `- [Page Title](path/to/page.md)`
+   - Add a Markdown link with the page title and its repository-relative path
 
 4. **Test links:**
    ```bash
@@ -305,8 +305,6 @@ If you reword but keep the link target the same:
 ## Resources
 
 - **Audit Report:** [Phase 0 Audit (May 2026)](plans/docs-audit-2026-05.md)
-- **Work Plans:** [Phase 1 Plans](plans/README.md)
-- **Progress:** [Session Progress Log](plans/PROGRESS.md)
 - **Index:** [Complete Documentation Index](INDEX.md)
 
 ---

--- a/docs/architecture/core/render-api.md
+++ b/docs/architecture/core/render-api.md
@@ -325,9 +325,9 @@ void testRegistryFindsAllBackends() {
 
 - **2D Engine:** [docs/architecture/core/2d-engine.md](2d-engine.md) — scene graph, entities, rendering pipeline
 - **Platform Runtimes:**
-  - [Android Runtime](../platforms/android-runtime.md)
-  - [iOS Runtime](../platforms/ios-runtime.md)
-  - [Web Runtime](../platforms/web-runtime.md)
+  - [Android Runtime](../../runtime/platforms/android-runtime.md)
+  - [iOS Runtime](../../runtime/platforms/ios-runtime.md)
+  - [Web Runtime](../../runtime/platforms/web-runtime.md)
 - **System Architecture:** [docs/architecture/core/system-architecture.md](system-architecture.md) — how renderer fits into Engine
 - **Interop:** [docs/runtime/core/interop.md](../../runtime/core/interop.md) — Java↔native integration
 

--- a/docs/architecture/internals/core-physics-api.md
+++ b/docs/architecture/internals/core-physics-api.md
@@ -451,9 +451,9 @@ void testCollisionDetection() {
 
 ## Related Documentation
 
-- **2D Engine:** [docs/architecture/core/2d-engine.md](2d-engine.md) — entities and rendering
+- **2D Engine:** [docs/architecture/core/2d-engine.md](../core/2d-engine.md) — entities and rendering
 - **JES Physics:** [docs/scripting/jes/systems/jes-physics.md](../../scripting/jes/systems/jes-physics.md) — high-level component wrapper
-- **System Architecture:** [docs/architecture/core/system-architecture.md](system-architecture.md) — how physics fits
+- **System Architecture:** [docs/architecture/core/system-architecture.md](../core/system-architecture.md) — how physics fits
 - **Performance Tips:** [docs/architecture/quality/performance.md](../quality/performance.md)
 
 ---

--- a/docs/runtime/platforms/android-runtime.md
+++ b/docs/runtime/platforms/android-runtime.md
@@ -344,8 +344,8 @@ android {
 
 ## Related Documentation
 
-- **Render-API:** [docs/architecture/core/render-api.md](../architecture/core/render-api.md) — backend abstraction
-- **Runtime Core:** [docs/runtime/core/runtime.md](../runtime/core/runtime.md) — JvnApp integration
+- **Render-API:** [docs/architecture/core/render-api.md](../../architecture/core/render-api.md) — backend abstraction
+- **Runtime Core:** [docs/runtime/core/runtime.md](../core/runtime.md) — JvnApp integration
 - **Asset Management:** [docs/runtime/systems/asset-management.md](../systems/asset-management.md) — asset resolution
 - **Save System:** [docs/runtime/systems/save-system.md](../systems/save-system.md) — save/load persistence
 

--- a/docs/runtime/platforms/ios-runtime.md
+++ b/docs/runtime/platforms/ios-runtime.md
@@ -397,7 +397,7 @@ print("JVN Engine initialized", to: &StdErr)
 
 ## Related Documentation
 
-- **Render-API:** [docs/architecture/core/render-api.md](../architecture/core/render-api.md) — backend abstraction
+- **Render-API:** [docs/architecture/core/render-api.md](../../architecture/core/render-api.md) — backend abstraction
 - **Runtime Core:** [docs/runtime/core/runtime.md](../core/runtime.md) — JvnApp integration
 - **Asset Management:** [docs/runtime/systems/asset-management.md](../systems/asset-management.md) — asset resolution
 - **Save System:** [docs/runtime/systems/save-system.md](../systems/save-system.md) — save/load persistence

--- a/docs/runtime/platforms/swing-runtime.md
+++ b/docs/runtime/platforms/swing-runtime.md
@@ -460,8 +460,8 @@ Swing renders on CPU. For better performance:
 
 ## Related Documentation
 
-- **Render-API:** [docs/architecture/core/render-api.md](../architecture/core/render-api.md) — backend abstraction
-- **Platform Runtimes:** [docs/runtime/platforms/README.md](../runtime/platforms/README.md) — all platforms
+- **Render-API:** [docs/architecture/core/render-api.md](../../architecture/core/render-api.md) — backend abstraction
+- **Platform Runtimes:** [docs/runtime/platforms/README.md](README.md) — all platforms
 - **Desktop (JavaFX):** Not separately documented; see Architecture Overview
 - **Runtime Core:** [docs/runtime/core/runtime.md](../core/runtime.md) — JvnApp wrapper
 

--- a/docs/runtime/platforms/web-runtime.md
+++ b/docs/runtime/platforms/web-runtime.md
@@ -532,7 +532,7 @@ For development iteration:
 
 ## Related Documentation
 
-- **Render-API:** [docs/architecture/core/render-api.md](../architecture/core/render-api.md) — backend abstraction
+- **Render-API:** [docs/architecture/core/render-api.md](../../architecture/core/render-api.md) — backend abstraction
 - **Runtime Core:** [docs/runtime/core/runtime.md](../core/runtime.md) — JvnApp integration
 - **Asset Management:** [docs/runtime/systems/asset-management.md](../systems/asset-management.md) — asset resolution
 - **Save System:** [docs/runtime/systems/save-system.md](../systems/save-system.md) — save/load persistence

--- a/docs/scripting/timeline/animation/core-animation-api.md
+++ b/docs/scripting/timeline/animation/core-animation-api.md
@@ -416,7 +416,7 @@ public void testEasingCurves() {
 - **Puppeteer JES DSL:** [docs/editor/puppeteer/puppeteer-jes-dsl.md](../../../editor/puppeteer/puppeteer-jes-dsl.md) — exported timeline syntax
 - **JES Actions:** [docs/scripting/jes/timeline/jes-timeline.md](../../jes/timeline/jes-timeline.md) — `move`, `rotate`, `fade` etc.
 - **VNS Transitions:** [docs/scripting/vns/presentation/vns-transitions.md](../../vns/presentation/vns-transitions.md) — screen effects
-- **2D Engine:** [docs/architecture/core/2d-engine.md](../../architecture/core/2d-engine.md) — Scene2DBase render pipeline
+- **2D Engine:** [docs/architecture/core/2d-engine.md](../../../architecture/core/2d-engine.md) — Scene2DBase render pipeline
 
 ---
 


### PR DESCRIPTION
## What changed

- aligned the README version and documented wrapper commands with the active Gradle build and `jvnw` help
- repaired broken cross-document links in architecture, runtime-platform, animation, and maintenance docs
- removed references to maintenance-plan files that no longer exist

## Why

The documentation had drifted from the 0.2.0 build configuration and contained relative links that resolved to nonexistent paths.

## Impact

Readers now see the current project version, the complete supported wrapper command set, and working navigation between related documentation pages.

## Validation

- `./jvnw --help`
- `./jvnw build-info`
- `ELECTRON_RUN_AS_NODE=1 /app/share/codium/com.vscodium.codium scripts/doc-lint.mjs` (passes with 0 errors)
- `git diff --check`
