### PR TITLE
Improve game build publishing workflow

### DIFF
--- a/.github/fixtures/native-smoke-game/jvn.project
+++ b/.github/fixtures/native-smoke-game/jvn.project
@@ -1,0 +1,8 @@
+name=JVN Native Smoke
+version=1.0.0
+type=vn
+entryVns=scripts/story/prologue.vns
+runtime.ui=fx
+runtime.audio=auto
+width=960
+height=540

--- a/.github/fixtures/native-smoke-game/scripts/story/prologue.vns
+++ b/.github/fixtures/native-smoke-game/scripts/story/prologue.vns
@@ -1,0 +1,3 @@
+@scene prologue
+
+narrator: Native packaging smoke test.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           retention-days: 14
 
   platform-smoke:
-    name: Compile smoke (${{ matrix.os }})
+    name: Native package smoke (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
@@ -70,6 +70,35 @@ jobs:
         run: /bin/bash ./scripts/test-jvnw-bootstrap.sh
       - name: Compile every module
         run: ./gradlew compileAll
+      - name: Build and inspect unsigned native installer
+        shell: bash
+        run: |
+          set -eu
+          package_type=dmg
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            package_type=msi
+          fi
+          args=(
+            -PjvnGameProject="$GITHUB_WORKSPACE/.github/fixtures/native-smoke-game"
+            -PjvnGameName="JVN Native Smoke"
+            -PjvnGameVersion=1.0.0
+            -PjvnPackageMode=native
+            -PjvnNativePackageType="$package_type"
+            -PjvnReleaseProfile=default
+            --no-daemon
+          )
+          ./gradlew packageJvnGameNativeCurrent "${args[@]}"
+          ./gradlew smokeTestJvnGameRelease "${args[@]}"
+      - name: Upload native smoke reports
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: native-smoke-${{ runner.os }}
+          path: |
+            build/distributions/games/
+            build/reports/problems/
+          if-no-files-found: ignore
+          retention-days: 14
 
   dependency-review:
     name: Dependency review

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -753,29 +753,45 @@ fun gamePackageIconFile(): File? {
     .firstOrNull { it.isFile }
 }
 
+fun gamePackageExcludes(): List<String> {
+  val defaults = listOf(
+    ".git/**",
+    ".gradle/**",
+    ".jvn-gradle-user-home/**",
+    ".jvnignore",
+    "build/**",
+    "out/**",
+    "dist/**",
+    "save/**",
+    "saves/**",
+    "logs/**",
+    ".idea/**",
+    ".vscode/**",
+    "__MACOSX/**",
+    "**/*.log",
+    "**/*.tmp",
+    "**/Icon\r",
+    "**/.DS_Store",
+    "**/Thumbs.db"
+  )
+  val authoredProject = (findProperty("jvnGameProject") as String?)
+    ?.trim()
+    ?.takeIf { it.isNotBlank() }
+    ?.let { file(it) }
+  val authored = authoredProject?.resolve(".jvnignore")
+    ?.takeIf { it.isFile }
+    ?.readLines()
+    ?.map { it.trim() }
+    ?.filter { it.isNotBlank() && !it.startsWith("#") }
+    ?: emptyList()
+  return (defaults + authored).distinct()
+}
+
 fun copyGameProjectFiles(destination: File) {
   copy {
     from(gameProjectDir())
     into(destination)
-    exclude(
-      ".git/**",
-      ".gradle/**",
-      ".jvn-gradle-user-home/**",
-      "build/**",
-      "out/**",
-      "dist/**",
-      "save/**",
-      "saves/**",
-      "logs/**",
-      ".idea/**",
-      ".vscode/**",
-      "__MACOSX/**",
-      "**/*.log",
-      "**/*.tmp",
-      "**/Icon\r",
-      "**/.DS_Store",
-      "**/Thumbs.db"
-    )
+    exclude(gamePackageExcludes())
   }
 }
 
@@ -1522,6 +1538,40 @@ fun gameVersion(): String {
     ?: project.version.toString()
 }
 
+fun gameDisplayNameForTaskDiscovery(): String {
+  val explicit = (findProperty("jvnGameName") as String?)?.trim()
+  if (!explicit.isNullOrBlank()) return explicit
+  val rawProject = (findProperty("jvnGameProject") as String?)?.trim()
+  if (rawProject.isNullOrBlank()) return "jvn-game"
+  val dir = file(rawProject)
+  val manifest = File(dir, "jvn.project")
+  if (manifest.isFile) {
+    val props = Properties()
+    runCatching { manifest.inputStream().use { props.load(it) } }
+    val manifestName = props.getProperty("name", "").trim()
+    if (manifestName.isNotBlank()) return manifestName
+  }
+  return dir.name.ifBlank { "jvn-game" }
+}
+
+fun gameVersionForTaskDiscovery(): String {
+  val explicit = (findProperty("jvnGameVersion") as String?)?.trim()
+  if (!explicit.isNullOrBlank()) return explicit
+  val rawProject = (findProperty("jvnGameProject") as String?)?.trim()
+  if (!rawProject.isNullOrBlank()) {
+    val manifest = File(file(rawProject), "jvn.project")
+    if (manifest.isFile) {
+      val props = Properties()
+      runCatching { manifest.inputStream().use { props.load(it) } }
+      listOf("version", "releaseVersion", "build.version")
+        .map { props.getProperty(it, "").trim() }
+        .firstOrNull { it.isNotBlank() }
+        ?.let { return it }
+    }
+  }
+  return project.version.toString()
+}
+
 fun gameDistName(target: JvnGameTarget): String {
   return "${sanitizeGameName(gameDisplayName())}-${sanitizeGameName(gameVersion())}-${target.id}"
 }
@@ -1733,8 +1783,8 @@ val gameZipTasks = jvnGameTargets.map { target ->
   tasks.register<Zip>("assembleJvnGamePortable${target.taskSuffix}") {
     group = "distribution"
     description = "Assembles a portable JVN game zip for ${target.id}. Requires -PjvnGameProject=/path/to/game."
-    archiveBaseName.set(providers.provider { sanitizeGameName(gameDisplayName()) })
-    archiveVersion.set(providers.provider { sanitizeGameName(gameVersion()) })
+    archiveBaseName.set(providers.provider { sanitizeGameName(gameDisplayNameForTaskDiscovery()) })
+    archiveVersion.set(providers.provider { sanitizeGameName(gameVersionForTaskDiscovery()) })
     archiveClassifier.set(target.id)
     destinationDirectory.set(layout.buildDirectory.dir("distributions/games"))
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
@@ -1763,25 +1813,7 @@ val gameZipTasks = jvnGameTargets.map { target ->
     }
     from({ gameProjectDir() }) {
       into(providers.provider { "${gameDistName(target)}/game" })
-      exclude(
-        ".git/**",
-        ".gradle/**",
-        ".jvn-gradle-user-home/**",
-        "build/**",
-        "out/**",
-        "dist/**",
-        "save/**",
-        "saves/**",
-        "logs/**",
-        ".idea/**",
-        ".vscode/**",
-        "__MACOSX/**",
-        "**/*.log",
-        "**/*.tmp",
-        "**/Icon\r",
-        "**/.DS_Store",
-        "**/Thumbs.db"
-      )
+      exclude(gamePackageExcludes())
     }
     doLast {
       verifyPortableArtifact(target, archiveFile.get().asFile)
@@ -2258,132 +2290,6 @@ tasks.register("releaseJvnGameNativeCurrent") {
     maybeSignWindowsArtifact(artifact)
     maybeNotarizeMacArtifact(currentJpackageType(), artifact)
     runPublishCommands("native", artifact)
-  }
-}
-
-// Web export tasks
-tasks.register("assembleJvnGameWeb") {
-  group = "distribution"
-  description = "Builds a WebAssembly bundle for browser-based play using TeaVM."
-  doLast {
-    val distDir = File(buildDir, "distributions")
-    distDir.mkdirs()
-
-    logger.info("Web export task: Building WebAssembly bundle")
-    logger.info("TeaVM compilation not yet configured")
-    logger.info("To enable: Add org.teavm:teavm-gradle-plugin to web-runtime/build.gradle.kts")
-
-    // Create placeholder web bundle with metadata
-    val webBundleName = "game-${version}-web.zip"
-    val webBundleFile = File(distDir, webBundleName)
-
-    val htmlContent = """
-      <!DOCTYPE html>
-      <html>
-      <head>
-        <meta charset="utf-8">
-        <title>JVN Game</title>
-        <style>
-          body { font-family: Arial; margin: 0; padding: 20px; background: #333; color: #fff; }
-          canvas { border: 1px solid white; display: block; }
-        </style>
-      </head>
-      <body>
-        <h1>Game (WASM Bundle)</h1>
-        <canvas id="game-canvas" width="800" height="600"></canvas>
-        <p>TeaVM WASM compilation not yet configured.</p>
-        <p>To generate the actual game.js and .wasm files:</p>
-        <ol>
-          <li>Configure TeaVM Gradle plugin in web-runtime/build.gradle.kts</li>
-          <li>Run: ./gradlew :web-runtime:compileTeaVM</li>
-          <li>Output will be placed in: build/distributions/</li>
-        </ol>
-      </body>
-      </html>
-    """.trimIndent()
-
-    val metadataContent = """
-      name=game-${version}-web
-      type=wasm
-      format=web-bundle
-      target=browser
-      required-toolchain=TeaVM 0.10.0+
-      status=scaffolding
-    """.trimIndent()
-
-    // Create zip with stub content
-    ant.withGroovyBuilder {
-      "zip"("destfile" to webBundleFile.absolutePath) {
-        "fileset"("dir" to buildDir.absolutePath) {
-          "include"("name" to "README-web.txt")
-        }
-        "zipfileset"("file" to File(buildDir, "temp-web-readme.txt").also {
-          it.writeText(htmlContent)
-        }.absolutePath, "fullpath" to "index.html")
-      }
-    }
-
-    // Clean up temp file
-    File(buildDir, "temp-web-readme.txt").delete()
-
-    logger.info("Web bundle created: ${webBundleFile.absolutePath}")
-    logger.info("Note: This is a placeholder. Run 'assembleJvnGameWeb' after TeaVM configuration for actual WASM output.")
-  }
-}
-
-// Mobile export tasks
-tasks.register("assembleJvnGameMobile") {
-  group = "distribution"
-  description = "Builds native mobile packages (Android APK/AAB and iOS IPA)."
-  doLast {
-    val osId = System.getProperty("os.name", "").lowercase()
-    val distDir = File(buildDir, "distributions")
-    distDir.mkdirs()
-
-    logger.info("Mobile export task: Building native mobile packages")
-
-    if (osId.contains("win") || osId.contains("linux")) {
-      logger.info("Android build: Requires Android SDK and Android Gradle Plugin")
-      logger.info("To enable: Apply com.android.application plugin to android-runtime/build.gradle.kts")
-
-      // Create placeholder Android manifest
-      val androidMetadata = """
-        name=game-${version}-android
-        type=apk
-        format=android-package
-        target=android-api-24+
-        required-toolchain=Android SDK 34+, Android Gradle Plugin 8.0+
-        status=scaffolding
-      """.trimIndent()
-
-      val androidMetadataFile = File(distDir, "game-${version}-android.metadata.txt")
-      androidMetadataFile.writeText(androidMetadata)
-      logger.info("Android placeholder created: ${androidMetadataFile.absolutePath}")
-    }
-
-    if (osId.contains("mac")) {
-      logger.info("iOS build: Requires macOS + Xcode and Multi-OS Engine (MOE)")
-      logger.info("To enable: Apply org.moe plugin to ios-runtime/build.gradle.kts")
-
-      // Create placeholder iOS metadata
-      val iosMetadata = """
-        name=game-${version}-ios
-        type=ipa
-        format=ios-package
-        target=ios-13.0+
-        required-toolchain=Xcode 14+, Multi-OS Engine 1.10+
-        status=scaffolding
-      """.trimIndent()
-
-      val iosMetadataFile = File(distDir, "game-${version}-ios.metadata.txt")
-      iosMetadataFile.writeText(iosMetadata)
-      logger.info("iOS placeholder created: ${iosMetadataFile.absolutePath}")
-    } else {
-      logger.info("iOS builds only supported on macOS")
-    }
-
-    logger.info("Mobile export: Placeholder metadata created in ${distDir.absolutePath}")
-    logger.info("Note: This is a placeholder. Configure the appropriate plugin for actual APK/IPA output.")
   }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,8 +10,11 @@ import org.gradle.api.tasks.testing.Test
 import org.gradle.jvm.tasks.Jar
 import org.gradle.jvm.toolchain.JavaToolchainService
 import org.gradle.process.ExecOperations
+import java.io.ByteArrayOutputStream
 import java.net.HttpURLConnection
 import java.net.URI
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
 import java.security.MessageDigest
 import java.security.KeyFactory
 import java.security.Signature
@@ -677,8 +680,164 @@ fun verifyBundledRuntimeArtifact(target: JvnGameTarget, artifact: File) {
   writeArtifactChecksum(artifact)
 }
 
+fun commandOutput(vararg command: String): String {
+  val output = ByteArrayOutputStream()
+  val result = jvnExecOperations.exec {
+    commandLine(*command)
+    standardOutput = output
+    errorOutput = output
+    isIgnoreExitValue = true
+  }
+  if (result.exitValue != 0) {
+    throw GradleException("Command failed (${command.joinToString(" ")}): ${output.toString().trim()}")
+  }
+  return output.toString().trim()
+}
+
+fun extractZipSafely(artifact: File, destination: File) {
+  deleteAndMkdir(destination)
+  val root = destination.canonicalFile.toPath()
+  ZipFile(artifact).use { zip ->
+    val entries = zip.entries()
+    while (entries.hasMoreElements()) {
+      val entry = entries.nextElement()
+      val output = destination.resolve(entry.name).canonicalFile
+      if (!output.toPath().startsWith(root)) throw GradleException("Unsafe native app-image entry: ${entry.name}")
+      if (entry.isDirectory) output.mkdirs() else {
+        output.parentFile.mkdirs()
+        zip.getInputStream(entry).use { input -> output.outputStream().use { input.copyTo(it) } }
+      }
+    }
+  }
+}
+
+fun findSingle(root: File, predicate: (File) -> Boolean, label: String): File {
+  val matches = root.walkTopDown().filter { predicate(it) }.toList()
+  if (matches.isEmpty()) throw GradleException("Native package is missing $label under ${root.absolutePath}")
+  return matches.first()
+}
+
+fun verifyPackagedEntry(gameRoot: File) {
+  val manifest = gameRoot.resolve("jvn.project")
+  if (!manifest.isFile) throw GradleException("Native package is missing bundled jvn.project")
+  val props = Properties()
+  manifest.inputStream().use { props.load(it) }
+  val type = props.getProperty("type", "vn").trim().lowercase()
+  val rawEntry = if (type == "jes") props.getProperty("entry") else props.getProperty("entryVns")
+  val entry = if (type == "jes") rawEntry?.let { gameRoot.resolve(it) } else resolveScriptFile(gameRoot, rawEntry)
+  if (entry == null || !entry.isFile) {
+    throw GradleException("Native package manifest entry is missing: ${rawEntry ?: "(not configured)"}")
+  }
+}
+
+fun verifyRuntimeModules(javaExecutable: File) {
+  if (!javaExecutable.isFile) throw GradleException("Native package is missing runtime Java: ${javaExecutable.absolutePath}")
+  if (!currentHostIsWindows()) javaExecutable.setExecutable(true)
+  val modules = commandOutput(javaExecutable.absolutePath, "--list-modules")
+  runtimeImageModules().forEach { module ->
+    if (!modules.lineSequence().any { it.substringBefore('@') == module }) {
+      throw GradleException("Native runtime is missing required module '$module'")
+    }
+  }
+}
+
+fun verifyLauncherConfig(config: File) {
+  if (!config.isFile) throw GradleException("Native package is missing jpackage launcher configuration")
+  val text = config.readText()
+  if (!text.contains("app.mainclass=${gamePackagedMainClass()}")) {
+    throw GradleException("Native launcher does not use ${gamePackagedMainClass()}")
+  }
+  if (!text.contains("app.classpath=")) throw GradleException("Native launcher has no application classpath")
+}
+
+fun verifyMacNativePayload(app: File) {
+  val contents = app.resolve("Contents")
+  val executableName = commandOutput("/usr/libexec/PlistBuddy", "-c", "Print :CFBundleExecutable", contents.resolve("Info.plist").absolutePath)
+  val executable = contents.resolve("MacOS/$executableName")
+  val architecture = commandOutput("file", executable.absolutePath)
+  val expected = if (currentPackageHost().target.id.endsWith("aarch64")) "arm64" else "x86_64"
+  if (!architecture.contains(expected)) throw GradleException("Native executable architecture mismatch: $architecture")
+  verifyRuntimeModules(contents.resolve("runtime/Contents/Home/bin/java"))
+  verifyLauncherConfig(contents.resolve("app/$executableName.cfg"))
+  verifyPackagedEntry(contents.resolve("content/game"))
+  val iconName = commandOutput("/usr/libexec/PlistBuddy", "-c", "Print :CFBundleIconFile", contents.resolve("Info.plist").absolutePath)
+  if (!contents.resolve("Resources/$iconName").isFile) throw GradleException("Native macOS app is missing bundle icon '$iconName'")
+  if (selectedReleaseProfile().flag("mac.sign")) {
+    commandOutput("codesign", "--verify", "--deep", "--strict", app.absolutePath)
+  }
+}
+
+fun verifyWindowsNativePayload(root: File) {
+  val executable = findSingle(root, { it.isFile && it.extension.equals("exe", true) && it.parentFile.name.equals("bin", true) }, "launcher executable")
+  val cfg = findSingle(root, { it.isFile && it.extension.equals("cfg", true) && it.parentFile.name.equals("app", true) }, "launcher configuration")
+  val java = findSingle(root, { it.isFile && it.name.equals("java.exe", true) && it.parentFile.name.equals("bin", true) }, "runtime Java")
+  val game = findSingle(root, { it.isFile && it.name == "jvn.project" && it.parentFile.name == "game" }, "bundled jvn.project").parentFile
+  verifyRuntimeModules(java)
+  verifyLauncherConfig(cfg)
+  verifyPackagedEntry(game)
+  val bytes = executable.readBytes()
+  val peOffset = ByteBuffer.wrap(bytes, 0x3c, 4).order(ByteOrder.LITTLE_ENDIAN).int
+  val machine = ByteBuffer.wrap(bytes, peOffset + 4, 2).order(ByteOrder.LITTLE_ENDIAN).short.toInt() and 0xffff
+  if (machine != 0x8664) throw GradleException("Native Windows launcher is not x64 (PE machine=0x${machine.toString(16)})")
+  if (gamePackageIconFile() != null) {
+    val iconDimensions = commandOutput(
+      "powershell", "-NoProfile", "-Command",
+      "Add-Type -AssemblyName System.Drawing; " +
+        "\$icon = [System.Drawing.Icon]::ExtractAssociatedIcon('${executable.absolutePath.replace("'", "''")}'); " +
+        "if (\$null -eq \$icon) { exit 1 }; " +
+        "Write-Output \"\$(\$icon.Width)x\$(\$icon.Height)\""
+    )
+    if (!Regex("\\d+x\\d+").matches(iconDimensions)) {
+      throw GradleException("Native Windows launcher icon could not be inspected: $iconDimensions")
+    }
+  }
+  if (selectedReleaseProfile().flag("win.sign")) {
+    val signature = commandOutput("powershell", "-NoProfile", "-Command", "(Get-AuthenticodeSignature -LiteralPath '${executable.absolutePath.replace("'", "''")}').Status")
+    if (!signature.equals("Valid", true)) throw GradleException("Windows package signature is not valid: $signature")
+  }
+}
+
+fun verifyNativeArtifact(artifact: File, packageType: String) {
+  val inspectRoot = layout.buildDirectory.dir("tmp/jvn-native-smoke/${currentPackageHost().target.id}-$packageType").get().asFile
+  deleteAndMkdir(inspectRoot)
+  try {
+    when (packageType) {
+      "dmg" -> {
+        val mount = inspectRoot.resolve("mount")
+        mount.mkdirs()
+        commandOutput("hdiutil", "attach", "-nobrowse", "-readonly", "-mountpoint", mount.absolutePath, artifact.absolutePath)
+        try {
+          verifyMacNativePayload(findSingle(mount, { it.isDirectory && it.extension == "app" }, "macOS app bundle"))
+        } finally {
+          commandOutput("hdiutil", "detach", mount.absolutePath)
+        }
+      }
+      "msi" -> {
+        val extracted = inspectRoot.resolve("extracted")
+        extracted.mkdirs()
+        commandOutput("msiexec", "/a", artifact.absolutePath, "/qn", "TARGETDIR=${extracted.absolutePath}")
+        verifyWindowsNativePayload(extracted)
+      }
+      "app-image" -> {
+        val extracted = inspectRoot.resolve("extracted")
+        extractZipSafely(artifact, extracted)
+        when (currentPackageHost().osId) {
+          "macos" -> verifyMacNativePayload(findSingle(extracted, { it.isDirectory && it.extension == "app" }, "macOS app bundle"))
+          "windows" -> verifyWindowsNativePayload(extracted)
+        }
+      }
+      else -> {
+        if (!artifact.isFile || artifact.length() <= 0L) throw GradleException("Native package is missing or empty")
+      }
+    }
+    writeArtifactChecksum(artifact)
+  } finally {
+    inspectRoot.deleteRecursively()
+  }
+}
+
 fun verifyNativeArtifact(artifact: File) {
-  writeArtifactChecksum(artifact)
+  verifyNativeArtifact(artifact, currentJpackageType())
 }
 
 fun gameBundledDistName(target: JvnGameTarget): String {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -203,6 +203,12 @@ val jvnGameRuntimeProjectPaths = listOf(
   ":runtime",
   ":demo-game"
 )
+val jvnGamePackagingRuntime = configurations.create("jvnGamePackagingRuntime") {
+  isCanBeResolved = true
+  isCanBeConsumed = false
+  description = "Runtime dependencies staged into JVN desktop game packages."
+}
+dependencies.add(jvnGamePackagingRuntime.name, project(":runtime"))
 val jvnGameJavaFxConfigurations = mutableMapOf<String, org.gradle.api.artifacts.Configuration>()
 
 fun currentGameTarget(): JvnGameTarget {
@@ -2009,8 +2015,7 @@ fun gameBuildMetadata(target: JvnGameTarget, distName: String): String {
 }
 
 fun externalRuntimeJars(): List<File> {
-  val runtimeRuntime = project(":runtime").configurations.getByName("runtimeClasspath").resolve()
-  return runtimeRuntime
+  return jvnGamePackagingRuntime.resolve()
     .filter { it.isFile && it.extension.equals("jar", ignoreCase = true) }
     .filterNot { it.name.startsWith("javafx-") }
     .distinctBy { it.name }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,8 +13,14 @@ import org.gradle.process.ExecOperations
 import java.net.HttpURLConnection
 import java.net.URI
 import java.security.MessageDigest
+import java.security.KeyFactory
+import java.security.Signature
+import java.security.spec.PKCS8EncodedKeySpec
 import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
 import java.util.Properties
+import java.util.Base64
 import java.util.zip.ZipFile
 import javax.inject.Inject
 
@@ -138,6 +144,18 @@ data class JvnReleaseProfile(
         }
     }
     return values.toSortedMap().values.toList()
+  }
+
+  fun values(prefix: String): List<String> {
+    val roots = listOf("profile.$name.$prefix.", "profile.default.$prefix.")
+    val values = linkedMapOf<String, String>()
+    roots.forEach { root ->
+      properties.stringPropertyNames()
+        .filter { it.startsWith(root) }
+        .sortedWith(compareBy({ it.removePrefix(root).toIntOrNull() ?: Int.MAX_VALUE }, { it }))
+        .forEach { key -> values.putIfAbsent(key.removePrefix(root), properties.getProperty(key).trim()) }
+    }
+    return values.values.filter { it.isNotBlank() }
   }
 }
 
@@ -434,6 +452,25 @@ fun selectedReleaseProfile(): JvnReleaseProfile {
   return JvnReleaseProfile(selectedReleaseProfileName(), gameReleaseConfigFile(), gameReleaseConfig())
 }
 
+fun selectedPackageVariant(): String {
+  val explicit = (findProperty("jvnPackageVariant") as String?)?.trim()
+  if (!explicit.isNullOrBlank()) return explicit
+  return gameReleaseConfig().getProperty("defaultVariant", "standard").trim().ifBlank { "standard" }
+}
+
+fun packageVariantSuffix(): String {
+  val variant = sanitizeGameName(selectedPackageVariant())
+  return if (variant.equals("standard", ignoreCase = true)) "" else "-$variant"
+}
+
+fun numberedPropertyValues(properties: Properties, prefix: String): List<String> {
+  return properties.stringPropertyNames()
+    .filter { it.startsWith("$prefix.") }
+    .sortedWith(compareBy({ it.removePrefix("$prefix.").toIntOrNull() ?: Int.MAX_VALUE }, { it }))
+    .map { properties.getProperty(it).trim() }
+    .filter { it.isNotBlank() }
+}
+
 fun nativeGameVersion(): String {
   val explicit = (findProperty("jvnNativeVersion") as String?)?.trim()
   if (!explicit.isNullOrBlank()) return explicit
@@ -576,7 +613,15 @@ fun assertZipArtifactContains(artifact: File, label: String, requiredSuffixes: L
     val entries = zip.entries()
     while (entries.hasMoreElements()) {
       val entry = entries.nextElement()
-      if (!entry.isDirectory) names += entry.name.replace('\\', '/')
+      val normalized = entry.name.replace('\\', '/')
+      if (normalized.startsWith("/") || normalized.split('/').any { it == ".." }) {
+        throw GradleException("$label artifact ${artifact.name} contains an unsafe archive path: ${entry.name}")
+      }
+      if (!entry.isDirectory) names += normalized
+    }
+    val duplicates = names.groupingBy { it }.eachCount().filterValues { it > 1 }.keys
+    if (duplicates.isNotEmpty()) {
+      throw GradleException("$label artifact ${artifact.name} contains duplicate entries: ${duplicates.take(10).joinToString(", ")}")
     }
     val missing = requiredSuffixes.filter { suffix ->
       names.none { name ->
@@ -631,12 +676,12 @@ fun verifyNativeArtifact(artifact: File) {
 }
 
 fun gameBundledDistName(target: JvnGameTarget): String {
-  return "${sanitizeGameName(gameDisplayName())}-${sanitizeGameName(gameVersion())}-${target.id}-runtime"
+  return "${sanitizeGameName(gameDisplayName())}-${sanitizeGameName(gameVersion())}${packageVariantSuffix()}-${target.id}-runtime"
 }
 
 fun gameNativeArtifactStem(packageType: String): String {
   val host = currentPackageHost()
-  return "${sanitizeGameName(gameDisplayName())}-${sanitizeGameName(nativeGameVersion())}-${host.target.id}-$packageType"
+  return "${sanitizeGameName(gameDisplayName())}-${sanitizeGameName(nativeGameVersion())}${packageVariantSuffix()}-${host.target.id}-$packageType"
 }
 
 fun jpackageAppName(): String {
@@ -753,7 +798,7 @@ fun gamePackageIconFile(): File? {
     .firstOrNull { it.isFile }
 }
 
-fun gamePackageExcludes(): List<String> {
+fun gamePackageExcludes(targetId: String? = null): List<String> {
   val defaults = listOf(
     ".git/**",
     ".gradle/**",
@@ -784,14 +829,38 @@ fun gamePackageExcludes(): List<String> {
     ?.map { it.trim() }
     ?.filter { it.isNotBlank() && !it.startsWith("#") }
     ?: emptyList()
-  return (defaults + authored).distinct()
+  val releaseProperties = Properties()
+  authoredProject?.let { dir ->
+    listOf(
+      File(dir, "config/release/jvn-release.properties"),
+      File(dir, "config/release/release.properties"),
+      File(dir, "release/jvn-release.properties"),
+      File(dir, "jvn-release.properties")
+    ).firstOrNull { it.isFile }?.inputStream()?.use { releaseProperties.load(it) }
+  }
+  val variant = (findProperty("jvnPackageVariant") as String?)?.trim()
+    ?.takeIf { it.isNotBlank() }
+    ?: releaseProperties.getProperty("defaultVariant", "standard").trim().ifBlank { "standard" }
+  val profileName = (findProperty("jvnReleaseProfile") as String?)?.trim()
+    ?.takeIf { it.isNotBlank() }
+    ?: releaseProperties.getProperty("defaultProfile", "default").trim().ifBlank { "default" }
+  val platform = targetId?.substringBefore('-')
+  val configured = buildList {
+    addAll(numberedPropertyValues(releaseProperties, "variant.$variant.exclude"))
+    addAll(numberedPropertyValues(releaseProperties, "profile.$profileName.package.exclude"))
+    if (!platform.isNullOrBlank()) {
+      addAll(numberedPropertyValues(releaseProperties, "variant.$variant.$platform.exclude"))
+      addAll(numberedPropertyValues(releaseProperties, "profile.$profileName.package.$platform.exclude"))
+    }
+  }
+  return (defaults + authored + configured).distinct()
 }
 
-fun copyGameProjectFiles(destination: File) {
+fun copyGameProjectFiles(destination: File, targetId: String = currentGameTarget().id) {
   copy {
     from(gameProjectDir())
     into(destination)
-    exclude(gamePackageExcludes())
+    exclude(gamePackageExcludes(targetId))
   }
 }
 
@@ -1194,6 +1263,7 @@ fun jvnGameBuildPlanMap(): Map<String, Any?> {
     "packageMode" to selectedJvnGamePackageMode(),
     "requestedTarget" to selectedJvnGameTargetToken(),
     "releaseProfile" to profile.name,
+    "packageVariant" to selectedPackageVariant(),
     "releaseConfig" to (profile.file?.absolutePath ?: ""),
     "warnings" to validation.warnings,
     "artifacts" to artifacts.map { artifact ->
@@ -1221,7 +1291,7 @@ fun jvnGameReleaseManifestMap(): Map<String, Any?> {
   val profile = selectedReleaseProfile()
   val artifacts = selectedJvnGamePlannedArtifacts()
   return mapOf(
-    "schema" to 1,
+    "schema" to 2,
     "generatedAt" to Instant.now().toString(),
     "engineVersion" to project.version.toString(),
     "workspaceRoot" to rootDir.absolutePath,
@@ -1235,7 +1305,9 @@ fun jvnGameReleaseManifestMap(): Map<String, Any?> {
     "packageMode" to selectedJvnGamePackageMode(),
     "requestedTarget" to selectedJvnGameTargetToken(),
     "releaseProfile" to profile.name,
+    "packageVariant" to selectedPackageVariant(),
     "releaseConfig" to (profile.file?.absolutePath ?: ""),
+    "provenance" to jvnReleaseProvenance(),
     "warnings" to validation.warnings,
     "artifacts" to artifacts.map { artifact ->
       val checksumFile = artifactChecksumFile(artifact.artifact)
@@ -1255,6 +1327,38 @@ fun jvnGameReleaseManifestMap(): Map<String, Any?> {
         "checksumExists" to checksumFile.isFile
       )
     }
+  )
+}
+
+fun commandOutput(workingDir: File, vararg command: String): String? {
+  return try {
+    val process = ProcessBuilder(*command)
+      .directory(workingDir)
+      .redirectErrorStream(true)
+      .start()
+    val output = process.inputStream.bufferedReader().use { it.readText() }.trim()
+    if (process.waitFor() == 0) output.ifBlank { null } else null
+  } catch (_: Exception) {
+    null
+  }
+}
+
+fun gitProvenance(directory: File): Map<String, Any?> {
+  val commit = commandOutput(directory, "git", "rev-parse", "HEAD") ?: ""
+  val branch = commandOutput(directory, "git", "branch", "--show-current") ?: ""
+  val dirty = commandOutput(directory, "git", "status", "--porcelain")?.isNotBlank() ?: false
+  return mapOf("commit" to commit, "branch" to branch, "dirty" to dirty)
+}
+
+fun jvnReleaseProvenance(): Map<String, Any?> {
+  return mapOf(
+    "engine" to gitProvenance(rootDir),
+    "game" to gitProvenance(gameProjectDir()),
+    "javaVersion" to System.getProperty("java.version"),
+    "javaVendor" to System.getProperty("java.vendor"),
+    "gradleVersion" to gradle.gradleVersion,
+    "hostOs" to System.getProperty("os.name"),
+    "hostArch" to System.getProperty("os.arch")
   )
 }
 
@@ -1283,6 +1387,7 @@ fun writeJvnGameBuildMarkdownReport(): File {
     appendLine("- Mode: ${selectedJvnGamePackageMode()}")
     appendLine("- Requested Target: ${selectedJvnGameTargetToken()}")
     appendLine("- Release Profile: ${selectedReleaseProfile().name}")
+    appendLine("- Package Variant: ${selectedPackageVariant()}")
     appendLine("- Release Config: ${selectedReleaseProfile().file?.absolutePath ?: "(none)"}")
     appendLine()
     appendLine("## Artifacts")
@@ -1326,7 +1431,14 @@ fun writeJvnGameReleaseManifest(): Pair<File, File> {
     appendLine("- Mode: ${manifest["packageMode"]}")
     appendLine("- Requested Target: ${manifest["requestedTarget"]}")
     appendLine("- Release Profile: ${manifest["releaseProfile"]}")
+    appendLine("- Package Variant: ${manifest["packageVariant"]}")
     appendLine("- Project: ${manifest["projectRoot"]}")
+    val provenance = manifest["provenance"] as Map<*, *>
+    val engineSource = provenance["engine"] as Map<*, *>
+    val gameSource = provenance["game"] as Map<*, *>
+    appendLine("- Engine Source: `${engineSource["commit"]}`${if (engineSource["dirty"] == true) " (dirty)" else ""}")
+    appendLine("- Game Source: `${gameSource["commit"]}`${if (gameSource["dirty"] == true) " (dirty)" else ""}")
+    appendLine("- Toolchain: Java ${provenance["javaVersion"]}, Gradle ${provenance["gradleVersion"]}, ${provenance["hostOs"]} ${provenance["hostArch"]}")
     appendLine()
     appendLine("## Artifacts")
     appendLine()
@@ -1351,7 +1463,155 @@ fun writeJvnGameReleaseManifest(): Pair<File, File> {
       warnings.forEach { warning -> appendLine("- $warning") }
     }
   })
+  val historyStamp = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss")
+    .withZone(ZoneOffset.UTC)
+    .format(Instant.now())
+  val historyDir = reportDir.resolve("history/${sanitizeGameName(gameVersion())}")
+  historyDir.mkdirs()
+  jsonFile.copyTo(historyDir.resolve("$historyStamp-release-manifest.json"), overwrite = true)
+  markdownFile.copyTo(historyDir.resolve("$historyStamp-release-manifest.md"), overwrite = true)
   return jsonFile to markdownFile
+}
+
+fun verifySelectedJvnGameArtifacts() {
+  selectedJvnGamePlannedArtifacts().forEach { artifact ->
+    when (artifact.mode) {
+      "portable" -> verifyPortableArtifact(jvnGameTargets.first { it.id == artifact.targetId }, artifact.artifact)
+      "bundled" -> verifyBundledRuntimeArtifact(jvnGameTargets.first { it.id == artifact.targetId }, artifact.artifact)
+      "native" -> verifyNativeArtifact(artifact.artifact)
+      else -> throw GradleException("Unsupported artifact mode for smoke verification: ${artifact.mode}")
+    }
+  }
+}
+
+fun decodePemPrivateKey(file: File): ByteArray {
+  val text = file.readText()
+  val encoded = text
+    .replace(Regex("-----BEGIN [^-]+-----"), "")
+    .replace(Regex("-----END [^-]+-----"), "")
+    .replace(Regex("\\s+"), "")
+  return try {
+    Base64.getDecoder().decode(encoded)
+  } catch (ex: Exception) {
+    throw GradleException("Update signing key is not valid PEM/base64: ${file.absolutePath}", ex)
+  }
+}
+
+fun writeJvnGameUpdateBundle(): List<File> {
+  val profile = selectedReleaseProfile()
+  if (!profile.flag("update.enabled")) {
+    logger.lifecycle("Update bundle disabled for release profile '${profile.name}'.")
+    return emptyList()
+  }
+  val privateKeyFile = resolveProjectRelativeFile(profile.value("update.privateKey"))
+    ?.takeIf { it.isFile }
+    ?: throw GradleException("Signed updates are enabled, but update.privateKey does not reference a PKCS#8 PEM private key.")
+  val keyAlgorithm = profile.value("update.keyAlgorithm") ?: "Ed25519"
+  val signatureAlgorithm = profile.value("update.signatureAlgorithm")
+    ?: if (keyAlgorithm.equals("RSA", ignoreCase = true)) "SHA256withRSA" else "Ed25519"
+  val artifacts = selectedJvnGamePlannedArtifacts()
+  val missing = artifacts.filterNot { it.artifact.isFile }
+  if (missing.isNotEmpty()) {
+    throw GradleException("Cannot build update catalog; release artifacts are missing: ${missing.joinToString { it.artifact.name }}")
+  }
+  val updateDir = layout.buildDirectory.dir(
+    "distributions/updates/${sanitizeGameName(gameDisplayName())}/${sanitizeGameName(gameVersion())}${packageVariantSuffix()}"
+  ).get().asFile
+  updateDir.mkdirs()
+  val catalog = mapOf(
+    "schema" to 1,
+    "game" to gameDisplayName(),
+    "version" to gameVersion(),
+    "variant" to selectedPackageVariant(),
+    "generatedAt" to Instant.now().toString(),
+    "signatureAlgorithm" to signatureAlgorithm,
+    "updateMode" to "full-artifact",
+    "artifacts" to artifacts.map { artifact ->
+      mapOf(
+        "target" to artifact.targetId,
+        "mode" to artifact.mode,
+        "name" to artifact.artifact.name,
+        "bytes" to artifact.artifact.length(),
+        "sha256" to sha256Hex(artifact.artifact),
+        "url" to "${profile.value("update.baseUrl")?.trimEnd('/') ?: ""}/${artifact.artifact.name}"
+      )
+    }
+  )
+  val catalogFile = updateDir.resolve("updates.json")
+  val catalogBytes = JsonOutput.prettyPrint(JsonOutput.toJson(catalog)).toByteArray(Charsets.UTF_8)
+  catalogFile.writeBytes(catalogBytes)
+  val privateKey = KeyFactory.getInstance(keyAlgorithm)
+    .generatePrivate(PKCS8EncodedKeySpec(decodePemPrivateKey(privateKeyFile)))
+  val signer = Signature.getInstance(signatureAlgorithm)
+  signer.initSign(privateKey)
+  signer.update(catalogBytes)
+  val signatureFile = updateDir.resolve("updates.sig")
+  signatureFile.writeText(Base64.getEncoder().encodeToString(signer.sign()) + "\n")
+  val publicKeyFile = resolveProjectRelativeFile(profile.value("update.publicKey"))?.takeIf { it.isFile }
+  val outputs = mutableListOf(catalogFile, signatureFile)
+  if (publicKeyFile != null) {
+    val copied = updateDir.resolve("updates-public-key.pem")
+    publicKeyFile.copyTo(copied, overwrite = true)
+    outputs += copied
+  }
+  artifacts.forEach { artifact ->
+    artifact.artifact.copyTo(updateDir.resolve(artifact.artifact.name), overwrite = true)
+    artifactChecksumFile(artifact.artifact).takeIf { it.isFile }
+      ?.let { checksum -> checksum.copyTo(updateDir.resolve(checksum.name), overwrite = true) }
+  }
+  return outputs
+}
+
+fun writeJvnGameStoreBundle(): List<File> {
+  val profile = selectedReleaseProfile()
+  val preset = profile.value("store.preset")?.lowercase()?.ifBlank { "generic" } ?: "generic"
+  if (preset !in setOf("generic", "itch", "steam")) {
+    throw GradleException("Unsupported store.preset '$preset'. Supported presets: generic, itch, steam.")
+  }
+  val artifacts = selectedJvnGamePlannedArtifacts()
+  val missing = artifacts.filterNot { it.artifact.isFile }
+  if (missing.isNotEmpty()) {
+    throw GradleException("Cannot assemble store bundle; release artifacts are missing: ${missing.joinToString { it.artifact.name }}")
+  }
+  val storeDir = layout.buildDirectory.dir(
+    "distributions/stores/$preset/${sanitizeGameName(gameDisplayName())}-${sanitizeGameName(gameVersion())}${packageVariantSuffix()}"
+  ).get().asFile
+  storeDir.deleteRecursively()
+  storeDir.mkdirs()
+  val copied = mutableListOf<File>()
+  artifacts.forEach { artifact ->
+    copied += artifact.artifact.copyTo(storeDir.resolve(artifact.artifact.name), overwrite = true)
+    artifactChecksumFile(artifact.artifact).takeIf { it.isFile }
+      ?.let { copied += it.copyTo(storeDir.resolve(it.name), overwrite = true) }
+  }
+  val releaseManifest = layout.buildDirectory.file("reports/jvn-game-release/release-manifest.json").get().asFile
+  if (releaseManifest.isFile) copied += releaseManifest.copyTo(storeDir.resolve("release-manifest.json"), overwrite = true)
+  val storeManifest = storeDir.resolve("store-manifest.json")
+  val metadata = linkedMapOf<String, Any?>(
+    "schema" to 1,
+    "preset" to preset,
+    "game" to gameDisplayName(),
+    "version" to gameVersion(),
+    "variant" to selectedPackageVariant(),
+    "generatedAt" to Instant.now().toString(),
+    "artifacts" to artifacts.map { mapOf("target" to it.targetId, "name" to it.artifact.name, "sha256" to sha256Hex(it.artifact)) }
+  )
+  if (preset == "itch") {
+    metadata["project"] = profile.value("store.itch.project") ?: ""
+    metadata["channelPattern"] = profile.value("store.itch.channelPattern") ?: "{target}"
+  }
+  if (preset == "steam") {
+    val appId = profile.value("store.steam.appId")
+      ?: throw GradleException("store.preset=steam requires store.steam.appId in the release profile.")
+    metadata["appId"] = appId
+    metadata["depotId"] = profile.value("store.steam.depotId") ?: ""
+    val appIdFile = storeDir.resolve("steam_appid.txt")
+    appIdFile.writeText("$appId\n")
+    copied += appIdFile
+  }
+  storeManifest.writeText(JsonOutput.prettyPrint(JsonOutput.toJson(metadata)))
+  copied += storeManifest
+  return copied
 }
 
 fun publishCommandVariables(mode: String, artifact: File, targetId: String = currentPackageHost().target.id): Map<String, String> {
@@ -1399,6 +1659,10 @@ fun validateSelectedReleaseProfile() {
   val selectedName = selectedReleaseProfile().name
   val explicit = (findProperty("jvnReleaseProfile") as String?)?.trim()
   val configuredDefault = gameReleaseConfig().getProperty("defaultProfile", "").trim()
+  val packageVariant = selectedPackageVariant()
+  if (!packageVariant.matches(Regex("[A-Za-z0-9._-]+"))) {
+    throw GradleException("Invalid jvnPackageVariant '$packageVariant'. Use letters, numbers, dots, underscores, or hyphens.")
+  }
 
   if (!configuredDefault.isNullOrBlank() &&
       !configuredDefault.equals("default", ignoreCase = true) &&
@@ -1425,6 +1689,13 @@ fun validateSelectedReleaseProfile() {
   validateExistingProfileFile("licenseFile", profile.value("licenseFile"))
   validateExistingProfileFile("mac.entitlements", profile.value("mac.entitlements"))
   validateExistingProfileFile("win.certificateFile", profile.value("win.certificateFile"))
+  if (profile.flag("update.enabled")) {
+    validateExistingProfileFile("update.privateKey", profile.value("update.privateKey"))
+    validateExistingProfileFile("update.publicKey", profile.value("update.publicKey"))
+    if (profile.value("update.privateKey").isNullOrBlank()) {
+      throw GradleException("Release profile '${profile.name}' enables updates but does not configure update.privateKey.")
+    }
+  }
 
   val allowedPublishKeys = publishCommandVariables(
     "portable",
@@ -1573,7 +1844,7 @@ fun gameVersionForTaskDiscovery(): String {
 }
 
 fun gameDistName(target: JvnGameTarget): String {
-  return "${sanitizeGameName(gameDisplayName())}-${sanitizeGameName(gameVersion())}-${target.id}"
+  return "${sanitizeGameName(gameDisplayName())}-${sanitizeGameName(gameVersion())}${packageVariantSuffix()}-${target.id}"
 }
 
 fun gameLauncherBaseName(): String {
@@ -1813,7 +2084,7 @@ val gameZipTasks = jvnGameTargets.map { target ->
     }
     from({ gameProjectDir() }) {
       into(providers.provider { "${gameDistName(target)}/game" })
-      exclude(gamePackageExcludes())
+      exclude(gamePackageExcludes(target.id))
     }
     doLast {
       verifyPortableArtifact(target, archiveFile.get().asFile)
@@ -1887,6 +2158,49 @@ tasks.register("writeJvnGameReleaseManifest") {
   }
 }
 
+tasks.register("smokeTestJvnGameRelease") {
+  group = "verification"
+  description = "Opens and verifies every selected packaged game artifact, refreshes checksums, and rejects unsafe archive paths."
+  doLast {
+    val missing = selectedJvnGamePlannedArtifacts().filterNot { it.artifact.isFile }
+    if (missing.isNotEmpty()) {
+      throw GradleException(
+        "Cannot smoke-test missing packaged artifacts:\n - " +
+          missing.joinToString("\n - ") { "${it.targetId}: ${it.artifact.absolutePath} (build task: ${it.buildTask})" }
+      )
+    }
+    verifySelectedJvnGameArtifacts()
+    println("JVN packaged-artifact smoke test passed")
+    selectedJvnGamePlannedArtifacts().forEach { println("  - ${it.targetId}: ${it.artifact.absolutePath}") }
+  }
+}
+
+tasks.register("writeJvnGameUpdateBundle") {
+  group = "distribution"
+  description = "Writes a signed full-artifact update catalog for the selected release profile."
+  doLast {
+    validateSelectedReleaseProfile()
+    val outputs = writeJvnGameUpdateBundle()
+    if (outputs.isEmpty()) {
+      println("JVN update bundle is disabled for profile '${selectedReleaseProfile().name}'.")
+    } else {
+      println("JVN signed update bundle written:")
+      outputs.forEach { println("  - ${it.absolutePath}") }
+    }
+  }
+}
+
+tasks.register("assembleJvnGameStoreBundle") {
+  group = "distribution"
+  description = "Collects selected release artifacts into a generic, itch.io, or Steam upload layout."
+  doLast {
+    validateSelectedReleaseProfile()
+    val outputs = writeJvnGameStoreBundle()
+    println("JVN store bundle written:")
+    outputs.forEach { println("  - ${it.absolutePath}") }
+  }
+}
+
 tasks.register("assembleJvnGameRelease") {
   group = "distribution"
   description = "Builds the selected JVN game package mode/target and writes release manifests."
@@ -1901,12 +2215,15 @@ tasks.register("assembleJvnGameRelease") {
       )
     }
     val (jsonFile, markdownFile) = writeJvnGameReleaseManifest()
+    verifySelectedJvnGameArtifacts()
+    val updateOutputs = writeJvnGameUpdateBundle()
     println("JVN game release artifacts ready:")
     artifacts.forEach { artifact ->
       println("  - ${artifact.targetId}: ${artifact.artifact.absolutePath}")
     }
     println("  release manifest: ${jsonFile.absolutePath}")
     println("  release notes: ${markdownFile.absolutePath}")
+    if (updateOutputs.isNotEmpty()) println("  signed update catalog: ${updateOutputs.first().absolutePath}")
   }
 }
 
@@ -2072,7 +2389,7 @@ val bundledRuntimeZipTasks = jvnGameTargets.map { target ->
       targetJavaFxRuntimeJars(target).forEach { jar ->
         jar.copyTo(javafxDir.resolve(jar.name), overwrite = true)
       }
-      copyGameProjectFiles(gameDir)
+      copyGameProjectFiles(gameDir, target.id)
       copyDirectoryContents(runtime.runtimeDir, runtimeDir)
 
       val launcher = binDir.resolve(if (target.windows) "${gameLauncherBaseName()}.bat" else gameLauncherBaseName())

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -750,6 +750,7 @@ fun runtimeImageModules(): List<String> {
     "java.scripting",
     "java.sql",
     "java.xml",
+    "jdk.management",
     "jdk.unsupported"
   )
   modules += jvnJavaFxRuntimeModules
@@ -2462,6 +2463,15 @@ tasks.register("prepareJvnGameNativeInputCurrent") {
   jvnGameRuntimeProjectPaths.forEach { projectPath ->
     dependsOn("$projectPath:jar")
   }
+  inputs.files(providers.provider { gameRuntimeClasspathJars() })
+    .withPropertyName("runtimeClasspath")
+    .withPathSensitivity(PathSensitivity.RELATIVE)
+  inputs.dir(providers.provider { gameProjectDir() })
+    .withPropertyName("gameProject")
+    .withPathSensitivity(PathSensitivity.RELATIVE)
+  inputs.property("nativePackageType", providers.provider { currentJpackageType() })
+  inputs.property("releaseProfile", providers.provider { selectedReleaseProfileName() })
+  inputs.property("packageVariant", providers.provider { selectedPackageVariant() })
   outputs.dir(providers.provider { jpackageInputDir() })
   outputs.dir(providers.provider { jpackageContentDir() })
   doLast {

--- a/docs/project-setup/release/build-system.md
+++ b/docs/project-setup/release/build-system.md
@@ -31,6 +31,8 @@ Project Explorer -> Build
 
 The popup reads the current project's `jvn.project`, lets you set the release name/version, target, format, native package type, and release profile, then launches the matching Gradle task in the run console. Use **Ship Build** when you want the editor to build the selected package plan and write release manifests in one step. Use **Scan Dependencies** when you want an in-view shipping report for missing media, bad script/config links, broken menu targets, bad stage/timeline references, unused media, and packaging blockers. The report groups errors, warnings, and cleanup notes, supports per-finding copy/open actions, and still provides a console scan button for CI-style output. The view also reveals output folders, copies CLI/publish notes, shows checksum availability for completed artifacts, and can run the selected release profile.
 
+If a game does not have release configuration yet, **Create Release Config** writes a safe cross-platform starter profile at `config/release/jvn-release.properties`, selects it, and reveals it for authoring. Existing configurations remain untouched.
+
 Before enabling build actions, the popup validates:
 
 - the selected project is not the JVN engine workspace
@@ -113,6 +115,20 @@ Archives are written to:
 If `-PjvnBuildOutputDir=<dir>` is set, packaged game artifacts and their `.sha256` sidecars are written there instead.
 
 Each completed game artifact also receives a sibling `.sha256` file. The checksum sidecar is written after the package has been opened and checked for required launch content, so a missing checksum is a useful sign that the build did not finish its packaging verification step.
+
+### Controlling Shipped Files
+
+Add a `.jvnignore` file at the game project root to exclude authoring-only content from every desktop package. Use one Gradle/Ant-style path pattern per line; blank lines and lines beginning with `#` are ignored.
+
+```text
+# Source art and local production notes
+source-art/**
+notes/**
+**/*.kra
+**/*.psd
+```
+
+JVN always excludes version-control metadata, IDE state, build outputs, saves, logs, temporary files, and `.jvnignore` itself. Authored patterns are added to those safe defaults and apply consistently to portable zips, desktop bundles, and native packages.
 
 `dist-preflight` writes both machine-readable and human-readable reports:
 

--- a/modules/editor/src/main/java/com/jvn/editor/ui/GameBuildPublisherView.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/GameBuildPublisherView.java
@@ -110,6 +110,8 @@ public class GameBuildPublisherView extends BorderPane {
   private final Label runtimeBadgeLabel = new Label();
   private final Label releaseBadgeLabel = new Label();
   private final Label statusLabel = new Label();
+  private final Label configurationNoticeLabel = new Label();
+  private final Label validationNoticeLabel = new Label();
   private final Label commandPreviewLabel = new Label();
   private final Label artifactInventoryLabel = new Label();
   private final Label dependencySummaryLabel = new Label("Dependency report: not scanned yet.");
@@ -279,6 +281,8 @@ public class GameBuildPublisherView extends BorderPane {
     styleBadge(releaseBadgeLabel);
     statusLabel.setWrapText(true);
     statusLabel.getStyleClass().addAll("build-publisher-note", "build-publisher-note-status");
+    styleWorkflowNotice(configurationNoticeLabel);
+    styleWorkflowNotice(validationNoticeLabel);
     commandPreviewLabel.setWrapText(true);
     commandPreviewLabel.getStyleClass().addAll("build-publisher-command-preview", "build-publisher-path");
     artifactInventoryLabel.setWrapText(true);
@@ -344,8 +348,10 @@ public class GameBuildPublisherView extends BorderPane {
     buildAllButton.setOnAction(e -> buildAllTargets());
     preflightButton = button("Run Preflight", ButtonTone.SECONDARY, false);
     preflightButton.setOnAction(e -> runPreflight());
+    richAction(preflightButton, "Package preflight", "Check the manifest, target, output, and release settings.");
     dependencyScanButton = button("Scan Dependencies", ButtonTone.SECONDARY, false);
     dependencyScanButton.setOnAction(e -> runDependencyScan());
+    richAction(dependencyScanButton, "Scan game content", "Find missing assets, broken links, and unused media.");
     dependencyConsoleButton = button("Run Console Scan", ButtonTone.SECONDARY, false);
     dependencyConsoleButton.setOnAction(e -> runDependencyScanInConsole());
     copyDependencyReportButton = button("Copy Report", ButtonTone.SECONDARY, false);
@@ -413,11 +419,14 @@ public class GameBuildPublisherView extends BorderPane {
 
     FlowPane dependencyBadgeRow = new FlowPane(6, 6, dependencyErrorsBadgeLabel, dependencyWarningsBadgeLabel, dependencyInfoBadgeLabel);
     dependencyBadgeRow.setAlignment(Pos.CENTER_LEFT);
-    FlowPane dependencyActionsRow = new FlowPane(8, 8, preflightButton, dependencyScanButton,
-        dependencyConsoleButton, copyDependencyReportButton, clearDependencyReportButton);
+    FlowPane dependencyActionsRow = new FlowPane(10, 10, preflightButton, dependencyScanButton);
     dependencyActionsRow.setAlignment(Pos.CENTER_LEFT);
+    FlowPane dependencyUtilityRow = new FlowPane(8, 8, dependencyConsoleButton,
+        copyDependencyReportButton, clearDependencyReportButton);
+    dependencyUtilityRow.setAlignment(Pos.CENTER_LEFT);
+    TitledPane dependencyToolsPane = disclosure("More validation tools", dependencyUtilityRow);
     VBox dependencyCard = card("Check before shipping", dependencySummaryLabel, dependencyBadgeRow,
-        dependencyActionsRow, dependencyReportBox);
+        dependencyActionsRow, dependencyToolsPane, dependencyReportBox);
     renderDependencyPlaceholder("Run Scan Dependencies to inspect missing media, scripts, menus, stage presets, timelines, packaging blockers, and unused media.");
 
     Label nativeNote = new Label("Desktop bundles build locally for Windows, Linux, macOS Intel, and macOS Apple Silicon. Native installers still build on the matching host OS only.");
@@ -438,7 +447,8 @@ public class GameBuildPublisherView extends BorderPane {
     VBox validateStep = step("2", "Validate", "Catch broken references and packaging issues before exporting.", dependencyCard);
     VBox shipStep = step("3", "Build & ship", "Create the selected package, then use advanced workflows only when needed.", actionCard);
 
-    VBox content = new VBox(14, header, configureStep, validateStep, shipStep, nativeNote);
+    VBox content = new VBox(14, header, configureStep, configurationNoticeLabel,
+        validateStep, validationNoticeLabel, shipStep, nativeNote);
     content.getStyleClass().add("build-publisher-content");
     content.setFillWidth(true);
 
@@ -480,6 +490,39 @@ public class GameBuildPublisherView extends BorderPane {
     VBox box = new VBox(3, field, helpLabel);
     box.setFillWidth(true);
     return box;
+  }
+
+  private void styleWorkflowNotice(Label notice) {
+    notice.setWrapText(true);
+    notice.setMaxWidth(Double.MAX_VALUE);
+    notice.getStyleClass().addAll("build-publisher-workflow-notice", "build-publisher-workflow-notice-pending");
+  }
+
+  private void setWorkflowNotice(Label notice, String tone, String text) {
+    notice.setText(text);
+    notice.getStyleClass().removeAll(
+        "build-publisher-workflow-notice-ready",
+        "build-publisher-workflow-notice-pending",
+        "build-publisher-workflow-notice-blocked",
+        "build-publisher-workflow-notice-running");
+    notice.getStyleClass().add("build-publisher-workflow-notice-" + tone);
+  }
+
+  private void richAction(Button button, String title, String description) {
+    Label titleLabel = new Label(title);
+    titleLabel.getStyleClass().add("build-publisher-action-title");
+    Label descriptionLabel = new Label(description);
+    descriptionLabel.setWrapText(true);
+    descriptionLabel.getStyleClass().add("build-publisher-action-description");
+    VBox graphic = new VBox(3, titleLabel, descriptionLabel);
+    graphic.setAlignment(Pos.CENTER_LEFT);
+    button.setText("");
+    button.setGraphic(graphic);
+    button.setContentDisplay(ContentDisplay.GRAPHIC_ONLY);
+    button.setAlignment(Pos.CENTER_LEFT);
+    button.setMinWidth(260);
+    button.setMaxWidth(Double.MAX_VALUE);
+    button.getStyleClass().add("build-publisher-action-tile");
   }
 
   private VBox card(String title, Node... nodes) {
@@ -613,7 +656,37 @@ public class GameBuildPublisherView extends BorderPane {
     refreshActionButtons(result);
     refreshUtilityButtons(result);
     refreshCommandPreview(result);
+    refreshWorkflowNotices(result);
     return result;
+  }
+
+  private void refreshWorkflowNotices(ValidationResult result) {
+    if (result == null || !result.errors().isEmpty()) {
+      String issue = result == null || result.errors().isEmpty()
+          ? "Complete the release configuration above."
+          : result.errors().get(0);
+      setWorkflowNotice(configurationNoticeLabel, "blocked", "Configuration needs attention — " + issue);
+      setWorkflowNotice(validationNoticeLabel, "pending", "Validation unlocks after the configuration is ready.");
+      return;
+    }
+
+    setWorkflowNotice(configurationNoticeLabel, "ready",
+        "✓ Configuration ready — continue to Validate below.");
+    if (dependencyScanTask != null && dependencyScanTask.isRunning()) {
+      setWorkflowNotice(validationNoticeLabel, "running", "Scanning game content… Results will appear here when ready.");
+    } else if (dependencyReport == null) {
+      setWorkflowNotice(validationNoticeLabel, "pending",
+          "Next: scan the game content, or run package preflight before shipping.");
+    } else if (dependencyReport.errorCount() > 0) {
+      setWorkflowNotice(validationNoticeLabel, "blocked",
+          "Validation found " + dependencyReport.errorCount() + " blocking issue(s). Fix them before shipping.");
+    } else if (dependencyReport.warningCount() > 0) {
+      setWorkflowNotice(validationNoticeLabel, "ready",
+          "✓ Validation complete with " + dependencyReport.warningCount() + " warning(s) — review them, then continue to Build & ship.");
+    } else {
+      setWorkflowNotice(validationNoticeLabel, "ready",
+          "✓ Validation clear — continue to Build & ship below.");
+    }
   }
 
   private void applyValidation(ValidationResult result) {
@@ -1036,8 +1109,6 @@ public class GameBuildPublisherView extends BorderPane {
     setDependencyBadges(0, 0, 0);
     dependencySummaryLabel.setText("Scanning " + scanRoot.getAbsolutePath() + "...");
     renderDependencyBusy();
-    refreshUtilityButtons(validateForm());
-
     Task<ProjectDependencyValidator.Report> task = new Task<>() {
       @Override
       protected ProjectDependencyValidator.Report call() {
@@ -1045,6 +1116,8 @@ public class GameBuildPublisherView extends BorderPane {
       }
     };
     dependencyScanTask = task;
+    refreshUtilityButtons(validateForm());
+    refreshWorkflowNotices(validateForm());
     task.setOnSucceeded(e -> {
       if (dependencyScanTask != task) return;
       dependencyScanTask = null;
@@ -1054,6 +1127,7 @@ public class GameBuildPublisherView extends BorderPane {
       setNoteTone(statusLabel, dependencyReport.errorCount() > 0 ? "error"
           : dependencyReport.warningCount() > 0 ? "warn" : "ok");
       refreshUtilityButtons(validateForm());
+      refreshWorkflowNotices(validateForm());
     });
     task.setOnFailed(e -> {
       if (dependencyScanTask != task) return;
@@ -1065,6 +1139,7 @@ public class GameBuildPublisherView extends BorderPane {
       statusLabel.setText("Dependency scan failed: " + (ex == null ? "unknown failure" : ex.getMessage()));
       setNoteTone(statusLabel, "error");
       refreshUtilityButtons(validateForm());
+      refreshWorkflowNotices(validateForm());
     });
     Thread thread = new Thread(task, "jvn-build-dependency-scan");
     thread.setDaemon(true);
@@ -1366,6 +1441,7 @@ public class GameBuildPublisherView extends BorderPane {
     dependencySummaryLabel.setText("Dependency report: not scanned yet.");
     renderDependencyPlaceholder("Run Scan Dependencies to inspect missing media, scripts, menus, stage presets, timelines, packaging blockers, and unused media.");
     refreshUtilityButtons(validateForm());
+    refreshWorkflowNotices(validateForm());
   }
 
   private void copyDependencyReport() {

--- a/modules/editor/src/main/java/com/jvn/editor/ui/GameBuildPublisherView.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/GameBuildPublisherView.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.nio.file.Path;
 import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
@@ -14,6 +15,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.function.Consumer;
+import org.jspecify.annotations.Nullable;
 import com.jvn.core.project.ProjectDependencyValidator;
 import com.jvn.editor.ui.build.ProjectManifestService;
 import com.jvn.editor.ui.build.BuildArtifactService;
@@ -50,6 +52,7 @@ import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 import javafx.scene.transform.Rotate;
+import javafx.stage.FileChooser;
 import javafx.util.Duration;
 
 /**
@@ -153,6 +156,17 @@ public class GameBuildPublisherView extends BorderPane {
   private Button btnResetOutputDir;
   private Button zipOutputButton;
   private final TextField outputDirField = new TextField();
+  private final TextField gameIconField = new TextField();
+  private final Label nativeReleaseSummaryLabel = new Label();
+  private final VBox nativeReleaseBox = new VBox(8);
+  private Button chooseGameIconButton;
+  private Button clearGameIconButton;
+  private Button nativeReleaseButton;
+  private Button nativeReleaseConfigButton;
+  private Button nativeCopyChecklistButton;
+  private Button nativeRevealIconButton;
+  private Button nativeRevealBuildsButton;
+  private Button nativeVerifyButton;
   private File customOutputDir = null;
   private ProjectDependencyValidator.Report dependencyReport = null;
   private Task<ProjectDependencyValidator.Report> dependencyScanTask = null;
@@ -177,7 +191,7 @@ public class GameBuildPublisherView extends BorderPane {
     Label subtitle = new Label("Package and release the current JVN game project as portable zips, cross-target desktop bundles, or host-native installers.");
     subtitle.setWrapText(true);
     subtitle.getStyleClass().add("build-publisher-subtitle");
-    Label capabilityNote = new Label("Desktop shipping targets: Windows x64, Linux x64, macOS Intel, and macOS Apple Silicon. Linux ARM64 remains unavailable with the current JavaFX runtime artifacts.");
+    Label capabilityNote = new Label("Windows x64, Linux x64, macOS Intel, and macOS Apple Silicon are supported desktop targets.");
     capabilityNote.setWrapText(true);
     capabilityNote.getStyleClass().addAll("build-publisher-note", "build-publisher-note-status");
 
@@ -314,6 +328,23 @@ public class GameBuildPublisherView extends BorderPane {
     HBox.setHgrow(outputDirField, Priority.ALWAYS);
     outputDirLabel.setMinWidth(120);
 
+    gameIconField.setEditable(false);
+    gameIconField.setFocusTraversable(false);
+    gameIconField.setPromptText("No package icon selected");
+    styleField(gameIconField);
+    chooseGameIconButton = button("Choose Icon", ButtonTone.SECONDARY, false);
+    chooseGameIconButton.setOnAction(e -> chooseGameIcon());
+    clearGameIconButton = button("Clear", ButtonTone.SECONDARY, false);
+    clearGameIconButton.setOnAction(e -> clearGameIcon());
+    Label gameIconLabel = label("Game Icon");
+    HBox gameIconRow = new HBox(6, gameIconLabel, gameIconField, chooseGameIconButton, clearGameIconButton);
+    gameIconRow.setAlignment(Pos.CENTER_LEFT);
+    HBox.setHgrow(gameIconField, Priority.ALWAYS);
+    gameIconLabel.setMinWidth(120);
+    Label gameIconHelp = new Label("Used by native installers and app bundles. Required format on this host: " + nativeIconExtension() + ".");
+    gameIconHelp.setWrapText(true);
+    gameIconHelp.getStyleClass().add("build-publisher-field-help");
+
     VBox projectCard = card("Game details", form, manifestLabel);
 
     FlowPane badgeRow = new FlowPane(6, 6, formatBadgeLabel, targetBadgeLabel, runtimeBadgeLabel, releaseBadgeLabel);
@@ -332,7 +363,8 @@ public class GameBuildPublisherView extends BorderPane {
     utilitiesRow.setAlignment(Pos.CENTER_LEFT);
 
     VBox planCard = card("Release preview", badgeRow, buildPlanTitleLabel, buildPlanBodyLabel,
-        buildPlanHintLabel, outputLabel, outputDirRow, validationLabel, releaseConfigLabel, utilitiesRow);
+        buildPlanHintLabel, outputLabel, outputDirRow, gameIconRow, gameIconHelp,
+        validationLabel, releaseConfigLabel, utilitiesRow);
 
     Label buildHelp = new Label("Portable zips still need Java on the player machine. Desktop bundles include a prebuilt runtime for the selected target, so players do not need Java installed. The first bundle build for a target downloads and caches that runtime locally. Native packages use jpackage and stay host-specific.");
     buildHelp.setWrapText(true);
@@ -346,12 +378,12 @@ public class GameBuildPublisherView extends BorderPane {
     buildSelectedButton.setOnAction(e -> buildSelectedTarget());
     buildAllButton = button("Build All Targets", ButtonTone.PRIMARY, false);
     buildAllButton.setOnAction(e -> buildAllTargets());
-    preflightButton = button("Run Preflight", ButtonTone.SECONDARY, false);
+    preflightButton = button("Package Preflight", ButtonTone.SECONDARY, false);
     preflightButton.setOnAction(e -> runPreflight());
-    richAction(preflightButton, "Package preflight", "Check the manifest, target, output, and release settings.");
-    dependencyScanButton = button("Scan Dependencies", ButtonTone.SECONDARY, false);
+    preflightButton.setTooltip(new Tooltip("Check the manifest, target, output, and release settings."));
+    dependencyScanButton = button("Scan Game Content", ButtonTone.PRIMARY, false);
     dependencyScanButton.setOnAction(e -> runDependencyScan());
-    richAction(dependencyScanButton, "Scan game content", "Find missing assets, broken links, and unused media.");
+    dependencyScanButton.setTooltip(new Tooltip("Find missing assets, broken links, and unused media."));
     dependencyConsoleButton = button("Run Console Scan", ButtonTone.SECONDARY, false);
     dependencyConsoleButton.setOnAction(e -> runDependencyScanInConsole());
     copyDependencyReportButton = button("Copy Report", ButtonTone.SECONDARY, false);
@@ -360,6 +392,18 @@ public class GameBuildPublisherView extends BorderPane {
     clearDependencyReportButton.setOnAction(e -> clearDependencyReport());
     releaseButton = button("Run Release Hooks", ButtonTone.SECONDARY, false);
     releaseButton.setOnAction(e -> runReleaseProfile());
+    nativeReleaseButton = button("Sign & Release Package", ButtonTone.PRIMARY, false);
+    nativeReleaseButton.setOnAction(e -> runReleaseProfile());
+    nativeReleaseConfigButton = button("Release Settings", ButtonTone.SECONDARY, false);
+    nativeReleaseConfigButton.setOnAction(e -> openReleaseConfig());
+    nativeCopyChecklistButton = button("Copy Checklist", ButtonTone.SECONDARY, false);
+    nativeCopyChecklistButton.setOnAction(e -> copyNativeReleaseChecklist());
+    nativeRevealIconButton = button("Reveal Icon", ButtonTone.SECONDARY, false);
+    nativeRevealIconButton.setOnAction(e -> revealGameIcon());
+    nativeRevealBuildsButton = button("Reveal Builds", ButtonTone.SECONDARY, false);
+    nativeRevealBuildsButton.setOnAction(e -> revealBuilds());
+    nativeVerifyButton = button("Verify Package", ButtonTone.SECONDARY, false);
+    nativeVerifyButton.setOnAction(e -> runPackagedArtifactSmokeTest());
     smokeTestButton = button("Verify Packaged Build", ButtonTone.SECONDARY, false);
     smokeTestButton.setOnAction(e -> runPackagedArtifactSmokeTest());
     updateBundleButton = button("Build Signed Update", ButtonTone.SECONDARY, false);
@@ -391,7 +435,7 @@ public class GameBuildPublisherView extends BorderPane {
     zipOutputButton.setOnAction(e -> zipOutputFolder());
     zipOutputButton.setDisable(true);
 
-    Label buildActionsLabel = new Label("Ready to create your release?");
+    Label buildActionsLabel = new Label("Release package");
     buildActionsLabel.getStyleClass().add("build-publisher-section-label");
     FlowPane buildPrimaryRow = new FlowPane(8, 8, shipBuildButton);
     buildPrimaryRow.setAlignment(Pos.CENTER_LEFT);
@@ -414,20 +458,34 @@ public class GameBuildPublisherView extends BorderPane {
         artifactInventoryLabel, buildDangerRow);
     TitledPane artifactToolsPane = disclosure("Commands, manifests & artifact tools", artifactToolsContent);
 
+    nativeReleaseSummaryLabel.setWrapText(true);
+    nativeReleaseSummaryLabel.getStyleClass().add("build-publisher-copy");
+    Label nativeReleaseTitle = new Label("Finish native release");
+    nativeReleaseTitle.getStyleClass().add("build-publisher-section-label");
+    FlowPane nativeReleaseActions = new FlowPane(8, 8, nativeReleaseButton, nativeReleaseConfigButton,
+        nativeCopyChecklistButton, nativeRevealIconButton, nativeRevealBuildsButton, nativeVerifyButton);
+    nativeReleaseActions.setAlignment(Pos.CENTER_LEFT);
+    nativeReleaseBox.getChildren().setAll(nativeReleaseTitle, nativeReleaseSummaryLabel, nativeReleaseActions);
+    nativeReleaseBox.getStyleClass().add("build-publisher-native-release");
+
     VBox actionCard = card("Create release", buildHelp, optionsRow,
-        buildActionsLabel, buildPrimaryRow, buildOnlyPane, advancedReleasePane, artifactToolsPane, statusLabel);
+        buildActionsLabel, buildPrimaryRow, nativeReleaseBox, buildOnlyPane,
+        advancedReleasePane, artifactToolsPane, statusLabel);
 
     FlowPane dependencyBadgeRow = new FlowPane(6, 6, dependencyErrorsBadgeLabel, dependencyWarningsBadgeLabel, dependencyInfoBadgeLabel);
     dependencyBadgeRow.setAlignment(Pos.CENTER_LEFT);
-    FlowPane dependencyActionsRow = new FlowPane(10, 10, preflightButton, dependencyScanButton);
+    Label dependencyActionsHelp = new Label("Scan content first to catch broken project references. Package preflight checks the selected release configuration.");
+    dependencyActionsHelp.setWrapText(true);
+    dependencyActionsHelp.getStyleClass().add("build-publisher-copy");
+    FlowPane dependencyActionsRow = new FlowPane(8, 8, dependencyScanButton, preflightButton);
     dependencyActionsRow.setAlignment(Pos.CENTER_LEFT);
     FlowPane dependencyUtilityRow = new FlowPane(8, 8, dependencyConsoleButton,
         copyDependencyReportButton, clearDependencyReportButton);
     dependencyUtilityRow.setAlignment(Pos.CENTER_LEFT);
     TitledPane dependencyToolsPane = disclosure("More validation tools", dependencyUtilityRow);
-    VBox dependencyCard = card("Check before shipping", dependencySummaryLabel, dependencyBadgeRow,
-        dependencyActionsRow, dependencyToolsPane, dependencyReportBox);
-    renderDependencyPlaceholder("Run Scan Dependencies to inspect missing media, scripts, menus, stage presets, timelines, packaging blockers, and unused media.");
+    VBox dependencyCard = card("Validation status", dependencySummaryLabel, dependencyBadgeRow,
+        dependencyActionsHelp, dependencyActionsRow, dependencyToolsPane, dependencyReportBox);
+    renderDependencyPlaceholder("Scan game content to inspect missing media, scripts, menus, stage presets, timelines, packaging blockers, and unused media.");
 
     Label nativeNote = new Label("Desktop bundles build locally for Windows, Linux, macOS Intel, and macOS Apple Silicon. Native installers still build on the matching host OS only.");
     nativeNote.setWrapText(true);
@@ -506,23 +564,6 @@ public class GameBuildPublisherView extends BorderPane {
         "build-publisher-workflow-notice-blocked",
         "build-publisher-workflow-notice-running");
     notice.getStyleClass().add("build-publisher-workflow-notice-" + tone);
-  }
-
-  private void richAction(Button button, String title, String description) {
-    Label titleLabel = new Label(title);
-    titleLabel.getStyleClass().add("build-publisher-action-title");
-    Label descriptionLabel = new Label(description);
-    descriptionLabel.setWrapText(true);
-    descriptionLabel.getStyleClass().add("build-publisher-action-description");
-    VBox graphic = new VBox(3, titleLabel, descriptionLabel);
-    graphic.setAlignment(Pos.CENTER_LEFT);
-    button.setText("");
-    button.setGraphic(graphic);
-    button.setContentDisplay(ContentDisplay.GRAPHIC_ONLY);
-    button.setAlignment(Pos.CENTER_LEFT);
-    button.setMinWidth(260);
-    button.setMaxWidth(Double.MAX_VALUE);
-    button.getStyleClass().add("build-publisher-action-tile");
   }
 
   private VBox card(String title, Node... nodes) {
@@ -657,7 +698,66 @@ public class GameBuildPublisherView extends BorderPane {
     refreshUtilityButtons(result);
     refreshCommandPreview(result);
     refreshWorkflowNotices(result);
+    refreshNativeReleaseState(result);
     return result;
+  }
+
+  private void refreshNativeReleaseState(ValidationResult result) {
+    boolean nativeMode = selectedPackageMode() == PackageMode.NATIVE_PACKAGE;
+    nativeReleaseBox.setManaged(nativeMode);
+    nativeReleaseBox.setVisible(nativeMode);
+    String icon = releaseProfileValue(projectRoot, selectedReleaseProfile(), "icon");
+    gameIconField.setText(icon);
+    clearGameIconButton.setDisable(icon.isBlank());
+    chooseGameIconButton.setDisable(projectRoot == null || !projectRoot.isDirectory());
+    if (!nativeMode) return;
+
+    Properties properties = loadReleaseConfig(projectRoot);
+    String profile = selectedReleaseProfile();
+    String os = currentHostOs();
+    List<String> steps = new ArrayList<>();
+    steps.add(icon.isBlank()
+        ? "1. Choose a " + nativeIconExtension() + " game icon before the final package."
+        : "1. Icon ready: " + icon);
+    if ("macos".equals(os)) {
+      boolean sign = releaseProfileFlag(properties, profile, "mac.sign");
+      boolean notarize = releaseProfileFlag(properties, profile, "mac.notarize");
+      String identity = releaseProfileValue(properties, profile, "mac.signingIdentity");
+      String notaryProfile = releaseProfileValue(properties, profile, "mac.notarytoolProfile");
+      steps.add(sign && !identity.isBlank()
+          ? "2. Code signing ready: " + identity
+          : "2. Configure mac.sign=true and a Developer ID signing identity in the release profile.");
+      steps.add(notarize && !notaryProfile.isBlank()
+          ? "3. Notarization ready: keychain profile " + notaryProfile
+          : "3. Configure mac.notarize=true and mac.notarytoolProfile, then run the signed release.");
+    } else if ("windows".equals(os)) {
+      boolean sign = releaseProfileFlag(properties, profile, "win.sign");
+      String certificate = releaseProfileValue(properties, profile, "win.certificateFile");
+      String subject = releaseProfileValue(properties, profile, "win.subjectName");
+      steps.add(sign && (!certificate.isBlank() || !subject.isBlank())
+          ? "2. Authenticode signing is configured."
+          : "2. Configure win.sign=true and a certificate file or subject name in the release profile.");
+      steps.add("3. Run the signed release, then test the installer on a clean Windows account.");
+    } else {
+      steps.add("2. Configure Linux package metadata in the release profile.");
+      steps.add("3. Run the release profile, then verify the package on its target distribution.");
+    }
+    nativeReleaseSummaryLabel.setText(String.join("\n", steps));
+    boolean valid = result != null && result.errors().isEmpty();
+    nativeReleaseButton.setDisable(!valid || findReleaseConfig(projectRoot) == null);
+    nativeReleaseConfigButton.setText(findReleaseConfig(projectRoot) == null ? "Create Release Settings" : "Release Settings");
+    nativeReleaseConfigButton.setDisable(projectRoot == null || !projectRoot.isDirectory());
+    nativeCopyChecklistButton.setDisable(projectRoot == null || !projectRoot.isDirectory());
+    nativeRevealIconButton.setDisable(icon.isBlank() || !resolveReleaseProfileFile(icon).isFile());
+    File[] artifacts = buildDistributionsDir().listFiles(file -> file.isFile() && !file.isHidden());
+    boolean hasArtifacts = artifacts != null && artifacts.length > 0;
+    nativeRevealBuildsButton.setDisable(!hasArtifacts);
+    nativeVerifyButton.setDisable(!valid || !hasArtifacts);
+    nativeReleaseButton.setText(switch (os) {
+      case "macos" -> "Build Signed & Notarized Package";
+      case "windows" -> "Build & Sign Package";
+      default -> "Build Release Package";
+    });
   }
 
   private void refreshWorkflowNotices(ValidationResult result) {
@@ -671,7 +771,7 @@ public class GameBuildPublisherView extends BorderPane {
     }
 
     setWorkflowNotice(configurationNoticeLabel, "ready",
-        "✓ Configuration ready — continue to Validate below.");
+        "Configuration ready, continue to Validate below.");
     if (dependencyScanTask != null && dependencyScanTask.isRunning()) {
       setWorkflowNotice(validationNoticeLabel, "running", "Scanning game content… Results will appear here when ready.");
     } else if (dependencyReport == null) {
@@ -682,10 +782,10 @@ public class GameBuildPublisherView extends BorderPane {
           "Validation found " + dependencyReport.errorCount() + " blocking issue(s). Fix them before shipping.");
     } else if (dependencyReport.warningCount() > 0) {
       setWorkflowNotice(validationNoticeLabel, "ready",
-          "✓ Validation complete with " + dependencyReport.warningCount() + " warning(s) — review them, then continue to Build & ship.");
+          "Validation complete with " + dependencyReport.warningCount() + " warning(s), review them, then continue to Build & ship.");
     } else {
       setWorkflowNotice(validationNoticeLabel, "ready",
-          "✓ Validation clear — continue to Build & ship below.");
+          "Validation clear, continue to Build & ship below.");
     }
   }
 
@@ -1758,6 +1858,160 @@ public class GameBuildPublisherView extends BorderPane {
     }
   }
 
+  private void chooseGameIcon() {
+    if (projectRoot == null || !projectRoot.isDirectory()) return;
+    File config = findReleaseConfig(projectRoot);
+    if (config == null) config = createReleaseConfig();
+    if (config == null) return;
+    FileChooser chooser = new FileChooser();
+    chooser.setTitle("Choose Game Package Icon");
+    String extension = nativeIconExtension();
+    chooser.getExtensionFilters().setAll(
+        new FileChooser.ExtensionFilter(extension.substring(1).toUpperCase(Locale.ROOT) + " icon", "*" + extension),
+        new FileChooser.ExtensionFilter("All files", "*.*"));
+    File selected = chooser.showOpenDialog(getScene() == null ? null : getScene().getWindow());
+    if (selected == null) return;
+    if (!selected.getName().toLowerCase(Locale.ROOT).endsWith(extension)) {
+      statusLabel.setText("Game icon must be a " + extension + " file on this host.");
+      setNoteTone(statusLabel, "error");
+      return;
+    }
+    try {
+      File packagingDir = new File(projectRoot, "packaging");
+      Files.createDirectories(packagingDir.toPath());
+      File destination = new File(packagingDir, "icon" + extension);
+      if (!selected.getCanonicalFile().equals(destination.getCanonicalFile())) {
+        Files.copy(selected.toPath(), destination.toPath(), StandardCopyOption.REPLACE_EXISTING);
+      }
+      String relativePath = projectRoot.toPath().relativize(destination.toPath()).toString().replace(File.separatorChar, '/');
+      updateReleaseConfigProperty(config, releaseProfilePropertyKey("icon"), relativePath);
+      gameIconField.setText(relativePath);
+      statusLabel.setText("Game icon set to " + relativePath + ".");
+      setNoteTone(statusLabel, "ok");
+      refreshFormState();
+    } catch (Exception ex) {
+      statusLabel.setText("Could not set game icon: " + ex.getMessage());
+      setNoteTone(statusLabel, "error");
+    }
+  }
+
+  private void clearGameIcon() {
+    File config = findReleaseConfig(projectRoot);
+    if (config == null) return;
+    try {
+      updateReleaseConfigProperty(config, releaseProfilePropertyKey("icon"), null);
+      gameIconField.clear();
+      statusLabel.setText("Game icon removed from the selected release profile.");
+      setNoteTone(statusLabel, "status");
+      refreshFormState();
+    } catch (Exception ex) {
+      statusLabel.setText("Could not clear game icon: " + ex.getMessage());
+      setNoteTone(statusLabel, "error");
+    }
+  }
+
+  private void revealGameIcon() {
+    String icon = releaseProfileValue(projectRoot, selectedReleaseProfile(), "icon");
+    File file = resolveReleaseProfileFile(icon);
+    if (!file.isFile()) {
+      statusLabel.setText("The configured game icon could not be found.");
+      setNoteTone(statusLabel, "error");
+      return;
+    }
+    if (EditorPathExplorer.show(getScene() == null ? null : getScene().getWindow(), file)) {
+      statusLabel.setText("Revealed game icon.");
+      setNoteTone(statusLabel, "status");
+    } else {
+      statusLabel.setText("Could not reveal game icon.");
+      setNoteTone(statusLabel, "error");
+    }
+  }
+
+  private File resolveReleaseProfileFile(String path) {
+    if (path == null || path.isBlank()) return new File("");
+    File file = new File(path);
+    return file.isAbsolute() ? file : new File(projectRoot, path);
+  }
+
+  private void copyNativeReleaseChecklist() {
+    StringBuilder text = new StringBuilder();
+    text.append(nameField.getText()).append(" native release checklist\n\n");
+    text.append(nativeReleaseSummaryLabel.getText()).append("\n\n");
+    File config = findReleaseConfig(projectRoot);
+    text.append("Release settings: ")
+        .append(config == null ? "not created" : config.getAbsolutePath())
+        .append('\n');
+    BuildTaskSelection release = releaseTaskForSelection();
+    if (release != null) {
+      text.append("Release command: ")
+          .append(BuildCliFormatter.buildCliCommand(release.taskName(), buildGradleArgs()))
+          .append('\n');
+    }
+    text.append("Artifacts: ").append(buildDistributionsDir().getAbsolutePath()).append('\n');
+    ClipboardContent content = new ClipboardContent();
+    content.putString(text.toString());
+    Clipboard.getSystemClipboard().setContent(content);
+    statusLabel.setText("Copied the native release checklist.");
+    setNoteTone(statusLabel, "ok");
+  }
+
+  private String releaseProfilePropertyKey(String key) {
+    return "profile." + selectedReleaseProfile() + "." + key;
+  }
+
+  static void updateReleaseConfigProperty(File config, String key, @Nullable String value) throws Exception {
+    List<String> lines = Files.exists(config.toPath()) ? Files.readAllLines(config.toPath()) : new ArrayList<>();
+    String prefix = key + "=";
+    int existing = -1;
+    for (int i = 0; i < lines.size(); i++) {
+      if (lines.get(i).stripLeading().startsWith(prefix)) {
+        existing = i;
+        break;
+      }
+    }
+    if (value == null || value.isBlank()) {
+      if (existing >= 0) lines.remove(existing);
+    } else if (existing >= 0) {
+      lines.set(existing, prefix + value);
+    } else {
+      if (!lines.isEmpty() && !lines.get(lines.size() - 1).isBlank()) lines.add("");
+      lines.add(prefix + value);
+    }
+    Files.write(config.toPath(), lines);
+  }
+
+  private String nativeIconExtension() {
+    return switch (currentHostOs()) {
+      case "macos" -> ".icns";
+      case "windows" -> ".ico";
+      default -> ".png";
+    };
+  }
+
+  private static String currentHostOs() {
+    String os = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
+    if (os.contains("mac")) return "macos";
+    if (os.contains("win")) return "windows";
+    return "linux";
+  }
+
+  private String releaseProfileValue(File root, String profile, String key) {
+    return releaseProfileValue(loadReleaseConfig(root), profile, key);
+  }
+
+  private static String releaseProfileValue(Properties properties, String profile, String key) {
+    for (String candidate : List.of("profile." + profile + "." + key, "profile.default." + key, key)) {
+      String value = properties.getProperty(candidate, "").trim();
+      if (!value.isBlank()) return value;
+    }
+    return "";
+  }
+
+  private static boolean releaseProfileFlag(Properties properties, String profile, String key) {
+    String value = releaseProfileValue(properties, profile, key).toLowerCase(Locale.ROOT);
+    return !value.isBlank() && !List.of("0", "false", "no", "off").contains(value);
+  }
+
   static String defaultReleaseConfigText(String gameName) {
     String displayName = gameName == null || gameName.trim().isBlank() ? "JVN Game" : gameName.trim();
     return """
@@ -1777,12 +2031,27 @@ public class GameBuildPublisherView extends BorderPane {
 
         # Optional platform icons (paths are relative to the game project).
         # profile.release.icon=packaging/icon.png
-        # profile.release.mac.packageIdentifier=com.example.game
+        # Use icon.icns on macOS, icon.ico on Windows, and icon.png on Linux.
 
-        # Enable these only after configuring platform credentials and tools.
+        # macOS signing and notarization. Create the notary profile with:
+        # xcrun notarytool store-credentials JVN_NOTARY
+        profile.release.mac.packageIdentifier=com.example.game
         profile.release.mac.sign=false
+        # profile.release.mac.signingIdentity=Developer ID Application: Your Studio
+        # profile.release.mac.installerSignIdentity=Developer ID Installer: Your Studio
         profile.release.mac.notarize=false
+        # profile.release.mac.notarytoolProfile=JVN_NOTARY
+
+        # Windows Authenticode signing. Use either certificateFile or subjectName.
         profile.release.win.sign=false
+        # profile.release.win.certificateFile=packaging/signing-certificate.pfx
+        # profile.release.win.certificatePasswordEnv=JVN_CERTIFICATE_PASSWORD
+        # profile.release.win.subjectName=Your Studio
+
+        # Linux package integration.
+        profile.release.linux.shortcut=true
+        # profile.release.linux.appCategory=Game
+        # profile.release.linux.debMaintainer=you@example.com
 
         # Signed full-artifact update catalog (PKCS#8 private key).
         profile.release.update.enabled=false

--- a/modules/editor/src/main/java/com/jvn/editor/ui/GameBuildPublisherView.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/GameBuildPublisherView.java
@@ -3,6 +3,7 @@ package com.jvn.editor.ui;
 import java.io.File;
 import java.io.FileInputStream;
 import java.nio.file.Path;
+import java.nio.file.Files;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
@@ -36,6 +37,7 @@ import javafx.scene.control.Label;
 import javafx.scene.control.ProgressIndicator;
 import javafx.scene.control.ScrollPane;
 import javafx.scene.control.TextField;
+import javafx.scene.control.Tooltip;
 import javafx.scene.input.Clipboard;
 import javafx.scene.input.ClipboardContent;
 import javafx.scene.layout.BorderPane;
@@ -168,6 +170,9 @@ public class GameBuildPublisherView extends BorderPane {
     Label subtitle = new Label("Package and release the current JVN game project as portable zips, cross-target desktop bundles, or host-native installers.");
     subtitle.setWrapText(true);
     subtitle.getStyleClass().add("build-publisher-subtitle");
+    Label capabilityNote = new Label("Desktop shipping targets: Windows x64, Linux x64, macOS Intel, and macOS Apple Silicon. Linux ARM64 remains unavailable with the current JavaFX runtime artifacts.");
+    capabilityNote.setWrapText(true);
+    capabilityNote.getStyleClass().addAll("build-publisher-note", "build-publisher-note-status");
 
     Label quickModesLabel = new Label("Quick Modes");
     quickModesLabel.getStyleClass().add("build-publisher-section-label");
@@ -185,7 +190,7 @@ public class GameBuildPublisherView extends BorderPane {
     FlowPane presetRow = new FlowPane(8, 8, presetPortableButton, presetDesktopButton, presetNativeButton);
     presetRow.setAlignment(Pos.CENTER_LEFT);
 
-    VBox titleBlock = new VBox(4, title, subtitle);
+    VBox titleBlock = new VBox(4, title, subtitle, capabilityNote);
     VBox quickModesBlock = new VBox(6, quickModesLabel, quickModesHelp, presetRow);
     VBox header = new VBox(12, titleBlock, quickModesBlock);
     header.getStyleClass().add("build-publisher-header");
@@ -197,20 +202,13 @@ public class GameBuildPublisherView extends BorderPane {
     versionField.setPromptText("0.1.0");
     styleField(versionField);
 
-    targetBox.getItems().setAll(
-        new TargetChoice("Current machine", "assembleJvnGamePortableCurrent", currentTargetDescription(), currentTargetToken()),
-        new TargetChoice("Windows x64", "assembleJvnGamePortableWindowsX64", "Builds a Windows portable zip.", "windows-x64"),
-        new TargetChoice("Linux x64", "assembleJvnGamePortableLinuxX64", "Builds a Linux portable zip.", "linux-x64"),
-        new TargetChoice("Linux ARM64", "assembleJvnGamePortableLinuxAarch64", "Builds a Linux ARM64 portable zip.", "linux-aarch64"),
-        new TargetChoice("macOS x64", "assembleJvnGamePortableMacosX64", "Builds an Intel macOS portable zip.", "macos-x64"),
-        new TargetChoice("macOS Apple Silicon", "assembleJvnGamePortableMacosAarch64", "Builds an Apple Silicon macOS portable zip.", "macos-aarch64"),
-        new TargetChoice("All supported targets", "assembleJvnGamePortable", "Builds Windows x64, Linux x64, Linux ARM64, macOS x64, and macOS Apple Silicon.", "all")
-    );
+    targetBox.getItems().setAll(desktopTargetChoices());
     targetBox.getSelectionModel().select(0);
+    targetBox.setTooltip(new Tooltip(targetBox.getValue().description()));
     styleField(targetBox);
     targetBox.setMaxWidth(Double.MAX_VALUE);
 
-    formatBox.getItems().setAll(PackageMode.values());
+    formatBox.getItems().setAll(PackageMode.supportedValues());
     formatBox.getSelectionModel().select(PackageMode.PORTABLE_ZIP);
     styleField(formatBox);
     formatBox.setMaxWidth(Double.MAX_VALUE);
@@ -307,7 +305,7 @@ public class GameBuildPublisherView extends BorderPane {
 
     openProjectButton = button("Open Project", ButtonTone.SECONDARY, false);
     openProjectButton.setOnAction(e -> openProjectFolder());
-    openReleaseConfigButton = button("Open Release Config", ButtonTone.SECONDARY, false);
+    openReleaseConfigButton = button("Create Release Config", ButtonTone.SECONDARY, false);
     openReleaseConfigButton.setOnAction(e -> openReleaseConfig());
     revealRuntimeCacheButton = button("Reveal Runtime Cache", ButtonTone.SECONDARY, false);
     revealRuntimeCacheButton.setOnAction(e -> revealRuntimeCache());
@@ -415,8 +413,14 @@ public class GameBuildPublisherView extends BorderPane {
 
     nameField.textProperty().addListener((obs, oldValue, newValue) -> refreshFormState());
     versionField.textProperty().addListener((obs, oldValue, newValue) -> refreshFormState());
-    targetBox.valueProperty().addListener((obs, oldValue, newValue) -> refreshFormState());
-    formatBox.valueProperty().addListener((obs, oldValue, newValue) -> refreshFormState());
+    targetBox.valueProperty().addListener((obs, oldValue, newValue) -> {
+      targetBox.setTooltip(newValue == null ? null : new Tooltip(newValue.description()));
+      refreshFormState();
+    });
+    formatBox.valueProperty().addListener((obs, oldValue, newValue) -> {
+      refreshTargetChoicesForMode(newValue);
+      refreshFormState();
+    });
     nativeTypeBox.valueProperty().addListener((obs, oldValue, newValue) -> refreshFormState());
     releaseProfileBox.valueProperty().addListener((obs, oldValue, newValue) -> refreshFormState());
     releaseProfileBox.getEditor().textProperty().addListener((obs, oldValue, newValue) -> refreshFormState());
@@ -561,14 +565,14 @@ public class GameBuildPublisherView extends BorderPane {
       return;
     }
     if (!result.errors().isEmpty()) {
-      validationLabel.setText("Blocked: " + result.errors().get(0));
+      validationLabel.setText(formatValidationMessages("Blocked", result.errors()));
       setNoteTone(validationLabel, "error");
       statusLabel.setText("Build unavailable: " + result.errors().get(0));
       setNoteTone(statusLabel, "error");
       return;
     }
     if (!result.warnings().isEmpty()) {
-      validationLabel.setText("Warning: " + result.warnings().get(0));
+      validationLabel.setText(formatValidationMessages("Warnings", result.warnings()));
       setNoteTone(validationLabel, "warn");
       setNoteTone(statusLabel, "status");
       return;
@@ -645,8 +649,6 @@ public class GameBuildPublisherView extends BorderPane {
         case PORTABLE_ZIP -> "Ship Portable";
         case BUNDLED_RUNTIME_ZIP -> "Ship Desktop";
         case NATIVE_PACKAGE -> "Ship Native";
-        case WEB_BUNDLE -> "Ship Web";
-        case MOBILE_PACKAGE -> "Ship Mobile";
       });
     }
     if (buildSelectedButton != null) {
@@ -657,8 +659,6 @@ public class GameBuildPublisherView extends BorderPane {
         case PORTABLE_ZIP -> "Build All Portable Targets";
         case BUNDLED_RUNTIME_ZIP -> "Build All Desktop Bundles";
         case NATIVE_PACKAGE -> "Build All";
-        case WEB_BUNDLE -> "Build Web Bundle";
-        case MOBILE_PACKAGE -> "Build Mobile Package";
       });
     }
     BuildTaskSelection releaseSelection = releaseTaskForSelection();
@@ -688,7 +688,11 @@ public class GameBuildPublisherView extends BorderPane {
     }
     if (copyDependencyReportButton != null) copyDependencyReportButton.setDisable(dependencyReport == null);
     if (clearDependencyReportButton != null) clearDependencyReportButton.setDisable(dependencyReport == null && !dependencyScanRunning);
-    if (openReleaseConfigButton != null) openReleaseConfigButton.setDisable(findReleaseConfig(projectRoot) == null);
+    if (openReleaseConfigButton != null) {
+      File releaseConfig = findReleaseConfig(projectRoot);
+      openReleaseConfigButton.setText(releaseConfig == null ? "Create Release Config" : "Open Release Config");
+      openReleaseConfigButton.setDisable(projectRoot == null || !projectRoot.isDirectory());
+    }
     boolean allowCache = workspaceRoot != null && workspaceRoot.isDirectory();
     if (revealRuntimeCacheButton != null) revealRuntimeCacheButton.setDisable(!allowCache);
     if (clearRuntimeCacheButton != null) clearRuntimeCacheButton.setDisable(!allowCache || (result != null && !result.errors().isEmpty() && selectedPackageMode() == PackageMode.NATIVE_PACKAGE));
@@ -820,8 +824,6 @@ public class GameBuildPublisherView extends BorderPane {
                 + currentTargetToken() + "-"
                 + (nativeType == null ? "native" : nativeType.token()) + ext).getPath());
       }
-      case WEB_BUNDLE -> outputLabel.setText("Output: " + new File(outDir, stem + "-web.zip").getPath());
-      case MOBILE_PACKAGE -> outputLabel.setText("Output: " + new File(outDir, stem + "-mobile.zip").getPath());
     }
     updateOutputDirField();
   }
@@ -852,8 +854,6 @@ public class GameBuildPublisherView extends BorderPane {
         String nativeLabel = nativeType == null ? "native package" : nativeType.label().toLowerCase(Locale.ROOT);
         yield nativeLabel.substring(0, 1).toUpperCase(Locale.ROOT) + nativeLabel.substring(1) + " for " + target.label();
       }
-      case WEB_BUNDLE -> "Web bundle (WASM)";
-      case MOBILE_PACKAGE -> "Mobile package";
     };
   }
 
@@ -868,8 +868,6 @@ public class GameBuildPublisherView extends BorderPane {
         yield "Self-contained build with a packaged runtime for " + target.label() + ". Players can unzip and launch without installing Java.";
       }
       case NATIVE_PACKAGE -> "Host-native installer path with release-profile support for signing, notarization, and publish hooks.";
-      case WEB_BUNDLE -> "WebAssembly bundle for browser-based play. Compiles via TeaVM for maximum compatibility.";
-      case MOBILE_PACKAGE -> "Native mobile package for Android (APK/AAB) and iOS (IPA). Compile on appropriate host.";
     };
   }
 
@@ -888,8 +886,6 @@ public class GameBuildPublisherView extends BorderPane {
           ? "First bundle builds may download and verify runtimes for each target, then reuse the local cache."
           : targetDescription + " The first build for this target downloads and verifies its runtime cache.";
       case NATIVE_PACKAGE -> targetDescription + " Release hooks only run for a single selected artifact.";
-      case WEB_BUNDLE -> "Requires TeaVM toolchain. Build produces a WASM bundle with HTML5 canvas rendering.";
-      case MOBILE_PACKAGE -> "Android requires Android SDK. iOS requires macOS + Xcode. Choose target platform above.";
     };
   }
 
@@ -915,8 +911,6 @@ public class GameBuildPublisherView extends BorderPane {
       case PORTABLE_ZIP -> new BuildTaskSelection("assembleJvnGamePortable", "Build Game - All Portable Targets");
       case BUNDLED_RUNTIME_ZIP -> new BuildTaskSelection("assembleJvnGameBundledRuntime", "Build Game - All Desktop Bundles");
       case NATIVE_PACKAGE -> null;
-      case WEB_BUNDLE -> new BuildTaskSelection("assembleJvnGameWeb", "Build Game - Web Bundle");
-      case MOBILE_PACKAGE -> new BuildTaskSelection("assembleJvnGameMobile", "Build Game - Mobile Package");
     };
     if (selection == null) return;
     buildTask(selection.taskName(), selection.title());
@@ -1525,9 +1519,8 @@ public class GameBuildPublisherView extends BorderPane {
   private void openReleaseConfig() {
     File config = findReleaseConfig(projectRoot);
     if (config == null) {
-      statusLabel.setText("No release config file found.");
-      setNoteTone(statusLabel, "warn");
-      return;
+      config = createReleaseConfig();
+      if (config == null) return;
     }
     if (EditorPathExplorer.show(getScene() == null ? null : getScene().getWindow(), config)) {
       statusLabel.setText("Revealed release config.");
@@ -1536,6 +1529,58 @@ public class GameBuildPublisherView extends BorderPane {
       statusLabel.setText("Could not reveal release config.");
       setNoteTone(statusLabel, "error");
     }
+  }
+
+  private File createReleaseConfig() {
+    if (projectRoot == null || !projectRoot.isDirectory()) {
+      statusLabel.setText("Release config unavailable: open a game project first.");
+      setNoteTone(statusLabel, "error");
+      return null;
+    }
+    File config = new File(projectRoot, "config/release/jvn-release.properties");
+    try {
+      Files.createDirectories(config.toPath().getParent());
+      if (!config.exists()) {
+        Files.writeString(config.toPath(), defaultReleaseConfigText(nameField.getText()));
+      }
+      releaseProfileBox.getItems().setAll(availableReleaseProfiles(projectRoot));
+      setReleaseProfileSelection("release");
+      releaseConfigLabel.setText(releaseConfigText(projectRoot));
+      statusLabel.setText("Created release profile: " + config.getAbsolutePath());
+      setNoteTone(statusLabel, "ok");
+      refreshFormState();
+      return config;
+    } catch (Exception ex) {
+      statusLabel.setText("Could not create release config: " + ex.getMessage());
+      setNoteTone(statusLabel, "error");
+      return null;
+    }
+  }
+
+  static String defaultReleaseConfigText(String gameName) {
+    String displayName = gameName == null || gameName.trim().isBlank() ? "JVN Game" : gameName.trim();
+    return """
+        # JVN desktop shipping profile
+        defaultProfile=release
+
+        profile.release.vendor=Your Studio
+        profile.release.description=%s
+        profile.release.aboutUrl=https://example.com
+        profile.release.licenseFile=LICENSE
+
+        # Optional platform icons (paths are relative to the game project).
+        # profile.release.icon=packaging/icon.png
+        # profile.release.mac.packageIdentifier=com.example.game
+
+        # Enable these only after configuring platform credentials and tools.
+        profile.release.mac.sign=false
+        profile.release.mac.notarize=false
+        profile.release.win.sign=false
+
+        # Optional publish command. Supported placeholders include artifact, mode,
+        # target, version, gameName, projectDir, and profile.
+        # profile.release.publish.command.1=butler push "{artifact}" account/game:channel
+        """.formatted(displayName + " built with JVN.");
   }
 
   private void revealRuntimeCache() {
@@ -1682,6 +1727,39 @@ public class GameBuildPublisherView extends BorderPane {
     }
   }
 
+  private void refreshTargetChoicesForMode(PackageMode mode) {
+    String previousToken = targetBox.getValue() == null ? currentTargetToken() : targetBox.getValue().outputToken();
+    List<TargetChoice> choices = mode == PackageMode.NATIVE_PACKAGE
+        ? List.of(currentTargetChoice())
+        : desktopTargetChoices();
+    targetBox.getItems().setAll(choices);
+    String desiredToken = mode == PackageMode.NATIVE_PACKAGE ? currentTargetToken() : previousToken;
+    selectTargetByToken(desiredToken);
+    if (targetBox.getValue() == null) targetBox.getSelectionModel().selectFirst();
+  }
+
+  private static TargetChoice currentTargetChoice() {
+    return new TargetChoice(
+        "Current machine",
+        "assembleJvnGamePortableCurrent",
+        currentTargetDescription(),
+        currentTargetToken());
+  }
+
+  private static List<TargetChoice> desktopTargetChoices() {
+    return List.of(
+        currentTargetChoice(),
+        new TargetChoice("Windows x64", "assembleJvnGamePortableWindowsX64", "Builds a Windows desktop artifact.", "windows-x64"),
+        new TargetChoice("Linux x64", "assembleJvnGamePortableLinuxX64", "Builds a Linux desktop artifact.", "linux-x64"),
+        new TargetChoice("macOS x64", "assembleJvnGamePortableMacosX64", "Builds an Intel macOS desktop artifact.", "macos-x64"),
+        new TargetChoice("macOS Apple Silicon", "assembleJvnGamePortableMacosAarch64", "Builds an Apple Silicon macOS desktop artifact.", "macos-aarch64"),
+        new TargetChoice("All supported targets", "assembleJvnGamePortable", "Builds Windows x64, Linux x64, macOS x64, and macOS Apple Silicon.", "all"));
+  }
+
+  static List<String> supportedDesktopTargetTokens() {
+    return desktopTargetChoices().stream().map(TargetChoice::outputToken).distinct().toList();
+  }
+
   private PackageMode selectedPackageMode() {
     PackageMode mode = formatBox.getValue();
     return mode == null ? PackageMode.PORTABLE_ZIP : mode;
@@ -1717,8 +1795,6 @@ public class GameBuildPublisherView extends BorderPane {
         String label = nativeType == null ? "Native Package" : nativeType.label();
         yield new BuildTaskSelection("packageJvnGameNativeCurrent", "Build Game - " + label);
       }
-      case WEB_BUNDLE -> new BuildTaskSelection("assembleJvnGameWeb", "Build Game - Web Bundle");
-      case MOBILE_PACKAGE -> new BuildTaskSelection("assembleJvnGameMobile", "Build Game - Mobile Package");
     };
   }
 
@@ -1738,7 +1814,6 @@ public class GameBuildPublisherView extends BorderPane {
       }
       case NATIVE_PACKAGE ->
           new BuildTaskSelection("releaseJvnGameNativeCurrent", "Release Game - Native Package");
-      case WEB_BUNDLE, MOBILE_PACKAGE -> null; // Release not yet implemented for web/mobile
     };
   }
 
@@ -1813,7 +1888,6 @@ public class GameBuildPublisherView extends BorderPane {
     return switch (target.outputToken()) {
       case "windows-x64" -> "WindowsX64";
       case "linux-x64" -> "LinuxX64";
-      case "linux-aarch64" -> "LinuxAarch64";
       case "macos-x64" -> "MacosX64";
       case "macos-aarch64" -> "MacosAarch64";
       default -> "";
@@ -1862,7 +1936,7 @@ public class GameBuildPublisherView extends BorderPane {
     String os = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
     String arch = System.getProperty("os.arch", "").toLowerCase(Locale.ROOT);
     if (os.contains("win")) return "windows-x64";
-    if (os.contains("linux") && (arch.contains("aarch64") || arch.contains("arm64"))) return "linux-aarch64";
+    if (os.contains("linux") && (arch.contains("aarch64") || arch.contains("arm64"))) return "unsupported-linux-aarch64";
     if (os.contains("linux")) return "linux-x64";
     if (os.contains("mac") && (arch.contains("aarch64") || arch.contains("arm64"))) return "macos-aarch64";
     if (os.contains("mac")) return "macos-x64";
@@ -1872,9 +1946,7 @@ public class GameBuildPublisherView extends BorderPane {
   private enum PackageMode {
     PORTABLE_ZIP("Portable Zip", "portable"),
     BUNDLED_RUNTIME_ZIP("Desktop Bundle", "bundled"),
-    NATIVE_PACKAGE("Native Package", "native"),
-    WEB_BUNDLE("Web (WASM)", "web"),
-    MOBILE_PACKAGE("Mobile", "mobile");
+    NATIVE_PACKAGE("Native Package", "native");
 
     private final String label;
     private final String gradleToken;
@@ -1888,10 +1960,19 @@ public class GameBuildPublisherView extends BorderPane {
       return gradleToken;
     }
 
+    private static List<PackageMode> supportedValues() {
+      return List.of(PORTABLE_ZIP, BUNDLED_RUNTIME_ZIP, NATIVE_PACKAGE);
+    }
+
     @Override
     public String toString() {
       return label;
     }
+  }
+
+  static String formatValidationMessages(String heading, List<String> messages) {
+    if (messages == null || messages.isEmpty()) return heading + ": none";
+    return heading + ":\n• " + String.join("\n• ", messages);
   }
 
   private record ValidationResult(List<String> errors, List<String> warnings) {

--- a/modules/editor/src/main/java/com/jvn/editor/ui/GameBuildPublisherView.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/GameBuildPublisherView.java
@@ -37,6 +37,7 @@ import javafx.scene.control.Label;
 import javafx.scene.control.ProgressIndicator;
 import javafx.scene.control.ScrollPane;
 import javafx.scene.control.TextField;
+import javafx.scene.control.TitledPane;
 import javafx.scene.control.Tooltip;
 import javafx.scene.input.Clipboard;
 import javafx.scene.input.ClipboardContent;
@@ -95,6 +96,7 @@ public class GameBuildPublisherView extends BorderPane {
   private final ComboBox<PackageMode> formatBox = new ComboBox<>();
   private final ComboBox<NativeTypeChoice> nativeTypeBox = new ComboBox<>();
   private final ComboBox<String> releaseProfileBox = new ComboBox<>();
+  private final ComboBox<String> packageVariantBox = new ComboBox<>();
   private final Label nativeTypeFieldLabel = new Label("Native Type");
   private final Label manifestLabel = new Label();
   private final Label outputLabel = new Label();
@@ -126,6 +128,9 @@ public class GameBuildPublisherView extends BorderPane {
   private Button copyDependencyReportButton;
   private Button clearDependencyReportButton;
   private Button releaseButton;
+  private Button smokeTestButton;
+  private Button updateBundleButton;
+  private Button storeBundleButton;
   private Button copyShipCliButton;
   private Button copyCliButton;
   private Button openProjectButton;
@@ -174,25 +179,24 @@ public class GameBuildPublisherView extends BorderPane {
     capabilityNote.setWrapText(true);
     capabilityNote.getStyleClass().addAll("build-publisher-note", "build-publisher-note-status");
 
-    Label quickModesLabel = new Label("Quick Modes");
+    Label quickModesLabel = new Label("Start with a release type");
     quickModesLabel.getStyleClass().add("build-publisher-section-label");
-    Label quickModesHelp = new Label("Switch the popup to the most common release flows without re-entering the whole plan.");
+    Label quickModesHelp = new Label("Choose the closest outcome. You can fine-tune the target and package below.");
     quickModesHelp.setWrapText(true);
     quickModesHelp.getStyleClass().add("build-publisher-copy");
 
-    presetPortableButton = button("Current Portable", ButtonTone.SECONDARY, true);
+    presetPortableButton = button("Portable · needs Java", ButtonTone.SECONDARY, true);
     presetPortableButton.setOnAction(e -> applyPreset(PackageMode.PORTABLE_ZIP, currentTargetToken()));
-    presetDesktopButton = button("Desktop Bundles", ButtonTone.SECONDARY, true);
+    presetDesktopButton = button("Desktop · all OSes", ButtonTone.SECONDARY, true);
     presetDesktopButton.setOnAction(e -> applyPreset(PackageMode.BUNDLED_RUNTIME_ZIP, "all"));
-    presetNativeButton = button("Native Current", ButtonTone.SECONDARY, true);
+    presetNativeButton = button("Installer · this OS", ButtonTone.SECONDARY, true);
     presetNativeButton.setOnAction(e -> applyPreset(PackageMode.NATIVE_PACKAGE, currentTargetToken()));
 
     FlowPane presetRow = new FlowPane(8, 8, presetPortableButton, presetDesktopButton, presetNativeButton);
     presetRow.setAlignment(Pos.CENTER_LEFT);
 
     VBox titleBlock = new VBox(4, title, subtitle, capabilityNote);
-    VBox quickModesBlock = new VBox(6, quickModesLabel, quickModesHelp, presetRow);
-    VBox header = new VBox(12, titleBlock, quickModesBlock);
+    VBox header = new VBox(12, titleBlock);
     header.getStyleClass().add("build-publisher-header");
 
     projectField.setEditable(false);
@@ -222,6 +226,12 @@ public class GameBuildPublisherView extends BorderPane {
     styleField(releaseProfileBox);
     releaseProfileBox.setMaxWidth(Double.MAX_VALUE);
     releaseProfileBox.getEditor().setPromptText("default");
+    releaseProfileBox.setTooltip(new Tooltip("Named signing and publishing settings from config/release/jvn-release.properties."));
+    packageVariantBox.setEditable(true);
+    styleField(packageVariantBox);
+    packageVariantBox.setMaxWidth(Double.MAX_VALUE);
+    packageVariantBox.getEditor().setPromptText("standard");
+    packageVariantBox.setTooltip(new Tooltip("Optional content edition such as standard, demo, or deluxe."));
 
     GridPane form = new GridPane();
     form.setHgap(10);
@@ -234,14 +244,16 @@ public class GameBuildPublisherView extends BorderPane {
     form.add(label("Version"), 0, 2);
     form.add(versionField, 1, 2);
     form.add(label("Target"), 0, 3);
-    form.add(targetBox, 1, 3);
-    form.add(label("Format"), 0, 4);
-    form.add(formatBox, 1, 4);
+    form.add(describedField(targetBox, "Which operating system receives this build."), 1, 3);
+    form.add(label("Package"), 0, 4);
+    form.add(describedField(formatBox, "Portable, self-contained desktop, or native installer."), 1, 4);
     nativeTypeFieldLabel.getStyleClass().add("layout-launcher-field-label");
     form.add(nativeTypeFieldLabel, 0, 5);
-    form.add(nativeTypeBox, 1, 5);
+    form.add(describedField(nativeTypeBox, "Installer type supported by this machine."), 1, 5);
     form.add(label("Release Profile"), 0, 6);
-    form.add(releaseProfileBox, 1, 6);
+    form.add(describedField(releaseProfileBox, "Signing and publishing recipe. Use default for ordinary builds."), 1, 6);
+    form.add(label("Package Variant"), 0, 7);
+    form.add(describedField(packageVariantBox, "Content edition, for example standard or demo."), 1, 7);
     form.getColumnConstraints().add(new javafx.scene.layout.ColumnConstraints(120));
     javafx.scene.layout.ColumnConstraints fill = new javafx.scene.layout.ColumnConstraints();
     fill.setHgrow(Priority.ALWAYS);
@@ -298,7 +310,7 @@ public class GameBuildPublisherView extends BorderPane {
     HBox.setHgrow(outputDirField, Priority.ALWAYS);
     outputDirLabel.setMinWidth(120);
 
-    VBox projectCard = card("Game", form, manifestLabel);
+    VBox projectCard = card("Game details", form, manifestLabel);
 
     FlowPane badgeRow = new FlowPane(6, 6, formatBadgeLabel, targetBadgeLabel, runtimeBadgeLabel, releaseBadgeLabel);
     badgeRow.setAlignment(Pos.CENTER_LEFT);
@@ -315,13 +327,16 @@ public class GameBuildPublisherView extends BorderPane {
     FlowPane utilitiesRow = new FlowPane(8, 8, openProjectButton, openReleaseConfigButton, revealRuntimeCacheButton, clearRuntimeCacheButton);
     utilitiesRow.setAlignment(Pos.CENTER_LEFT);
 
-    VBox planCard = card("Build Plan", badgeRow, buildPlanTitleLabel, buildPlanBodyLabel, buildPlanHintLabel, outputLabel, outputDirRow, validationLabel, releaseConfigLabel, utilitiesRow);
+    VBox planCard = card("Release preview", badgeRow, buildPlanTitleLabel, buildPlanBodyLabel,
+        buildPlanHintLabel, outputLabel, outputDirRow, validationLabel, releaseConfigLabel, utilitiesRow);
 
     Label buildHelp = new Label("Portable zips still need Java on the player machine. Desktop bundles include a prebuilt runtime for the selected target, so players do not need Java installed. The first bundle build for a target downloads and caches that runtime locally. Native packages use jpackage and stay host-specific.");
     buildHelp.setWrapText(true);
     buildHelp.getStyleClass().add("build-publisher-copy");
 
     shipBuildButton = button("Ship Build", ButtonTone.PRIMARY, false);
+    shipBuildButton.getStyleClass().add("build-publisher-cta");
+    shipBuildButton.setAccessibleHelp("Builds the selected package plan and writes its release manifest.");
     shipBuildButton.setOnAction(e -> shipSelectedBuild());
     buildSelectedButton = button("Build Selected", ButtonTone.PRIMARY, false);
     buildSelectedButton.setOnAction(e -> buildSelectedTarget());
@@ -339,6 +354,12 @@ public class GameBuildPublisherView extends BorderPane {
     clearDependencyReportButton.setOnAction(e -> clearDependencyReport());
     releaseButton = button("Run Release Hooks", ButtonTone.SECONDARY, false);
     releaseButton.setOnAction(e -> runReleaseProfile());
+    smokeTestButton = button("Verify Packaged Build", ButtonTone.SECONDARY, false);
+    smokeTestButton.setOnAction(e -> runPackagedArtifactSmokeTest());
+    updateBundleButton = button("Build Signed Update", ButtonTone.SECONDARY, false);
+    updateBundleButton.setOnAction(e -> writeSignedUpdateBundle());
+    storeBundleButton = button("Build Store Bundle", ButtonTone.SECONDARY, false);
+    storeBundleButton.setOnAction(e -> writeStoreBundle());
     copyShipCliButton = button("Copy Ship Command", ButtonTone.SECONDARY, false);
     copyShipCliButton.setOnAction(e -> copyShipCommand());
     copyCliButton = button("Copy Build Command", ButtonTone.SECONDARY, false);
@@ -364,35 +385,47 @@ public class GameBuildPublisherView extends BorderPane {
     zipOutputButton.setOnAction(e -> zipOutputFolder());
     zipOutputButton.setDisable(true);
 
-    Label buildActionsLabel = new Label("Ship & Build");
+    Label buildActionsLabel = new Label("Ready to create your release?");
     buildActionsLabel.getStyleClass().add("build-publisher-section-label");
-    Label toolsLabel = new Label("Tools & Artifacts");
-    toolsLabel.getStyleClass().add("build-publisher-section-label");
-
-    FlowPane buildPrimaryRow = new FlowPane(8, 8, shipBuildButton, buildSelectedButton, buildAllButton, preflightButton, dependencyScanButton, releaseButton);
+    FlowPane buildPrimaryRow = new FlowPane(8, 8, shipBuildButton);
     buildPrimaryRow.setAlignment(Pos.CENTER_LEFT);
-    FlowPane buildUtilityRow = new FlowPane(8, 8, copyShipCliButton, copyCliButton, reveal, revealManifestButton, copyManifestPathButton, refreshArtifactsButton, zipOutputButton, notes);
+    Label buildOnlyHelp = new Label("Create packages without writing the complete release manifest or running the shipping plan.");
+    buildOnlyHelp.setWrapText(true);
+    buildOnlyHelp.getStyleClass().add("build-publisher-copy");
+    FlowPane buildOnlyRow = new FlowPane(8, 8, buildSelectedButton, buildAllButton);
+    buildOnlyRow.setAlignment(Pos.CENTER_LEFT);
+    TitledPane buildOnlyPane = disclosure("Build only (advanced)", new VBox(8, buildOnlyHelp, buildOnlyRow));
+    FlowPane releaseWorkflowRow = new FlowPane(8, 8, smokeTestButton, updateBundleButton, storeBundleButton, releaseButton);
+    releaseWorkflowRow.setAlignment(Pos.CENTER_LEFT);
+    FlowPane buildUtilityRow = new FlowPane(8, 8, copyShipCliButton, copyCliButton, reveal,
+        revealManifestButton, copyManifestPathButton, refreshArtifactsButton, zipOutputButton, notes);
     buildUtilityRow.setAlignment(Pos.CENTER_LEFT);
     FlowPane buildDangerRow = new FlowPane(8, 8, cleanOutputButton);
     buildDangerRow.setAlignment(Pos.CENTER_LEFT);
-    javafx.scene.control.Separator actionSep = new javafx.scene.control.Separator();
+    VBox advancedReleaseContent = new VBox(10, releaseWorkflowRow);
+    TitledPane advancedReleasePane = disclosure("Advanced release workflows", advancedReleaseContent);
+    VBox artifactToolsContent = new VBox(10, commandPreviewLabel, buildUtilityRow,
+        artifactInventoryLabel, buildDangerRow);
+    TitledPane artifactToolsPane = disclosure("Commands, manifests & artifact tools", artifactToolsContent);
 
-    VBox actionCard = card("Actions", buildHelp, optionsRow, commandPreviewLabel,
-        buildActionsLabel, buildPrimaryRow,
-        toolsLabel, buildUtilityRow,
-        actionSep, buildDangerRow,
-        artifactInventoryLabel, statusLabel);
+    VBox actionCard = card("Create release", buildHelp, optionsRow,
+        buildActionsLabel, buildPrimaryRow, buildOnlyPane, advancedReleasePane, artifactToolsPane, statusLabel);
 
     FlowPane dependencyBadgeRow = new FlowPane(6, 6, dependencyErrorsBadgeLabel, dependencyWarningsBadgeLabel, dependencyInfoBadgeLabel);
     dependencyBadgeRow.setAlignment(Pos.CENTER_LEFT);
-    FlowPane dependencyActionsRow = new FlowPane(8, 8, dependencyConsoleButton, copyDependencyReportButton, clearDependencyReportButton);
+    FlowPane dependencyActionsRow = new FlowPane(8, 8, preflightButton, dependencyScanButton,
+        dependencyConsoleButton, copyDependencyReportButton, clearDependencyReportButton);
     dependencyActionsRow.setAlignment(Pos.CENTER_LEFT);
-    VBox dependencyCard = card("Dependency Report", dependencySummaryLabel, dependencyBadgeRow, dependencyActionsRow, dependencyReportBox);
+    VBox dependencyCard = card("Check before shipping", dependencySummaryLabel, dependencyBadgeRow,
+        dependencyActionsRow, dependencyReportBox);
     renderDependencyPlaceholder("Run Scan Dependencies to inspect missing media, scripts, menus, stage presets, timelines, packaging blockers, and unused media.");
 
     Label nativeNote = new Label("Desktop bundles build locally for Windows, Linux, macOS Intel, and macOS Apple Silicon. Native installers still build on the matching host OS only.");
     nativeNote.setWrapText(true);
     nativeNote.getStyleClass().add("build-publisher-copy");
+
+    VBox quickModesBlock = new VBox(6, quickModesLabel, quickModesHelp, presetRow);
+    quickModesBlock.getStyleClass().add("build-publisher-mode-picker");
 
     HBox topRow = new HBox(14, projectCard, planCard);
     topRow.setAlignment(Pos.TOP_LEFT);
@@ -401,7 +434,11 @@ public class GameBuildPublisherView extends BorderPane {
     projectCard.setMaxWidth(Double.MAX_VALUE);
     planCard.setMaxWidth(Double.MAX_VALUE);
 
-    VBox content = new VBox(14, header, topRow, actionCard, dependencyCard, nativeNote);
+    VBox configureStep = step("1", "Configure", "Choose what players will download.", quickModesBlock, topRow);
+    VBox validateStep = step("2", "Validate", "Catch broken references and packaging issues before exporting.", dependencyCard);
+    VBox shipStep = step("3", "Build & ship", "Create the selected package, then use advanced workflows only when needed.", actionCard);
+
+    VBox content = new VBox(14, header, configureStep, validateStep, shipStep, nativeNote);
     content.getStyleClass().add("build-publisher-content");
     content.setFillWidth(true);
 
@@ -424,6 +461,8 @@ public class GameBuildPublisherView extends BorderPane {
     nativeTypeBox.valueProperty().addListener((obs, oldValue, newValue) -> refreshFormState());
     releaseProfileBox.valueProperty().addListener((obs, oldValue, newValue) -> refreshFormState());
     releaseProfileBox.getEditor().textProperty().addListener((obs, oldValue, newValue) -> refreshFormState());
+    packageVariantBox.valueProperty().addListener((obs, oldValue, newValue) -> refreshFormState());
+    packageVariantBox.getEditor().textProperty().addListener((obs, oldValue, newValue) -> refreshFormState());
     offlineModeCheck.selectedProperty().addListener((obs, oldValue, newValue) -> refreshFormState());
     refreshRuntimeCheck.selectedProperty().addListener((obs, oldValue, newValue) -> refreshFormState());
   }
@@ -434,6 +473,15 @@ public class GameBuildPublisherView extends BorderPane {
     return label;
   }
 
+  private VBox describedField(Node field, String help) {
+    Label helpLabel = new Label(help);
+    helpLabel.setWrapText(true);
+    helpLabel.getStyleClass().add("build-publisher-field-help");
+    VBox box = new VBox(3, field, helpLabel);
+    box.setFillWidth(true);
+    return box;
+  }
+
   private VBox card(String title, Node... nodes) {
     Label label = new Label(title);
     label.getStyleClass().add("build-publisher-card-title");
@@ -442,6 +490,31 @@ public class GameBuildPublisherView extends BorderPane {
     box.getChildren().add(label);
     box.getChildren().addAll(nodes);
     return box;
+  }
+
+  private VBox step(String number, String title, String description, Node... nodes) {
+    Label numberLabel = new Label(number);
+    numberLabel.getStyleClass().add("build-publisher-step-number");
+    Label titleLabel = new Label(title);
+    titleLabel.getStyleClass().add("build-publisher-step-title");
+    Label descriptionLabel = new Label(description);
+    descriptionLabel.setWrapText(true);
+    descriptionLabel.getStyleClass().add("build-publisher-step-description");
+    VBox copy = new VBox(2, titleLabel, descriptionLabel);
+    HBox heading = new HBox(10, numberLabel, copy);
+    heading.setAlignment(Pos.CENTER_LEFT);
+    VBox box = new VBox(12, heading);
+    box.getChildren().addAll(nodes);
+    box.getStyleClass().add("build-publisher-step");
+    return box;
+  }
+
+  private TitledPane disclosure(String title, Node content) {
+    TitledPane pane = new TitledPane(title, content);
+    pane.setExpanded(false);
+    pane.setAnimated(false);
+    pane.getStyleClass().add("build-publisher-disclosure");
+    return pane;
   }
 
   private Button button(String text, ButtonTone tone, boolean pill) {
@@ -479,10 +552,12 @@ public class GameBuildPublisherView extends BorderPane {
     clearDependencyReport();
     Properties manifest = ProjectManifestService.loadManifest(root);
     releaseProfileBox.getItems().setAll(availableReleaseProfiles(root));
+    packageVariantBox.getItems().setAll(availablePackageVariants(root));
     if (manifest == null) {
       nameField.setText(root == null ? "" : root.getName());
       versionField.setText("0.1.0");
       setReleaseProfileSelection(defaultReleaseProfile(root));
+      setPackageVariantSelection(defaultPackageVariant(root));
       releaseConfigLabel.setText(releaseConfigText(root));
       manifestLabel.setText("No jvn.project found. Choose a JVN game project before building.");
       statusLabel.setText("Build unavailable: missing jvn.project.");
@@ -500,6 +575,7 @@ public class GameBuildPublisherView extends BorderPane {
     nameField.setText(name.isBlank() ? root.getName() : name);
     versionField.setText(version);
     setReleaseProfileSelection(defaultReleaseProfile(root));
+    setPackageVariantSelection(defaultPackageVariant(root));
     releaseConfigLabel.setText(releaseConfigText(root));
     manifestLabel.setText("Manifest: type=" + manifest.getProperty("type", "vn")
         + "  " + ProjectManifestService.manifestEntryText(manifest)
@@ -517,6 +593,13 @@ public class GameBuildPublisherView extends BorderPane {
     }
     releaseProfileBox.setValue(value);
     releaseProfileBox.getEditor().setText(value);
+  }
+
+  private void setPackageVariantSelection(String variant) {
+    String value = variant == null || variant.isBlank() ? "standard" : variant.trim();
+    if (!packageVariantBox.getItems().contains(value)) packageVariantBox.getItems().add(value);
+    packageVariantBox.setValue(value);
+    packageVariantBox.getEditor().setText(value);
   }
 
 
@@ -554,6 +637,9 @@ public class GameBuildPublisherView extends BorderPane {
       buildAllButton.setVisible(supportsBuildAll);
     }
     if (preflightButton != null) preflightButton.setDisable(!canBuild);
+    if (smokeTestButton != null) smokeTestButton.setDisable(!canBuild);
+    if (updateBundleButton != null) updateBundleButton.setDisable(!canBuild);
+    if (storeBundleButton != null) storeBundleButton.setDisable(!canBuild);
     boolean canRelease = canBuild && releaseTaskForSelection() != null;
     if (releaseButton != null) releaseButton.setDisable(!canRelease);
     if (copyShipCliButton != null) copyShipCliButton.setDisable(!canBuild);
@@ -790,6 +876,11 @@ public class GameBuildPublisherView extends BorderPane {
       warnings.add("No release profile config found. Native packaging will build unsigned packages without publish commands.");
     }
 
+    String variant = selectedPackageVariant();
+    if (!variant.matches("[A-Za-z0-9._-]+")) {
+      errors.add("Package variant may use only letters, numbers, dots, underscores, and hyphens.");
+    }
+
     return new ValidationResult(errors, warnings);
   }
 
@@ -798,7 +889,9 @@ public class GameBuildPublisherView extends BorderPane {
     TargetChoice target = targetBox.getValue();
     PackageMode mode = selectedPackageMode();
     String targetId = target == null ? "current-target" : target.outputToken();
-    String stem = BuildCliFormatter.safeToken(nameField.getText()) + "-" + BuildCliFormatter.safeToken(versionField.getText());
+    String variant = selectedPackageVariant();
+    String variantSuffix = "standard".equalsIgnoreCase(variant) ? "" : "-" + BuildCliFormatter.safeToken(variant);
+    String stem = BuildCliFormatter.safeToken(nameField.getText()) + "-" + BuildCliFormatter.safeToken(versionField.getText()) + variantSuffix;
     File outDir = buildDistributionsDir();
     switch (mode) {
       case PORTABLE_ZIP -> {
@@ -820,7 +913,7 @@ public class GameBuildPublisherView extends BorderPane {
         String ext = nativeType == null ? ".pkg" : nativeType.artifactSuffix();
         outputLabel.setText("Output: " + new File(outDir,
             BuildCliFormatter.safeToken(nameField.getText()) + "-"
-                + BuildCliFormatter.safeNativeVersionToken(versionField.getText()) + "-"
+                + BuildCliFormatter.safeNativeVersionToken(versionField.getText()) + variantSuffix + "-"
                 + currentTargetToken() + "-"
                 + (nativeType == null ? "native" : nativeType.token()) + ext).getPath());
       }
@@ -1008,6 +1101,33 @@ public class GameBuildPublisherView extends BorderPane {
     setNoteTone(statusLabel, "status");
   }
 
+  private void runPackagedArtifactSmokeTest() {
+    if (!canBuild() || onBuildRequested == null) return;
+    List<String> args = buildGradleArgs();
+    onBuildRequested.accept(new BuildRequest(
+        "smokeTestJvnGameRelease", args.toArray(String[]::new), "Verify Packaged Game"));
+    statusLabel.setText("Started packaged-artifact verification.");
+    setNoteTone(statusLabel, "status");
+  }
+
+  private void writeSignedUpdateBundle() {
+    if (!canBuild() || onBuildRequested == null) return;
+    List<String> args = buildGradleArgs();
+    onBuildRequested.accept(new BuildRequest(
+        "writeJvnGameUpdateBundle", args.toArray(String[]::new), "Build Signed Game Update"));
+    statusLabel.setText("Started signed update-catalog generation.");
+    setNoteTone(statusLabel, "status");
+  }
+
+  private void writeStoreBundle() {
+    if (!canBuild() || onBuildRequested == null) return;
+    List<String> args = buildGradleArgs();
+    onBuildRequested.accept(new BuildRequest(
+        "assembleJvnGameStoreBundle", args.toArray(String[]::new), "Build Game Store Bundle"));
+    statusLabel.setText("Started store upload-bundle generation.");
+    setNoteTone(statusLabel, "status");
+  }
+
   private void buildTask(String taskName, String title) {
     if (!canBuild()) return;
     List<String> args = buildGradleArgs();
@@ -1047,6 +1167,8 @@ public class GameBuildPublisherView extends BorderPane {
     if (!version.isBlank()) args.add("-PjvnGameVersion=" + version);
     String profile = selectedReleaseProfile();
     if (!profile.isBlank()) args.add("-PjvnReleaseProfile=" + profile);
+    String variant = selectedPackageVariant();
+    if (!variant.isBlank()) args.add("-PjvnPackageVariant=" + variant);
     if (selectedPackageMode() == PackageMode.BUNDLED_RUNTIME_ZIP && refreshRuntimeCheck.isSelected()) {
       args.add("-PjvnRefreshBundledRuntime=true");
     }
@@ -1424,6 +1546,7 @@ public class GameBuildPublisherView extends BorderPane {
     notes.append("Version: ").append(versionField.getText()).append('\n');
     notes.append("Format: ").append(selectedPackageMode().label).append('\n');
     notes.append("Release profile: ").append(selectedReleaseProfile()).append('\n');
+    notes.append("Package variant: ").append(selectedPackageVariant()).append('\n');
     notes.append("Artifacts: ").append(outputLabel.getText().replace("Output: ", "")).append('\n');
     switch (selectedPackageMode()) {
       case PORTABLE_ZIP -> {
@@ -1545,6 +1668,8 @@ public class GameBuildPublisherView extends BorderPane {
       }
       releaseProfileBox.getItems().setAll(availableReleaseProfiles(projectRoot));
       setReleaseProfileSelection("release");
+      packageVariantBox.getItems().setAll(availablePackageVariants(projectRoot));
+      setPackageVariantSelection(defaultPackageVariant(projectRoot));
       releaseConfigLabel.setText(releaseConfigText(projectRoot));
       statusLabel.setText("Created release profile: " + config.getAbsolutePath());
       setNoteTone(statusLabel, "ok");
@@ -1562,6 +1687,12 @@ public class GameBuildPublisherView extends BorderPane {
     return """
         # JVN desktop shipping profile
         defaultProfile=release
+        defaultVariant=standard
+
+        # Package variants can exclude authoring or edition-specific files.
+        # variant.demo.exclude.1=assets/bonus/**
+        # variant.steam.exclude.1=store/itch/**
+        # variant.steam.windows.exclude.1=store/macos/**
 
         profile.release.vendor=Your Studio
         profile.release.description=%s
@@ -1576,6 +1707,19 @@ public class GameBuildPublisherView extends BorderPane {
         profile.release.mac.sign=false
         profile.release.mac.notarize=false
         profile.release.win.sign=false
+
+        # Signed full-artifact update catalog (PKCS#8 private key).
+        profile.release.update.enabled=false
+        # profile.release.update.baseUrl=https://downloads.example.com/game
+        # profile.release.update.privateKey=packaging/update-private-key.pem
+        # profile.release.update.publicKey=packaging/update-public-key.pem
+
+        # Store upload layout: generic, itch, or steam.
+        profile.release.store.preset=generic
+        # profile.release.store.itch.project=account/game
+        # profile.release.store.itch.channelPattern={target}
+        # profile.release.store.steam.appId=000000
+        # profile.release.store.steam.depotId=000001
 
         # Optional publish command. Supported placeholders include artifact, mode,
         # target, version, gameName, projectDir, and profile.
@@ -1770,6 +1914,11 @@ public class GameBuildPublisherView extends BorderPane {
     return value == null || value.trim().isBlank() ? "default" : value.trim();
   }
 
+  private String selectedPackageVariant() {
+    String value = packageVariantBox.isEditable() ? packageVariantBox.getEditor().getText() : packageVariantBox.getValue();
+    return value == null || value.trim().isBlank() ? "standard" : value.trim();
+  }
+
   private BuildTaskSelection buildTaskForSelection() {
     PackageMode mode = selectedPackageMode();
     TargetChoice target = targetBox.getValue();
@@ -1856,6 +2005,25 @@ public class GameBuildPublisherView extends BorderPane {
       profiles.add(profile);
     }
     return profiles;
+  }
+
+  private List<String> availablePackageVariants(File root) {
+    Properties props = loadReleaseConfig(root);
+    List<String> variants = new ArrayList<>();
+    variants.add("standard");
+    for (String key : props.stringPropertyNames()) {
+      if (!key.startsWith("variant.")) continue;
+      String suffix = key.substring("variant.".length());
+      String variant = suffix.contains(".") ? suffix.substring(0, suffix.indexOf('.')) : suffix;
+      if (variant.isBlank() || variants.contains(variant)) continue;
+      variants.add(variant);
+    }
+    return variants;
+  }
+
+  private String defaultPackageVariant(File root) {
+    String configured = loadReleaseConfig(root).getProperty("defaultVariant", "standard").trim();
+    return configured.isBlank() ? "standard" : configured;
   }
 
   private String defaultReleaseProfile(File root) {

--- a/modules/editor/src/main/java/com/jvn/editor/ui/GameBuildPublisherView.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/GameBuildPublisherView.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.nio.file.Path;
 import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
@@ -159,6 +158,8 @@ public class GameBuildPublisherView extends BorderPane {
   private final TextField gameIconField = new TextField();
   private final Label nativeReleaseSummaryLabel = new Label();
   private final VBox nativeReleaseBox = new VBox(8);
+  private final FlowPane validationActionsRow = new FlowPane(8, 8);
+  private final FlowPane nativeReleaseActionsRow = new FlowPane(8, 8);
   private Button chooseGameIconButton;
   private Button clearGameIconButton;
   private Button nativeReleaseButton;
@@ -341,7 +342,7 @@ public class GameBuildPublisherView extends BorderPane {
     gameIconRow.setAlignment(Pos.CENTER_LEFT);
     HBox.setHgrow(gameIconField, Priority.ALWAYS);
     gameIconLabel.setMinWidth(120);
-    Label gameIconHelp = new Label("Used by native installers and app bundles. Required format on this host: " + nativeIconExtension() + ".");
+    Label gameIconHelp = new Label("Choose a square transparent PNG (512x512 or larger). JVN generates the native " + nativeIconExtension() + " icon.");
     gameIconHelp.setWrapText(true);
     gameIconHelp.getStyleClass().add("build-publisher-field-help");
 
@@ -462,10 +463,10 @@ public class GameBuildPublisherView extends BorderPane {
     nativeReleaseSummaryLabel.getStyleClass().add("build-publisher-copy");
     Label nativeReleaseTitle = new Label("Finish native release");
     nativeReleaseTitle.getStyleClass().add("build-publisher-section-label");
-    FlowPane nativeReleaseActions = new FlowPane(8, 8, nativeReleaseButton, nativeReleaseConfigButton,
+    nativeReleaseActionsRow.getChildren().setAll(nativeReleaseButton, nativeReleaseConfigButton,
         nativeCopyChecklistButton, nativeRevealIconButton, nativeRevealBuildsButton, nativeVerifyButton);
-    nativeReleaseActions.setAlignment(Pos.CENTER_LEFT);
-    nativeReleaseBox.getChildren().setAll(nativeReleaseTitle, nativeReleaseSummaryLabel, nativeReleaseActions);
+    nativeReleaseActionsRow.setAlignment(Pos.CENTER_LEFT);
+    nativeReleaseBox.getChildren().setAll(nativeReleaseTitle, nativeReleaseSummaryLabel, nativeReleaseActionsRow);
     nativeReleaseBox.getStyleClass().add("build-publisher-native-release");
 
     VBox actionCard = card("Create release", buildHelp, optionsRow,
@@ -477,14 +478,14 @@ public class GameBuildPublisherView extends BorderPane {
     Label dependencyActionsHelp = new Label("Scan content first to catch broken project references. Package preflight checks the selected release configuration.");
     dependencyActionsHelp.setWrapText(true);
     dependencyActionsHelp.getStyleClass().add("build-publisher-copy");
-    FlowPane dependencyActionsRow = new FlowPane(8, 8, dependencyScanButton, preflightButton);
-    dependencyActionsRow.setAlignment(Pos.CENTER_LEFT);
+    validationActionsRow.getChildren().setAll(dependencyScanButton, preflightButton);
+    validationActionsRow.setAlignment(Pos.CENTER_LEFT);
     FlowPane dependencyUtilityRow = new FlowPane(8, 8, dependencyConsoleButton,
         copyDependencyReportButton, clearDependencyReportButton);
     dependencyUtilityRow.setAlignment(Pos.CENTER_LEFT);
     TitledPane dependencyToolsPane = disclosure("More validation tools", dependencyUtilityRow);
     VBox dependencyCard = card("Validation status", dependencySummaryLabel, dependencyBadgeRow,
-        dependencyActionsHelp, dependencyActionsRow, dependencyToolsPane, dependencyReportBox);
+        dependencyActionsHelp, validationActionsRow, dependencyToolsPane, dependencyReportBox);
     renderDependencyPlaceholder("Scan game content to inspect missing media, scripts, menus, stage presets, timelines, packaging blockers, and unused media.");
 
     Label nativeNote = new Label("Desktop bundles build locally for Windows, Linux, macOS Intel, and macOS Apple Silicon. Native installers still build on the matching host OS only.");
@@ -717,7 +718,7 @@ public class GameBuildPublisherView extends BorderPane {
     String os = currentHostOs();
     List<String> steps = new ArrayList<>();
     steps.add(icon.isBlank()
-        ? "1. Choose a " + nativeIconExtension() + " game icon before the final package."
+        ? "1. Choose a high-resolution transparent PNG for the game icon."
         : "1. Icon ready: " + icon);
     if ("macos".equals(os)) {
       boolean sign = releaseProfileFlag(properties, profile, "mac.sign");
@@ -1865,34 +1866,68 @@ public class GameBuildPublisherView extends BorderPane {
     if (config == null) return;
     FileChooser chooser = new FileChooser();
     chooser.setTitle("Choose Game Package Icon");
-    String extension = nativeIconExtension();
     chooser.getExtensionFilters().setAll(
-        new FileChooser.ExtensionFilter(extension.substring(1).toUpperCase(Locale.ROOT) + " icon", "*" + extension),
+        new FileChooser.ExtensionFilter("High-resolution PNG icon", "*.png"),
         new FileChooser.ExtensionFilter("All files", "*.*"));
     File selected = chooser.showOpenDialog(getScene() == null ? null : getScene().getWindow());
     if (selected == null) return;
-    if (!selected.getName().toLowerCase(Locale.ROOT).endsWith(extension)) {
-      statusLabel.setText("Game icon must be a " + extension + " file on this host.");
-      setNoteTone(statusLabel, "error");
-      return;
-    }
+    installGameIcon(selected);
+  }
+
+  void installGameIcon(File selected) {
     try {
-      File packagingDir = new File(projectRoot, "packaging");
-      Files.createDirectories(packagingDir.toPath());
-      File destination = new File(packagingDir, "icon" + extension);
-      if (!selected.getCanonicalFile().equals(destination.getCanonicalFile())) {
-        Files.copy(selected.toPath(), destination.toPath(), StandardCopyOption.REPLACE_EXISTING);
-      }
-      String relativePath = projectRoot.toPath().relativize(destination.toPath()).toString().replace(File.separatorChar, '/');
+      File config = findReleaseConfig(projectRoot);
+      if (config == null) config = createReleaseConfig();
+      if (config == null) return;
+      GamePackageIconService.IconResult icon =
+          GamePackageIconService.install(selected, projectRoot, currentHostOs());
+      String relativePath = projectRoot.toPath().relativize(icon.platformIcon().toPath())
+          .toString().replace(File.separatorChar, '/');
       updateReleaseConfigProperty(config, releaseProfilePropertyKey("icon"), relativePath);
       gameIconField.setText(relativePath);
-      statusLabel.setText("Game icon set to " + relativePath + ".");
+      statusLabel.setText("Generated " + relativePath + " from " + icon.width() + "x" + icon.height() + " PNG artwork.");
       setNoteTone(statusLabel, "ok");
       refreshFormState();
     } catch (Exception ex) {
       statusLabel.setText("Could not set game icon: " + ex.getMessage());
       setNoteTone(statusLabel, "error");
     }
+  }
+
+  Button preflightButtonForTest() {
+    return preflightButton;
+  }
+
+  Button dependencyScanButtonForTest() {
+    return dependencyScanButton;
+  }
+
+  FlowPane validationActionsRowForTest() {
+    return validationActionsRow;
+  }
+
+  FlowPane nativeReleaseActionsRowForTest() {
+    return nativeReleaseActionsRow;
+  }
+
+  VBox nativeReleaseBoxForTest() {
+    return nativeReleaseBox;
+  }
+
+  Label nativeReleaseSummaryForTest() {
+    return nativeReleaseSummaryLabel;
+  }
+
+  TextField gameIconFieldForTest() {
+    return gameIconField;
+  }
+
+  void selectNativeModeForTest() {
+    formatBox.setValue(PackageMode.NATIVE_PACKAGE);
+  }
+
+  void selectPortableModeForTest() {
+    formatBox.setValue(PackageMode.PORTABLE_ZIP);
   }
 
   private void clearGameIcon() {

--- a/modules/editor/src/main/java/com/jvn/editor/ui/GamePackageIconService.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/GamePackageIconService.java
@@ -1,0 +1,150 @@
+package com.jvn.editor.ui;
+
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import javax.imageio.ImageIO;
+
+final class GamePackageIconService {
+  static final int MIN_SOURCE_SIZE = 512;
+
+  record IconResult(File source, File platformIcon, int width, int height) {}
+
+  private GamePackageIconService() {}
+
+  static IconResult install(File pngSource, File projectRoot, String hostOs) throws IOException, InterruptedException {
+    BufferedImage image = readAndValidate(pngSource);
+    File packagingDir = new File(projectRoot, "packaging");
+    Files.createDirectories(packagingDir.toPath());
+    File storedSource = new File(packagingDir, "icon-source.png");
+    if (!pngSource.getCanonicalFile().equals(storedSource.getCanonicalFile())) {
+      Files.copy(pngSource.toPath(), storedSource.toPath(), StandardCopyOption.REPLACE_EXISTING);
+    }
+
+    File platformIcon;
+    switch (normalizeHost(hostOs)) {
+      case "macos" -> {
+        platformIcon = new File(packagingDir, "icon.icns");
+        writeIcns(storedSource, platformIcon);
+      }
+      case "windows" -> {
+        platformIcon = new File(packagingDir, "icon.ico");
+        writeIco(image, platformIcon);
+      }
+      default -> {
+        platformIcon = new File(packagingDir, "icon.png");
+        Files.copy(storedSource.toPath(), platformIcon.toPath(), StandardCopyOption.REPLACE_EXISTING);
+      }
+    }
+    return new IconResult(storedSource, platformIcon, image.getWidth(), image.getHeight());
+  }
+
+  static BufferedImage readAndValidate(File source) throws IOException {
+    if (source == null || !source.isFile()) throw new IOException("Choose a readable PNG image.");
+    if (!source.getName().toLowerCase(Locale.ROOT).endsWith(".png")) {
+      throw new IOException("Game icon source must be a PNG image.");
+    }
+    BufferedImage image = ImageIO.read(source);
+    if (image == null) throw new IOException("The selected file is not a readable PNG image.");
+    if (image.getWidth() != image.getHeight()) {
+      throw new IOException("Game icon must be square; selected image is " + image.getWidth() + "x" + image.getHeight() + ".");
+    }
+    if (image.getWidth() < MIN_SOURCE_SIZE) {
+      throw new IOException("Game icon must be at least " + MIN_SOURCE_SIZE + "x" + MIN_SOURCE_SIZE + ".");
+    }
+    if (!image.getColorModel().hasAlpha() || !hasTransparentPixel(image)) {
+      throw new IOException("Game icon must include transparent pixels around the artwork.");
+    }
+    return image;
+  }
+
+  static void writeIco(BufferedImage source, File destination) throws IOException {
+    BufferedImage icon = resize(source, 256);
+    ByteArrayOutputStream png = new ByteArrayOutputStream();
+    if (!ImageIO.write(icon, "png", png)) throw new IOException("Could not encode Windows icon PNG data.");
+    byte[] data = png.toByteArray();
+    ByteBuffer header = ByteBuffer.allocate(22).order(ByteOrder.LITTLE_ENDIAN);
+    header.putShort((short) 0).putShort((short) 1).putShort((short) 1);
+    header.put((byte) 0).put((byte) 0).put((byte) 0).put((byte) 0);
+    header.putShort((short) 1).putShort((short) 32);
+    header.putInt(data.length).putInt(22);
+    Files.createDirectories(destination.toPath().getParent());
+    try (var output = Files.newOutputStream(destination.toPath())) {
+      output.write(header.array());
+      output.write(data);
+    }
+  }
+
+  private static void writeIcns(File source, File destination) throws IOException, InterruptedException {
+    Path iconset = destination.toPath().getParent().resolve(".jvn-icon.iconset");
+    deleteTree(iconset);
+    Files.createDirectories(iconset);
+    List<Integer> sizes = List.of(16, 32, 128, 256, 512);
+    try {
+      for (int size : sizes) {
+        run("sips", "-z", Integer.toString(size), Integer.toString(size), source.getAbsolutePath(),
+            "--out", iconset.resolve("icon_" + size + "x" + size + ".png").toString());
+        int retina = size * 2;
+        run("sips", "-z", Integer.toString(retina), Integer.toString(retina), source.getAbsolutePath(),
+            "--out", iconset.resolve("icon_" + size + "x" + size + "@2x.png").toString());
+      }
+      run("iconutil", "-c", "icns", iconset.toString(), "-o", destination.getAbsolutePath());
+    } finally {
+      deleteTree(iconset);
+    }
+  }
+
+  private static void run(String... command) throws IOException, InterruptedException {
+    Process process = new ProcessBuilder(command).redirectErrorStream(true).start();
+    String output = new String(process.getInputStream().readAllBytes());
+    int exit = process.waitFor();
+    if (exit != 0) throw new IOException(command[0] + " failed: " + output.trim());
+  }
+
+  private static BufferedImage resize(BufferedImage source, int size) {
+    BufferedImage target = new BufferedImage(size, size, BufferedImage.TYPE_INT_ARGB);
+    Graphics2D graphics = target.createGraphics();
+    try {
+      graphics.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+      graphics.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+      graphics.drawImage(source, 0, 0, size, size, null);
+    } finally {
+      graphics.dispose();
+    }
+    return target;
+  }
+
+  private static boolean hasTransparentPixel(BufferedImage image) {
+    for (int y = 0; y < image.getHeight(); y++) {
+      for (int x = 0; x < image.getWidth(); x++) {
+        if ((image.getRGB(x, y) >>> 24) < 255) return true;
+      }
+    }
+    return false;
+  }
+
+  private static String normalizeHost(String hostOs) {
+    String value = hostOs == null ? "" : hostOs.toLowerCase(Locale.ROOT);
+    if (value.contains("mac")) return "macos";
+    if (value.contains("win")) return "windows";
+    return "linux";
+  }
+
+  private static void deleteTree(Path root) throws IOException {
+    if (!Files.exists(root)) return;
+    try (var paths = Files.walk(root)) {
+      for (Path path : paths.sorted(Comparator.reverseOrder()).toList()) Files.deleteIfExists(path);
+    }
+  }
+}

--- a/modules/editor/src/main/resources/com/jvn/editor/editor-light.css
+++ b/modules/editor/src/main/resources/com/jvn/editor/editor-light.css
@@ -6201,6 +6201,57 @@
   -fx-font-weight: 600;
 }
 
+.build-publisher-workflow-notice {
+  -fx-padding: 12 15 12 15;
+  -fx-background-radius: 10;
+  -fx-border-radius: 10;
+  -fx-border-width: 1;
+  -fx-font-size: 11px;
+  -fx-font-weight: 800;
+}
+
+.build-publisher-workflow-notice-ready {
+  -fx-background-color: rgba(65, 137, 82, 0.11);
+  -fx-border-color: rgba(61, 125, 76, 0.30);
+  -fx-text-fill: #356f44;
+}
+
+.build-publisher-workflow-notice-pending {
+  -fx-background-color: rgba(168, 116, 56, 0.10);
+  -fx-border-color: rgba(141, 96, 46, 0.27);
+  -fx-text-fill: #795326;
+}
+
+.build-publisher-workflow-notice-blocked {
+  -fx-background-color: rgba(177, 72, 96, 0.10);
+  -fx-border-color: rgba(151, 56, 78, 0.28);
+  -fx-text-fill: #913a50;
+}
+
+.build-publisher-workflow-notice-running {
+  -fx-background-color: rgba(69, 111, 169, 0.10);
+  -fx-border-color: rgba(66, 105, 160, 0.28);
+  -fx-text-fill: #365f96;
+}
+
+.build-publisher-action-tile {
+  -fx-padding: 12 14 12 14;
+  -fx-min-height: 66;
+}
+
+.build-publisher-action-title {
+  -fx-text-fill: #302a25;
+  -fx-font-size: 12px;
+  -fx-font-weight: 900;
+}
+
+.build-publisher-action-description {
+  -fx-text-fill: #756b61;
+  -fx-font-size: 10px;
+  -fx-font-weight: 600;
+  -fx-max-width: 235;
+}
+
 .build-publisher-cta {
   -fx-font-size: 12px;
   -fx-padding: 10 22 10 22;

--- a/modules/editor/src/main/resources/com/jvn/editor/editor-light.css
+++ b/modules/editor/src/main/resources/com/jvn/editor/editor-light.css
@@ -6124,9 +6124,87 @@
   -fx-font-weight: 800;
 }
 
+.build-publisher-step {
+  -fx-padding: 15;
+  -fx-spacing: 12;
+  -fx-background-color: rgba(255,255,255,0.30);
+  -fx-background-radius: 14;
+  -fx-border-color: rgba(105,89,72,0.14);
+  -fx-border-radius: 14;
+  -fx-border-width: 1;
+}
+
+.build-publisher-step-number {
+  -fx-min-width: 30;
+  -fx-min-height: 30;
+  -fx-alignment: center;
+  -fx-background-color: #9a6933;
+  -fx-background-radius: 999;
+  -fx-text-fill: #fff9f2;
+  -fx-font-size: 12px;
+  -fx-font-weight: 900;
+}
+
+.build-publisher-step-title {
+  -fx-text-fill: #292420;
+  -fx-font-size: 16px;
+  -fx-font-weight: 900;
+}
+
+.build-publisher-step-description {
+  -fx-text-fill: #756b61;
+  -fx-font-size: 11px;
+  -fx-font-weight: 600;
+}
+
+.build-publisher-mode-picker {
+  -fx-padding: 12;
+  -fx-background-color: rgba(168,116,56,0.10);
+  -fx-background-radius: 10;
+  -fx-border-color: rgba(141,96,46,0.24);
+  -fx-border-radius: 10;
+  -fx-border-width: 1;
+}
+
+.build-publisher-disclosure {
+  -fx-background-color: transparent;
+  -fx-border-color: rgba(105,89,72,0.14);
+  -fx-border-radius: 9;
+}
+
+.build-publisher-disclosure > .title {
+  -fx-background-color: rgba(255,255,255,0.50);
+  -fx-background-radius: 9;
+  -fx-padding: 9 11 9 11;
+}
+
+.build-publisher-disclosure > .title > .text {
+  -fx-fill: #4a423a;
+  -fx-font-size: 11px;
+  -fx-font-weight: 800;
+}
+
+.build-publisher-disclosure > .content {
+  -fx-background-color: rgba(255,255,255,0.28);
+  -fx-border-color: transparent;
+  -fx-padding: 11;
+}
+
 .build-publisher-form {
   -fx-hgap: 12;
   -fx-vgap: 10;
+}
+
+.build-publisher-field-help {
+  -fx-text-fill: #82776c;
+  -fx-font-size: 9px;
+  -fx-font-weight: 600;
+}
+
+.build-publisher-cta {
+  -fx-font-size: 12px;
+  -fx-padding: 10 22 10 22;
+  -fx-min-height: 40;
 }
 
 .build-publisher-plan-title {

--- a/modules/editor/src/main/resources/com/jvn/editor/editor.css
+++ b/modules/editor/src/main/resources/com/jvn/editor/editor.css
@@ -6242,24 +6242,24 @@ The editor.css file defines the visual styling for the editor module, including 
 }
 
 .build-publisher-content {
-  -fx-padding: 18;
+  -fx-padding: 16;
 }
 
 .build-publisher-header {
-  -fx-padding: 16;
+  -fx-padding: 14 16 14 16;
   -fx-spacing: 12;
   -fx-background-color:
       linear-gradient(to bottom, rgba(255,255,255,0.035), rgba(255,255,255,0.0)),
       linear-gradient(to bottom, #181818 0%, #121212 100%);
-  -fx-background-radius: 14;
+  -fx-background-radius: 8;
   -fx-border-color: #2f2f2f;
-  -fx-border-radius: 14;
+  -fx-border-radius: 8;
   -fx-border-width: 1;
 }
 
 .build-publisher-title {
   -fx-text-fill: #f1f1f1;
-  -fx-font-size: 26px;
+  -fx-font-size: 22px;
   -fx-font-weight: 800;
 }
 
@@ -6287,12 +6287,12 @@ The editor.css file defines the visual styling for the editor module, including 
 }
 
 .build-publisher-step {
-  -fx-padding: 15;
+  -fx-padding: 14;
   -fx-spacing: 12;
   -fx-background-color: rgba(255,255,255,0.018);
-  -fx-background-radius: 14;
+  -fx-background-radius: 8;
   -fx-border-color: rgba(220,220,220,0.10);
-  -fx-border-radius: 14;
+  -fx-border-radius: 8;
   -fx-border-width: 1;
 }
 
@@ -6396,28 +6396,10 @@ The editor.css file defines the visual styling for the editor module, including 
   -fx-text-fill: #b5d2f5;
 }
 
-.build-publisher-action-tile {
-  -fx-padding: 12 14 12 14;
-  -fx-min-height: 66;
-}
-
-.build-publisher-action-title {
-  -fx-text-fill: #eeeeee;
-  -fx-font-size: 12px;
-  -fx-font-weight: 900;
-}
-
-.build-publisher-action-description {
-  -fx-text-fill: #9d9d9d;
-  -fx-font-size: 10px;
-  -fx-font-weight: 600;
-  -fx-max-width: 235;
-}
-
 .build-publisher-cta {
   -fx-font-size: 12px;
-  -fx-padding: 10 22 10 22;
-  -fx-min-height: 40;
+  -fx-padding: 11 26 11 26;
+  -fx-min-height: 42;
 }
 
 .build-publisher-plan-title {
@@ -6549,6 +6531,15 @@ The editor.css file defines the visual styling for the editor module, including 
 
 .build-publisher-options {
   -fx-padding: 2 0 2 0;
+}
+
+.build-publisher-native-release {
+  -fx-padding: 12;
+  -fx-background-color: rgba(72, 139, 88, 0.08);
+  -fx-background-radius: 8;
+  -fx-border-color: rgba(112, 190, 131, 0.24);
+  -fx-border-radius: 8;
+  -fx-border-width: 1;
 }
 
 .build-publisher-option {

--- a/modules/editor/src/main/resources/com/jvn/editor/editor.css
+++ b/modules/editor/src/main/resources/com/jvn/editor/editor.css
@@ -6286,9 +6286,87 @@ The editor.css file defines the visual styling for the editor module, including 
   -fx-font-weight: 800;
 }
 
+.build-publisher-step {
+  -fx-padding: 15;
+  -fx-spacing: 12;
+  -fx-background-color: rgba(255,255,255,0.018);
+  -fx-background-radius: 14;
+  -fx-border-color: rgba(220,220,220,0.10);
+  -fx-border-radius: 14;
+  -fx-border-width: 1;
+}
+
+.build-publisher-step-number {
+  -fx-min-width: 30;
+  -fx-min-height: 30;
+  -fx-alignment: center;
+  -fx-background-color: #8e673e;
+  -fx-background-radius: 999;
+  -fx-text-fill: #fff8ef;
+  -fx-font-size: 12px;
+  -fx-font-weight: 900;
+}
+
+.build-publisher-step-title {
+  -fx-text-fill: #f2f2f2;
+  -fx-font-size: 16px;
+  -fx-font-weight: 900;
+}
+
+.build-publisher-step-description {
+  -fx-text-fill: #999999;
+  -fx-font-size: 11px;
+  -fx-font-weight: 600;
+}
+
+.build-publisher-mode-picker {
+  -fx-padding: 12;
+  -fx-background-color: rgba(142,103,62,0.10);
+  -fx-background-radius: 10;
+  -fx-border-color: rgba(171,123,73,0.28);
+  -fx-border-radius: 10;
+  -fx-border-width: 1;
+}
+
+.build-publisher-disclosure {
+  -fx-background-color: transparent;
+  -fx-border-color: rgba(220,220,220,0.10);
+  -fx-border-radius: 9;
+}
+
+.build-publisher-disclosure > .title {
+  -fx-background-color: rgba(255,255,255,0.035);
+  -fx-background-radius: 9;
+  -fx-padding: 9 11 9 11;
+}
+
+.build-publisher-disclosure > .title > .text {
+  -fx-fill: #cfcfcf;
+  -fx-font-size: 11px;
+  -fx-font-weight: 800;
+}
+
+.build-publisher-disclosure > .content {
+  -fx-background-color: rgba(255,255,255,0.018);
+  -fx-border-color: transparent;
+  -fx-padding: 11;
+}
+
 .build-publisher-form {
   -fx-hgap: 12;
   -fx-vgap: 10;
+}
+
+.build-publisher-field-help {
+  -fx-text-fill: #858585;
+  -fx-font-size: 9px;
+  -fx-font-weight: 600;
+}
+
+.build-publisher-cta {
+  -fx-font-size: 12px;
+  -fx-padding: 10 22 10 22;
+  -fx-min-height: 40;
 }
 
 .build-publisher-plan-title {

--- a/modules/editor/src/main/resources/com/jvn/editor/editor.css
+++ b/modules/editor/src/main/resources/com/jvn/editor/editor.css
@@ -6363,6 +6363,57 @@ The editor.css file defines the visual styling for the editor module, including 
   -fx-font-weight: 600;
 }
 
+.build-publisher-workflow-notice {
+  -fx-padding: 12 15 12 15;
+  -fx-background-radius: 10;
+  -fx-border-radius: 10;
+  -fx-border-width: 1;
+  -fx-font-size: 11px;
+  -fx-font-weight: 800;
+}
+
+.build-publisher-workflow-notice-ready {
+  -fx-background-color: rgba(72, 139, 88, 0.14);
+  -fx-border-color: rgba(112, 190, 131, 0.38);
+  -fx-text-fill: #a9e2b5;
+}
+
+.build-publisher-workflow-notice-pending {
+  -fx-background-color: rgba(142, 103, 62, 0.12);
+  -fx-border-color: rgba(171, 123, 73, 0.34);
+  -fx-text-fill: #e1c199;
+}
+
+.build-publisher-workflow-notice-blocked {
+  -fx-background-color: rgba(128, 50, 67, 0.15);
+  -fx-border-color: rgba(185, 91, 112, 0.38);
+  -fx-text-fill: #f0a9b8;
+}
+
+.build-publisher-workflow-notice-running {
+  -fx-background-color: rgba(71, 104, 151, 0.15);
+  -fx-border-color: rgba(104, 147, 207, 0.38);
+  -fx-text-fill: #b5d2f5;
+}
+
+.build-publisher-action-tile {
+  -fx-padding: 12 14 12 14;
+  -fx-min-height: 66;
+}
+
+.build-publisher-action-title {
+  -fx-text-fill: #eeeeee;
+  -fx-font-size: 12px;
+  -fx-font-weight: 900;
+}
+
+.build-publisher-action-description {
+  -fx-text-fill: #9d9d9d;
+  -fx-font-size: 10px;
+  -fx-font-weight: 600;
+  -fx-max-width: 235;
+}
+
 .build-publisher-cta {
   -fx-font-size: 12px;
   -fx-padding: 10 22 10 22;

--- a/modules/editor/src/test/java/com/jvn/editor/ui/GameBuildPublisherViewFxTest.java
+++ b/modules/editor/src/test/java/com/jvn/editor/ui/GameBuildPublisherViewFxTest.java
@@ -1,0 +1,139 @@
+package com.jvn.editor.ui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.image.BufferedImage;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+import javax.imageio.ImageIO;
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class GameBuildPublisherViewFxTest {
+  private static boolean toolkitAvailable;
+
+  @TempDir Path tempDir;
+
+  @BeforeAll
+  static void startToolkit() {
+    if (System.getProperty("os.name", "").toLowerCase().contains("linux")
+        && System.getenv().getOrDefault("DISPLAY", "").isBlank()) {
+      toolkitAvailable = false;
+      return;
+    }
+    try {
+      CountDownLatch ready = new CountDownLatch(1);
+      Platform.startup(ready::countDown);
+      toolkitAvailable = ready.await(10, TimeUnit.SECONDS);
+    } catch (IllegalStateException alreadyStarted) {
+      toolkitAvailable = true;
+    } catch (Exception unavailable) {
+      toolkitAvailable = false;
+    }
+  }
+
+  @Test
+  void validationActionsStayCompactAndWrapInNarrowLayouts() throws Exception {
+    Assumptions.assumeTrue(toolkitAvailable, "JavaFX toolkit is unavailable in this environment");
+    runFx(() -> {
+      GameBuildPublisherView view = createView();
+      Scene scene = style(new Scene(view, 760, 900));
+      scene.getRoot().applyCss();
+      scene.getRoot().layout();
+
+      assertTrue(view.preflightButtonForTest().getGraphic() == null);
+      assertTrue(view.dependencyScanButtonForTest().getGraphic() == null);
+      assertTrue(view.preflightButtonForTest().minHeight(-1) <= 40);
+      assertTrue(view.dependencyScanButtonForTest().minHeight(-1) <= 40);
+      assertTrue(view.preflightButtonForTest().minWidth(-1) < 220);
+      assertTrue(view.dependencyScanButtonForTest().minWidth(-1) < 220);
+
+      view.validationActionsRowForTest().resize(220, 120);
+      view.validationActionsRowForTest().layout();
+      assertTrue(view.validationActionsRowForTest().prefHeight(220) > 50);
+      return null;
+    });
+  }
+
+  @Test
+  void nativeModeControlsGuidanceVisibilityAndPlatformChecklist() throws Exception {
+    Assumptions.assumeTrue(toolkitAvailable, "JavaFX toolkit is unavailable in this environment");
+    runFx(() -> {
+      GameBuildPublisherView view = createView();
+      style(new Scene(view, 800, 900));
+
+      view.selectPortableModeForTest();
+      assertFalse(view.nativeReleaseBoxForTest().isManaged());
+      assertFalse(view.nativeReleaseBoxForTest().isVisible());
+
+      view.selectNativeModeForTest();
+      assertTrue(view.nativeReleaseBoxForTest().isManaged());
+      assertTrue(view.nativeReleaseBoxForTest().isVisible());
+      assertTrue(view.nativeReleaseSummaryForTest().getText().contains("1."));
+      assertTrue(view.nativeReleaseSummaryForTest().getText().contains("2."));
+      assertTrue(view.nativeReleaseActionsRowForTest().getChildren().size() >= 5);
+      return null;
+    });
+  }
+
+  @Test
+  void selectingPngGeneratesAndSelectsPlatformIcon() throws Exception {
+    Assumptions.assumeTrue(toolkitAvailable, "JavaFX toolkit is unavailable in this environment");
+    Path source = transparentPng(tempDir.resolve("game-icon.png"));
+    runFx(() -> {
+      GameBuildPublisherView view = createView();
+      style(new Scene(view, 800, 900));
+      view.installGameIcon(source.toFile());
+
+      String configured = view.gameIconFieldForTest().getText();
+      assertTrue(configured.startsWith("packaging/icon."));
+      assertTrue(tempDir.resolve("game/" + configured).toFile().isFile());
+      assertTrue(tempDir.resolve("game/packaging/icon-source.png").toFile().isFile());
+      return null;
+    });
+  }
+
+  private GameBuildPublisherView createView() throws Exception {
+    Path workspace = Files.createDirectories(tempDir.resolve("workspace"));
+    Path project = Files.createDirectories(tempDir.resolve("game"));
+    Files.createDirectories(project.resolve("scripts/story"));
+    Files.writeString(project.resolve("scripts/story/prologue.vns"), "@scene prologue\n");
+    Files.writeString(project.resolve("jvn.project"), """
+        name=UI Test Game
+        version=1.0.0
+        type=vn
+        entryVns=scripts/story/prologue.vns
+        runtime.ui=fx
+        """);
+    return new GameBuildPublisherView(workspace.toFile(), project.toFile(), request -> {});
+  }
+
+  private static Scene style(Scene scene) {
+    var css = GameBuildPublisherView.class.getResource("/com/jvn/editor/editor.css");
+    if (css != null) scene.getStylesheets().add(css.toExternalForm());
+    return scene;
+  }
+
+  private static Path transparentPng(Path path) throws Exception {
+    BufferedImage image = new BufferedImage(512, 512, BufferedImage.TYPE_INT_ARGB);
+    image.setRGB(256, 256, 0xffffaa00);
+    ImageIO.write(image, "png", path.toFile());
+    return path;
+  }
+
+  private static <T> T runFx(Callable<T> callable) throws Exception {
+    FutureTask<T> task = new FutureTask<>(callable);
+    Platform.runLater(task);
+    return task.get(30, TimeUnit.SECONDS);
+  }
+}

--- a/modules/editor/src/test/java/com/jvn/editor/ui/GameBuildPublisherViewTest.java
+++ b/modules/editor/src/test/java/com/jvn/editor/ui/GameBuildPublisherViewTest.java
@@ -86,6 +86,8 @@ class GameBuildPublisherViewTest {
     String config = GameBuildPublisherView.defaultReleaseConfigText("Lantern House");
 
     assertTrue(config.contains("defaultProfile=release"));
+    assertTrue(config.contains("defaultVariant=standard"));
+    assertTrue(config.contains("variant.demo.exclude.1"));
     assertTrue(config.contains("profile.release.description=Lantern House built with JVN."));
     assertTrue(config.contains("profile.release.mac.sign=false"));
     assertTrue(config.contains("profile.release.win.sign=false"));

--- a/modules/editor/src/test/java/com/jvn/editor/ui/GameBuildPublisherViewTest.java
+++ b/modules/editor/src/test/java/com/jvn/editor/ui/GameBuildPublisherViewTest.java
@@ -2,6 +2,7 @@ package com.jvn.editor.ui;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -61,5 +62,33 @@ class GameBuildPublisherViewTest {
         new GameBuildPublisherView.ArtifactSummary("game.zip", 1536L, 2_000L, true)));
 
     assertTrue(text.contains("sha256"));
+  }
+
+  @Test
+  void validationSummaryShowsEveryBlockingIssue() {
+    String text = GameBuildPublisherView.formatValidationMessages(
+        "Blocked",
+        List.of("Missing jvn.project", "Output folder is read-only"));
+
+    assertEquals("Blocked:\n• Missing jvn.project\n• Output folder is read-only", text);
+  }
+
+  @Test
+  void desktopShippingOffersOnlyBackedTargets() {
+    List<String> targets = GameBuildPublisherView.supportedDesktopTargetTokens();
+
+    assertTrue(targets.containsAll(List.of("windows-x64", "linux-x64", "macos-x64", "macos-aarch64", "all")));
+    assertFalse(targets.contains("linux-aarch64"));
+  }
+
+  @Test
+  void releaseConfigTemplateStartsSafeAndCrossPlatform() {
+    String config = GameBuildPublisherView.defaultReleaseConfigText("Lantern House");
+
+    assertTrue(config.contains("defaultProfile=release"));
+    assertTrue(config.contains("profile.release.description=Lantern House built with JVN."));
+    assertTrue(config.contains("profile.release.mac.sign=false"));
+    assertTrue(config.contains("profile.release.win.sign=false"));
+    assertTrue(config.contains("profile.release.publish.command.1"));
   }
 }

--- a/modules/editor/src/test/java/com/jvn/editor/ui/GameBuildPublisherViewTest.java
+++ b/modules/editor/src/test/java/com/jvn/editor/ui/GameBuildPublisherViewTest.java
@@ -90,7 +90,45 @@ class GameBuildPublisherViewTest {
     assertTrue(config.contains("variant.demo.exclude.1"));
     assertTrue(config.contains("profile.release.description=Lantern House built with JVN."));
     assertTrue(config.contains("profile.release.mac.sign=false"));
+    assertTrue(config.contains("profile.release.mac.signingIdentity"));
+    assertTrue(config.contains("profile.release.mac.notarytoolProfile"));
     assertTrue(config.contains("profile.release.win.sign=false"));
+    assertTrue(config.contains("profile.release.win.certificateFile"));
+    assertTrue(config.contains("profile.release.linux.shortcut=true"));
     assertTrue(config.contains("profile.release.publish.command.1"));
+  }
+
+  @Test
+  void releaseConfigPropertyUpdatePreservesCommentsAndOtherSettings() throws Exception {
+    Path config = Files.writeString(tempDir.resolve("jvn-release.properties"), """
+        # Keep this guidance
+        defaultProfile=release
+        profile.release.mac.sign=true
+        """);
+
+    GameBuildPublisherView.updateReleaseConfigProperty(
+        config.toFile(), "profile.release.icon", "packaging/icon.icns");
+
+    String updated = Files.readString(config);
+    assertTrue(updated.contains("# Keep this guidance"));
+    assertTrue(updated.contains("profile.release.mac.sign=true"));
+    assertTrue(updated.contains("profile.release.icon=packaging/icon.icns"));
+  }
+
+  @Test
+  void releaseConfigPropertyCanBeReplacedAndRemoved() throws Exception {
+    Path config = Files.writeString(tempDir.resolve("jvn-release.properties"), """
+        profile.release.icon=packaging/old.icns
+        profile.release.mac.sign=false
+        """);
+
+    GameBuildPublisherView.updateReleaseConfigProperty(
+        config.toFile(), "profile.release.icon", "packaging/icon.icns");
+    GameBuildPublisherView.updateReleaseConfigProperty(
+        config.toFile(), "profile.release.icon", null);
+
+    String updated = Files.readString(config);
+    assertFalse(updated.contains("profile.release.icon="));
+    assertTrue(updated.contains("profile.release.mac.sign=false"));
   }
 }

--- a/modules/editor/src/test/java/com/jvn/editor/ui/GamePackageIconServiceTest.java
+++ b/modules/editor/src/test/java/com/jvn/editor/ui/GamePackageIconServiceTest.java
@@ -1,0 +1,60 @@
+package com.jvn.editor.ui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.awt.image.BufferedImage;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import javax.imageio.ImageIO;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class GamePackageIconServiceTest {
+  @TempDir Path tempDir;
+
+  @Test
+  void rejectsSmallOpaqueAndNonSquareSources() throws Exception {
+    Path small = writePng("small.png", 256, 256, true);
+    Path opaque = writePng("opaque.png", 512, 512, false);
+    Path wide = writePng("wide.png", 640, 512, true);
+
+    assertThrows(Exception.class, () -> GamePackageIconService.readAndValidate(small.toFile()));
+    assertThrows(Exception.class, () -> GamePackageIconService.readAndValidate(opaque.toFile()));
+    assertThrows(Exception.class, () -> GamePackageIconService.readAndValidate(wide.toFile()));
+  }
+
+  @Test
+  void generatesPngBackedWindowsIconAndStoresSource() throws Exception {
+    Path source = writePng("source.png", 512, 512, true);
+
+    GamePackageIconService.IconResult result =
+        GamePackageIconService.install(source.toFile(), tempDir.toFile(), "windows");
+
+    assertEquals("icon-source.png", result.source().getName());
+    assertEquals("icon.ico", result.platformIcon().getName());
+    byte[] bytes = Files.readAllBytes(result.platformIcon().toPath());
+    assertTrue(bytes.length > 22);
+    assertEquals(0, bytes[0]);
+    assertEquals(1, bytes[2]);
+    assertEquals((byte) 0x89, bytes[22]);
+    assertEquals('P', bytes[23]);
+    assertEquals('N', bytes[24]);
+    assertEquals('G', bytes[25]);
+  }
+
+  private Path writePng(String name, int width, int height, boolean transparent) throws Exception {
+    BufferedImage image = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+    if (!transparent) {
+      int[] pixels = new int[width * height];
+      java.util.Arrays.fill(pixels, 0xff00ff00);
+      image.setRGB(0, 0, width, height, pixels, 0, width);
+    } else {
+      image.setRGB(width / 2, height / 2, 0xff00ff00);
+    }
+    Path path = tempDir.resolve(name);
+    ImageIO.write(image, "png", path.toFile());
+    return path;
+  }
+}

--- a/modules/runtime/src/main/java/com/jvn/runtime/GamePackageLauncher.java
+++ b/modules/runtime/src/main/java/com/jvn/runtime/GamePackageLauncher.java
@@ -96,11 +96,10 @@ public final class GamePackageLauncher {
     }
 
     List<File> roots = new ArrayList<>();
-    String userDir = System.getProperty("user.dir", "").trim();
-    if (!userDir.isBlank()) roots.add(new File(userDir));
-
     File codeSource = codeSourceRoot();
     if (codeSource != null) roots.add(codeSource);
+    String userDir = System.getProperty("user.dir", "").trim();
+    if (!userDir.isBlank()) roots.add(new File(userDir));
     return findPackagedGameRoot(roots);
   }
 

--- a/modules/runtime/src/test/java/com/jvn/runtime/GamePackageLauncherTest.java
+++ b/modules/runtime/src/test/java/com/jvn/runtime/GamePackageLauncherTest.java
@@ -83,4 +83,18 @@ class GamePackageLauncherTest {
       else System.setProperty("jvn.packaged.gameRoot", previous);
     }
   }
+
+  @Test
+  void bundledGameWinsOverWorkingDirectoryProject() throws Exception {
+    Path bundle = Files.createTempDirectory("jvn-bundle-priority-");
+    Path app = Files.createDirectories(bundle.resolve("Contents/app"));
+    Path bundledGame = Files.createDirectories(bundle.resolve("Contents/content/game"));
+    Files.writeString(bundledGame.resolve("jvn.project"), "type=vn\n");
+    Path workingProject = Files.createTempDirectory("jvn-working-project-");
+    Files.writeString(workingProject.resolve("jvn.project"), "type=vn\n");
+
+    assertEquals(
+        bundledGame.toFile().getCanonicalFile(),
+        GamePackageLauncher.findPackagedGameRoot(List.of(app.toFile(), workingProject.toFile())).getCanonicalFile());
+  }
 }


### PR DESCRIPTION
## Summary

- reorganize the Build & Publish window around configure, validate, and ship steps
- add platform-aware native release guidance, signing utilities, game icon selection, and artifact tools
- fix macOS native packages by including `jdk.management` in the custom runtime image
- prioritize bundled game content and make native staging sensitive to runtime and project changes

## Root cause

Packaged JavaFX games crashed at startup because the custom `jlink` image omitted `jdk.management`, while `FxLauncher` loads `com.sun.management.OperatingSystemMXBean`. Native staging could also remain up to date after launcher jars or game content changed, allowing stale code into a rebuilt package.

## Validation

- `./gradlew :editor:test --tests com.jvn.editor.ui.GameBuildPublisherViewTest :runtime:test --tests com.jvn.runtime.GamePackageLauncherTest`
- rebuilt `My-Visual-Novel-1.1.0-macos-aarch64-dmg.dmg` through `jvnw`
- mounted and inspected the final DMG
- installed and launched `/Applications/My Visual Novel.app` through LaunchServices
- confirmed the packaged runtime contains `jdk.management@21.0.11` and reaches the JavaFX viewport without a new crash report