### PR TITLE
Add extensible animation easing API

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <div align="left">
   <img src="docs/assets/images/jvn_logo.svg" width="460" alt="Java Vector Nexus logo">
   <br>
-  <strong>Current version:</strong> v0.3.1 <em></em>
+  <strong>Current version:</strong> v0.4.0 <em></em>
 </div>
 
 JVN is a young, modular cross-platform Visual Novel engine and 2D animation toolkit written in Java.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,7 @@ interface JvnInjectedExecOperations {
 }
 
 val jvnGroup = (findProperty("jvnGroup") as String?) ?: "com.jvn"
-val jvnVersion = (findProperty("jvnVersion") as String?) ?: "0.3.1"
+val jvnVersion = (findProperty("jvnVersion") as String?) ?: "0.4.0"
 val jvnBuildDirOverride = (findProperty("jvnBuildDir") as String?)
   ?.trim()
   ?.takeIf { it.isNotBlank() }

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -21,9 +21,11 @@ source of truth for docs changes.
 | I am animating a shot | [Puppeteer Editor Guide](editor/puppeteer/puppeteer-editor-guide.md) |
 | I am lighting/staging a scene | [Scene Lighting Studio](editor/sidebars/right/sidebar-image-tint-tool.md) |
 | I am building menus/UI | [JVN Facets](scripting/ui/facets.md) |
+| I want reusable UI and animation patterns | [Reusable Authoring With Facets And Motifs](guides/facets-and-motifs.md) |
 | I am packaging a game | [Build And Release Docs](project-setup/release/README.md) |
 | I need the normative VNS/JES rules | [Scripting Language Contract](scripting/spec/README.md) |
 | I want to extend JVN | [Plugin authoring and reference](plugins/README.md) |
+| I want to add animation curves | [Animation Easing Extensions](plugins/animation-extensions.md) |
 
 ## Browse By Section
 
@@ -34,6 +36,7 @@ source of truth for docs changes.
 - [Project Setup And Delivery](project-setup/README.md)
 - [Architecture](architecture/README.md)
 - [Plugins](plugins/README.md)
+- [Animation Easing Extensions](plugins/animation-extensions.md)
 
 ## Common Workflows
 
@@ -65,12 +68,13 @@ source of truth for docs changes.
 ### Build Menus And UI
 
 1. [JVN Facets](scripting/ui/facets.md)
-2. [Menu Profiles](scripting/ui/menus/menu-profiles.md)
-3. [Menu Screens](scripting/ui/menus/menu-screens.md)
-4. [Reactive Overlay Screens](scripting/ui/menus/reactive-screens.md)
-5. [Menu Styles](scripting/ui/menus/menu-styles.md)
-6. [Text-First Layout Workflow](scripting/ui/layout/workflow/text-first-layout-workflow.md)
-7. [Layout DSL Cookbook](scripting/ui/layout/reference/layout-dsl-cookbook.md)
+2. [Reusable Authoring With Facets And Motifs](guides/facets-and-motifs.md)
+3. [Menu Profiles](scripting/ui/menus/menu-profiles.md)
+4. [Menu Screens](scripting/ui/menus/menu-screens.md)
+5. [Reactive Overlay Screens](scripting/ui/menus/reactive-screens.md)
+6. [Menu Styles](scripting/ui/menus/menu-styles.md)
+7. [Text-First Layout Workflow](scripting/ui/layout/workflow/text-first-layout-workflow.md)
+8. [Layout DSL Cookbook](scripting/ui/layout/reference/layout-dsl-cookbook.md)
 
 ### Create Gameplay Or Interactive Scenes
 

--- a/docs/editor/puppeteer/puppeteer-jes-dsl.md
+++ b/docs/editor/puppeteer/puppeteer-jes-dsl.md
@@ -2,6 +2,8 @@
 
 Complete reference for the JES timeline code that Puppeteer generates and exports. Covers the `timeline { }` block syntax, all action types, generic property channels, event cues, easing values, parallel blocks, wait commands, audio cues, camera actions, reusable Puppeteer Motifs, editor metadata comments, and how to use exported code in VNS scripts and JES scenes.
 
+Installed plugins may add qualified easing IDs with validated named numeric parameters, such as `studio.elastic-pop(overshoot: 1.4)`. See [Animation Easing Extensions](../../plugins/animation-extensions.md) for registration, grammar, discovery, and lifecycle behavior.
+
 Exporter: `modules/editor/src/main/java/com/jvn/editor/ui/actioneditor/CodeExporter.java`
 Runtime: `modules/core/src/main/java/com/jvn/core/animation/TimelineRunner.java`
 

--- a/docs/editor/puppeteer/puppeteer-motifs.md
+++ b/docs/editor/puppeteer/puppeteer-motifs.md
@@ -13,6 +13,10 @@ Use motifs for motion that should stay consistent across characters and scenes:
 
 Motifs expand the existing Puppeteer pipeline. They are not a second animation runtime and do not introduce another keyframe format.
 
+For a workflow that combines reusable animation with reactive project UI, see [Reusable Authoring With Facets And Motifs](../../guides/facets-and-motifs.md). A motif can stage the surrounding scene, but it cannot currently be embedded in a `.facet` file or target an individual Facet node.
+
+Motif parameters may substitute a contributed easing specification into an ordinary action. The extension must be installed when the expanded timeline is parsed. See [Animation Easing Extensions](../../plugins/animation-extensions.md).
+
 ```text
 motif definitions + use invocations
                 ↓ source expansion

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -13,6 +13,7 @@ rules and subsystem contracts live in the scripting and runtime references.
 
 - [VNS By Example](vns-by-example.md) — ten chapters covering story scripting
 - [JES By Example](jes-by-example.md) — ten chapters covering interactive scenes
+- [Reusable Authoring With Facets And Motifs](facets-and-motifs.md) — design reusable UI and animation vocabulary, then combine both safely
 
 ## Recipes
 

--- a/docs/guides/common-file-types.md
+++ b/docs/guides/common-file-types.md
@@ -23,6 +23,8 @@ This page is for beginners who can already open the editor, but are not yet sure
 | `scripts/timelines/*.jes` | Registered Puppeteer export files that can be called from VNS or used from JES. Named exports may include Puppeteer metadata comments for editor reopen/state handoff. | cinematic/technical authors |
 | `.clip` | Reusable Puppeteer clip snippets saved from track ranges. | cinematic authors |
 
+A Puppeteer motif is not a separate file type. It is a named `motif` definition inside timeline source and is invoked with `use`; the definition expands into ordinary timeline actions before parsing.
+
 ## Menu And UI Files
 
 | File | What it does | Usually edited by |
@@ -74,4 +76,5 @@ That gives you story, textbox, and menu control before you move into more specia
 
 - [Choose Your Path in JVN](choose-your-path.md)
 - [Getting Started Guide](getting-started.md)
+- [Reusable Authoring With Facets And Motifs](facets-and-motifs.md)
 - [Documentation Index](../INDEX.md)

--- a/docs/guides/facets-and-motifs.md
+++ b/docs/guides/facets-and-motifs.md
@@ -1,0 +1,231 @@
+# Reusable Authoring With Facets And Motifs
+
+Facets and Puppeteer Motifs solve the same broad authoring problem in different domains: they let a project name and reuse intent instead of repeating low-level declarations.
+
+- A **Facet** names a reactive UI composition: groups, text, images, bars, and overlay buttons.
+- A **Motif** names a parameterized animation composition: moves, fades, camera actions, waits, audio cues, events, and other timeline actions.
+
+They are complementary, but they are not interchangeable. A Facet becomes a live overlay at runtime. A motif disappears during source expansion and becomes ordinary timeline actions before playback.
+
+## Mental Model
+
+```text
+story variables -----> .facet file -----> reactive overlay rendering
+                              |
+                              +---- standard screen lifecycle and buttons
+
+motif arguments -----> motif expansion --> ordinary timeline actions
+                                              |
+                                              +---- TimelineData and playback
+```
+
+This distinction explains their different behavior:
+
+| Question | Facet | Motif |
+|---|---|---|
+| What does it reuse? | A nested reactive UI tree | A parameterized action sequence |
+| When is it resolved? | Loaded as an overlay definition; values are reevaluated while rendered | Expanded before timeline parsing |
+| Does the abstraction survive at runtime? | Yes, as a Facet specification | No, only the expanded actions remain |
+| How is it invoked? | `[screen show id]` or `[screen call id]` | `use name(argument=value)` inside timeline source |
+| Where does state come from? | Live VNS/VN variables and localization | Invocation arguments, defaults, and surrounding timeline state |
+| What owns interaction? | Standard overlay buttons | Timeline events or actions |
+
+## Choose The Primitive By The Intent
+
+Use a Facet when the reusable idea is a **piece of interface**:
+
+- a relationship card;
+- a quest or inventory summary;
+- an inspect panel;
+- a custom confirmation prompt;
+- a story-variable-driven HUD panel.
+
+Use a motif when the reusable idea is **motion or staging**:
+
+- a character entrance;
+- an emphasis pulse;
+- a camera focus beat;
+- a fade-and-hide transition;
+- a synchronized expression and sound cue.
+
+Use both when a scene needs a consistent presentation beat around a custom interface. Keep UI composition in the Facet and scene motion in motifs.
+
+## Combined Example: Character Inspection
+
+The following pattern opens a reactive character card while the scene uses a standard focus motion.
+
+### 1. Define the Facet
+
+Create `config/facets/character_inspect.facet`:
+
+```properties
+title=Character
+width=0.56
+height=0.48
+modal=true
+dim=true
+
+nodes=portrait,details,name,affinity_label,affinity
+
+node.portrait.type=image
+node.portrait.value=${inspect_portrait}
+node.portrait.x=0.06
+node.portrait.y=0.18
+node.portrait.width=0.28
+node.portrait.height=0.62
+
+node.details.type=group
+node.details.x=0.39
+node.details.y=0.18
+node.details.width=0.55
+node.details.height=0.62
+
+node.name.type=text
+node.name.parent=details
+node.name.text=${inspect_name}
+node.name.x=0
+node.name.y=0
+node.name.width=1
+node.name.height=0.20
+
+node.affinity_label.type=text
+node.affinity_label.parent=details
+node.affinity_label.text=Affinity
+node.affinity_label.x=0
+node.affinity_label.y=0.38
+node.affinity_label.width=1
+node.affinity_label.height=0.15
+
+node.affinity.type=bar
+node.affinity.parent=details
+node.affinity.value=${inspect_affinity}
+node.affinity.x=0
+node.affinity.y=0.58
+node.affinity.width=1
+node.affinity.height=0.12
+
+buttons=close
+button.close.label=Close
+button.close.action=hide
+```
+
+### 2. Define the staging motif
+
+Keep the motif in the timeline source that uses it:
+
+```jes
+motif inspect_focus(target, x=640, zoom=1.12, duration=320) {
+  move "${target}" {
+    x: ${x}
+    dur: ${duration}
+    easing: camera_glide
+  }
+  cameraZoom {
+    zoom: ${zoom}
+    dur: ${duration}
+    easing: camera_glide
+  }
+  wait ${duration}
+}
+
+timeline {
+  use inspect_focus(target="hero")
+}
+```
+
+Save or register this source as the named Puppeteer timeline `character_inspect_focus`.
+
+### 3. Supply live data and show the UI
+
+```vns
+[set inspect_name "Lavender"]
+[set inspect_portrait "assets/images/characters/lavender.png"]
+[set inspect_affinity 0.72]
+[call jes_timeline character_inspect_focus]
+[screen call character_inspect]
+```
+
+The motif controls scene staging; the Facet controls the overlay. Updating `inspect_affinity` while the overlay is visible changes the bar on a later render without re-expanding or replaying the motif.
+
+## Composition Boundaries
+
+Keeping the boundary explicit makes reusable project APIs easier to understand.
+
+### Facets do not import motifs
+
+A `.facet` file cannot contain `motif` or `use` declarations. Facet nodes do not currently have animation hooks, timeline IDs, or node-level actions. To coordinate motion with a Facet today, run the animation from the surrounding VNS/JES flow and show or call the screen separately.
+
+### Motifs do not define UI
+
+A motif expands only into source accepted by the timeline parser. It cannot declare Facet nodes or create a new overlay type. It may emit a supported event for surrounding code to handle, but that event does not turn the motif into a UI component.
+
+### Their reuse scopes differ
+
+Facet files are discovered by screen ID from project paths. Motifs currently have source-local definitions: there is no global motif registry or cross-file motif import. A Facet can therefore be reused from many VNS call sites, while a motif must be present in each complete timeline source that invokes it.
+
+## Design A Project Vocabulary
+
+Treat Facet IDs and motif names as a small project-facing API.
+
+Prefer intent-based names:
+
+```text
+Facets: relationship_card, quest_summary, item_inspect
+Motifs: hero_arrival, inspect_focus, warning_shake
+```
+
+Avoid names that expose incidental implementation:
+
+```text
+Facets: panel_04, three_texts_and_bar
+Motifs: move_x_then_alpha, animation_7
+```
+
+For stable authoring primitives:
+
+1. Keep the public parameter or variable set small.
+2. Give motif parameters useful defaults.
+3. Use consistent variable prefixes for each Facet, such as `inspect_*`.
+4. Document whether a motif advances the timeline cursor.
+5. Document whether a Facet is modal and whether callers should use `show` or `call`.
+6. Preserve motif-authored source when the abstraction matters; visual round trips retain expanded keyframes, not motif boundaries.
+
+## Test The Contract
+
+For a Facet, verify:
+
+- discovery from the intended `config/facets/` path;
+- empty, normal, and long text values;
+- missing and out-of-range numeric variables;
+- each conditional visibility branch;
+- keyboard/controller behavior of overlay buttons;
+- both the project viewport and any supported alternate aspect ratio.
+
+For a motif, verify:
+
+- defaults and every named override;
+- starting, midpoint, and final visual state;
+- cursor movement when composed before another motif;
+- nested motif expansion;
+- import into Puppeteer and runtime playback;
+- emitted audio or script events, if any.
+
+For a combined interaction, verify the animation and screen lifecycle independently first. Then test timing at the call site so a modal `[screen call]` does not unexpectedly block scene work that was intended to happen afterward.
+
+## Current Extension Direction
+
+Facets and motifs demonstrate two useful extension patterns for JVN:
+
+- **persistent declarative composition**, where a named object remains live and reactive;
+- **authoring-time composition**, where a named abstraction compiles into existing runtime primitives.
+
+Future extension APIs can follow either model without adding parallel runtimes. Potential additions such as reusable Facet components, motif libraries, custom Facet node renderers, or animation hooks should preserve the existing screen and timeline lifecycles.
+
+These are design directions, not current syntax. The current contracts are documented in the references below.
+
+## Read The Full References
+
+- [JVN Facets](../scripting/ui/facets.md) — file discovery, fields, nodes, geometry, reactivity, interaction, diagnostics, and limitations
+- [Puppeteer Motifs](../editor/puppeteer/puppeteer-motifs.md) — grammar, parameters, substitution, timing, nesting, editor behavior, recipes, and limitations
+- [Reactive Overlay Screens](../scripting/ui/menus/reactive-screens.md) — the lifecycle inherited by Facets
+- [Puppeteer JES Timeline DSL](../editor/puppeteer/puppeteer-jes-dsl.md) — the action language produced by motif expansion

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -7,6 +7,7 @@ JVN plugins add scripting commands, editor tools, asset importers, and runtime o
 - [Authoring your first plugin](authoring.md)
 - [Manifest reference](manifest.md)
 - [Extension-point reference](extension-points.md)
+- [Animation easing extensions](animation-extensions.md)
 - [Plugin API reference](api-reference.md)
 - [Host and lifecycle reference](host-reference.md)
 - [Packaging and distribution](distribution.md)

--- a/docs/plugins/animation-extensions.md
+++ b/docs/plugins/animation-extensions.md
@@ -1,0 +1,438 @@
+# Animation Easing Extensions
+
+Plugin API 1.1 introduces named, metadata-rich easing curves as JVN's first end-to-end animation extension family. A plugin can define a curve once, then use its stable ID in timeline source, runtime playback, Puppeteer imports, easing previews, and the editor easing catalog.
+
+This is the first vertical slice of a broader animation extension model. The current public contract covers **easing curves**. Transitions, timeline actions, constraints, and procedural-motion providers are design directions, not APIs available in 1.1.
+
+## Why Easing Is The First Extension
+
+An easing curve has a deliberately narrow contract:
+
+```text
+normalized progress + validated parameters -> interpolated progress
+```
+
+That small boundary is enough to exercise the complete extension path:
+
+```text
+plugin manifest capability
+        ↓
+context.contribute().animations().easing(...)
+        ↓
+owned host registry and lifecycle cleanup
+        ↓
+JES/Puppeteer easing parser
+        ↓
+TimelineData keyframes
+        ↓
+runtime and editor preview evaluation
+        ↓
+Puppeteer easing discovery and search
+```
+
+No plugin receives a `TimelineRunner`, editor window, renderer, scene, or other engine-internal object. The extension operates on an immutable frame supplied by the host.
+
+## Complete Example
+
+### Manifest
+
+Declare the `animation.easing` capability and require Plugin API 1.1 or newer:
+
+```json
+{
+  "id": "com.example.motion",
+  "name": "Example Motion",
+  "version": "1.0.0",
+  "jvnApi": ">=1.1.0 <2.0.0",
+  "entrypoint": "com.example.motion.MotionPlugin",
+  "description": "Project easing vocabulary.",
+  "vendor": "Example Studio",
+  "capabilities": ["animation.easing"]
+}
+```
+
+### Plugin entry point
+
+```java
+package com.example.motion;
+
+import com.jvn.plugin.api.JvnPlugin;
+import com.jvn.plugin.api.PluginContext;
+
+import static com.jvn.plugin.api.animation.AnimationEasingDefinition.easing;
+import static com.jvn.plugin.api.animation.AnimationEasingDefinition.range;
+
+public final class MotionPlugin implements JvnPlugin {
+  @Override
+  public void initialize(PluginContext context) {
+    context.contribute().animations().easing("example.elastic-pop",
+        easing("Elastic Pop")
+            .description("A quick overshoot followed by a soft settle.")
+            .category("Expressive")
+            .documentation("https://example.com/motion/elastic-pop")
+            .parameter("overshoot", 1.2, range(0.0, 3.0))
+            .parameter("settle", 0.7, range(0.1, 2.0))
+            .evaluate(frame -> {
+              double t = frame.progress();
+              double overshoot = frame.parameter("overshoot");
+              double settle = frame.parameter("settle");
+              return 1.0 - Math.exp(-6.0 * settle * t)
+                  * Math.cos((Math.PI * 2.0 + overshoot) * t);
+            }));
+  }
+}
+```
+
+### Timeline usage
+
+Use the registered ID as an easing value. Named arguments accept `:` or `=`; `:` is the canonical exported form.
+
+```jes
+move "hero" {
+  x: 640
+  dur: 420
+  easing: "example.elastic-pop(overshoot: 1.4, settle: 0.8)"
+}
+```
+
+Omit the argument list to use every declared default:
+
+```jes
+easing: "example.elastic-pop"
+```
+
+The quoted form is recommended because the value includes punctuation. The timeline parser also accepts an unquoted extension ID where the surrounding grammar preserves the complete token.
+
+## Public Authoring API
+
+The author-facing entry point is:
+
+```java
+context.contribute().animations()
+```
+
+It intentionally separates contribution authoring from host inspection. The host still exposes a read-only-style registry view to engine integrations, while plugins should use `contribute()` for new extension families.
+
+### `AnimationEasingDefinition.easing(label)`
+
+Creates a fluent easing definition builder. The label is required and is displayed in authoring tools.
+
+```java
+easing("Elastic Pop")
+```
+
+### Metadata
+
+Metadata travels with the evaluator:
+
+| Builder method | Meaning | Current consumer |
+|---|---|---|
+| `description(text)` | Short explanation of the motion | Editor search and future detail surfaces |
+| `category(name)` | Author-facing grouping | Puppeteer easing catalog |
+| `documentation(url)` | Stable external guide | Public contract; reserved for richer editor help |
+| `parameter(...)` | Named numeric control and range | Parser validation, default resolution, future controls |
+| `evaluate(function)` | Completes the definition | Runtime and preview evaluation |
+
+Metadata must describe behavior, not implementation. Prefer “Quick overshoot with a soft settle” over “Calls cosine after exponentiation.”
+
+### Parameters
+
+The compact overload declares a name, default, and allowed range:
+
+```java
+.parameter("overshoot", 1.2, range(0.0, 3.0))
+```
+
+The full overload adds a display label and description:
+
+```java
+.parameter(
+    "overshoot",
+    "Overshoot",
+    "Strength of the first pass beyond the destination.",
+    1.2,
+    range(0.0, 3.0))
+```
+
+Parameter names are normalized to lowercase snake case. Hyphens are normalized to underscores. Defaults and range endpoints must be finite, the minimum cannot exceed the maximum, and the default must fall inside the range.
+
+All parameters have defaults. This guarantees that a bare extension ID remains a complete easing specification and gives editor discovery a usable preview curve.
+
+### Evaluation frame
+
+`AnimationEasingFrame` exposes:
+
+| Member | Contract |
+|---|---|
+| `progress()` | Input clamped to `[0, 1]` |
+| `parameters()` | Immutable map containing every declared parameter after defaults and overrides are resolved |
+| `parameter(name)` | Convenient lookup that throws for an undeclared name |
+
+The evaluator may return values outside `[0, 1]`. Overshoot and anticipation curves depend on that behavior. It must return a finite number; a non-finite result falls back to linear progress for that evaluation.
+
+Keep evaluation deterministic, fast, non-blocking, and free of observable side effects. It runs frequently on render/update paths and may run many times while the editor draws a preview curve.
+
+Do not perform file access, network access, logging per frame, random-number generation, scene mutation, or allocation-heavy work inside the evaluator.
+
+## IDs And Namespacing
+
+Extension IDs are case-normalized and must be stable. Use at least two dot-separated segments:
+
+```text
+studio.elastic-pop
+studio.motion.elastic-pop
+com.example.motion.elastic-pop
+```
+
+The parser recognizes a dot-qualified ID as an extension reference. Built-in easing tokens remain unqualified, such as `linear`, `spring(...)`, and `ease_out_cubic`.
+
+Good IDs describe a durable motion concept:
+
+```text
+acme.hero-arrival
+acme.ui-soft-settle
+acme.camera-drift
+```
+
+Avoid IDs tied to an implementation revision or one scene:
+
+```text
+curve-v2
+scene-14-fix
+test
+```
+
+Changing an ID breaks timeline source that refers to it. Treat IDs and parameter names as a project API.
+
+## DSL Grammar
+
+The extension form is:
+
+```text
+<qualified-id>
+<qualified-id>(<name>: <number>, ...)
+```
+
+Equivalent argument separators:
+
+```jes
+easing: "studio.elastic-pop(overshoot: 1.4)"
+easing: "studio.elastic-pop(overshoot=1.4)"
+```
+
+Canonical formatting uses a colon and preserves the resolved parameter set:
+
+```text
+studio.elastic-pop(overshoot: 1.4, settle: 0.7)
+```
+
+Values are numeric literals. Expressions, strings, booleans, positional arguments, nested calls, and arithmetic are not part of the 1.1 contract.
+
+### Default resolution
+
+Given:
+
+```java
+.parameter("overshoot", 1.2, range(0.0, 3.0))
+.parameter("settle", 0.7, range(0.1, 2.0))
+```
+
+This source:
+
+```jes
+easing: "studio.elastic-pop(overshoot: 1.4)"
+```
+
+evaluates with:
+
+```text
+overshoot = 1.4
+settle    = 0.7
+```
+
+Defaults are resolved while the easing specification is parsed. The resulting `EasingSpec` retains the extension ID and resolved named values through `TimelineData`, editor import, preview, and playback.
+
+## Where Extensions Work
+
+### Puppeteer-authored timelines
+
+Plugin easings appear in the Puppeteer easing catalog after the editor loads the project plugin host. The catalog uses the contributed label and category and indexes the ID, description, and DSL form for search.
+
+Selecting an extension applies its default specification. Parameterized values can be entered through the easing specification text field. Dedicated generated parameter controls are not part of the initial 1.1 editor slice.
+
+### Hand-authored JES timelines
+
+Every timeline action that already accepts an easing specification can use a contributed ID. This includes entity transforms, generic property channels, and camera actions handled by the shared timeline parser.
+
+### JES scene actions
+
+The JES scene runtime uses the same `EasingSpec` parser and evaluator. Contributed easings therefore work in action paths that already resolve their easing through that shared contract.
+
+### VNS
+
+VNS can use contributed easing curves through named Puppeteer/JES timelines:
+
+```vns
+[call jes_timeline hero_arrival]
+```
+
+If `hero_arrival` contains `easing: "studio.elastic-pop(...)"`, runtime playback resolves the installed plugin evaluator. The specialized easing tokens on individual legacy VNS movement commands still use their existing built-in enum contract in 1.1; they do not directly accept plugin IDs yet.
+
+### Java engine code
+
+Engine modules parse a script-facing specification with `EasingSpec.tryParse(...)` and evaluate it with `Easing.apply(...)`. Plugin projects should not depend on `core` merely to call their own evaluator; test the dependency-light `AnimationEasing` directly instead.
+
+## Validation And Diagnostics
+
+Validation happens at several layers.
+
+### Plugin loading
+
+Initialization fails with a plugin diagnostic when:
+
+- the manifest omits `animation.easing` but the plugin accesses animation contributions;
+- another extension already owns the same normalized ID;
+- the definition or label is null;
+- parameter metadata contains null or duplicate names;
+- builder validation rejects a malformed range or default;
+- the plugin requires an incompatible Plugin API version.
+
+Because registrations are owned, any earlier registrations made by that plugin are removed when initialization fails.
+
+### Script parsing
+
+An easing specification is rejected when:
+
+- the qualified ID is not installed;
+- an argument is unknown or repeated;
+- an argument is missing `:` or `=`;
+- a value is not numeric or finite;
+- a value falls outside its declared range.
+
+Timeline diagnostics report the easing value as invalid through the existing easing diagnostic path. The parser does not silently bind an unknown qualified ID to a built-in curve.
+
+### Evaluation
+
+The evaluator is isolated at the narrow function boundary. If it throws or returns a non-finite value, JVN uses the input progress for that sample. This protects playback and previews from a single bad frame calculation.
+
+This fallback is not a substitute for plugin tests. Repeated evaluator failures are not currently promoted to a per-frame plugin diagnostic because doing so could flood logs and damage frame pacing.
+
+## Lifecycle And Ownership
+
+The animation easing registry follows the normal plugin ownership rules:
+
+1. The plugin declares `animation.easing`.
+2. `initialize` registers the definition.
+3. The editor or runtime exposes the live host registry to animation parsing and evaluation.
+4. The extension remains available while its plugin is active.
+5. Failure or shutdown removes every easing owned by that plugin.
+
+An already-parsed `EasingSpec` retains its ID and parameters, not a strong reference to plugin code. If the plugin disappears before evaluation, the curve falls back to linear progress. Newly parsed source rejects the now-unknown ID.
+
+This distinction makes project reload and plugin shutdown deterministic while avoiding stale evaluator instances.
+
+## Editor Reload Behavior
+
+The editor rebuilds its plugin host when a project opens. Project-local plugins are discovered from `<project>/plugins/`; user plugins are discovered from the normal user plugin location.
+
+After replacing a plugin JAR:
+
+1. reopen the project or restart the editor;
+2. reopen Puppeteer so its catalog is rebuilt from the current registry;
+3. verify the contributed category and label appear;
+4. import or preview a timeline that uses the qualified ID.
+
+This release does not watch plugin JARs continuously or unload arbitrary classes while an editor window is using them.
+
+## Testing An Easing Plugin
+
+Test the evaluator as a pure function first:
+
+```java
+AnimationEasing easing = createElasticPop();
+double value = easing.evaluate(new AnimationEasingFrame(
+    0.5,
+    Map.of("overshoot", 1.2, "settle", 0.7)));
+```
+
+Then test these contract points:
+
+- `progress = 0` and `progress = 1`;
+- at least three intermediate samples;
+- every parameter at its minimum, default, and maximum;
+- intentional overshoot or anticipation extrema;
+- finite output for the complete supported range;
+- deterministic output for repeated frames;
+- registration with and without the manifest capability;
+- duplicate IDs and duplicate parameter names;
+- DSL parsing with defaults and overrides;
+- unknown and out-of-range arguments;
+- cleanup after plugin shutdown;
+- Puppeteer catalog discovery;
+- runtime playback of an exported timeline.
+
+Sample curves before release. A small discontinuity that is hard to notice numerically can be very visible in camera motion.
+
+## Performance Guidance
+
+An easing evaluator sits on a hot path. Prefer basic arithmetic and `Math` functions. Capture immutable constants in the evaluator closure and precompute anything independent of `frame.progress()`.
+
+Good:
+
+```java
+double angularFrequency = Math.PI * 2.0;
+
+.evaluate(frame -> {
+  double t = frame.progress();
+  return 1.0 - Math.exp(-6.0 * t) * Math.cos(angularFrequency * t);
+})
+```
+
+Avoid:
+
+```java
+.evaluate(frame -> {
+  Files.readString(configPath);       // blocking I/O
+  context.logger().info("{}", frame); // per-frame logging
+  return new Random().nextDouble();    // nondeterministic and allocates
+})
+```
+
+The host supplies an immutable parameter map for safety. Evaluators should read from it, not copy or transform it on every sample.
+
+## Compatibility Rules
+
+Animation easing extensions require Plugin API 1.1. Use:
+
+```json
+"jvnApi": ">=1.1.0 <2.0.0"
+```
+
+Adding optional metadata or new host consumers is compatible within API 1.x. Removing a parameter, renaming an ID, narrowing an accepted range, or changing the mathematical meaning of an existing parameter can break project content even when Java binary compatibility is preserved.
+
+For a significant behavioral redesign, register a new ID and keep the old curve available through a deprecation window.
+
+## Current Limitations
+
+Plugin API 1.1 deliberately stops at a complete, narrow curve contract:
+
+- only numeric easing parameters are supported;
+- editor catalog selection starts from defaults; generated parameter controls are not yet available;
+- legacy per-command VNS easing enums do not accept extension IDs directly;
+- evaluator failures fall back safely but do not emit per-frame diagnostics;
+- plugin JAR hot replacement still requires project reopen or restart;
+- extension documentation URLs are metadata but do not yet produce an editor help button;
+- transitions, timeline actions, constraints, and procedural motion are not yet public contribution families;
+- there is one active editor/runtime easing registry view per application process.
+
+These boundaries keep the first API deterministic and portable. Future animation families should reuse the same ownership, metadata, validation, discovery, and DSL principles rather than introducing parallel plugin mechanisms.
+
+## Related Documentation
+
+- [Plugin authoring](authoring.md)
+- [Extension-point reference](extension-points.md)
+- [Plugin manifest reference](manifest.md)
+- [Plugin API reference](api-reference.md)
+- [Compatibility and security](compatibility-security.md)
+- [Puppeteer JES Timeline DSL](../editor/puppeteer/puppeteer-jes-dsl.md)
+- [Puppeteer Motifs](../editor/puppeteer/puppeteer-motifs.md)

--- a/docs/plugins/api-reference.md
+++ b/docs/plugins/api-reference.md
@@ -1,6 +1,6 @@
 # Plugin API reference
 
-This page defines the behavioral contract of Plugin API `1.0.0`. The generated Javadocs provide member-level details; this reference explains how the types work together.
+This page defines the behavioral contract of Plugin API `1.1.0`. The generated Javadocs provide member-level details; this reference explains how the types work together.
 
 ## Package map
 
@@ -11,6 +11,7 @@ This page defines the behavioral contract of Plugin API `1.0.0`. The generated J
 | `com.jvn.plugin.api.editor` | Editor actions without an `EditorApp` dependency |
 | `com.jvn.plugin.api.asset` | Explicit asset import requests and outcomes |
 | `com.jvn.plugin.api.runtime` | Runtime lifecycle events |
+| `com.jvn.plugin.api.animation` | Metadata-rich animation easing contributions |
 
 Only packages under `com.jvn.plugin.api` form the compatibility contract. `com.jvn.plugin.runtime` is a host implementation and is intended for application embedding and tests, not ordinary plugin logic.
 
@@ -95,6 +96,12 @@ Thread assignments beyond those documented are not compatibility guarantees. Plu
 Plugins may throw checked or runtime exceptions from lifecycle and callback methods. The host converts these into diagnostics and continues where safe. Expected user errors should still be returned as extension-specific diagnostics when the result type supports them; exceptions are for operations that cannot complete.
 
 Never catch `Throwable` in plugin code. The host does so only at the isolation boundary to prevent one extension from terminating the product.
+
+## Contribution API
+
+`PluginContext.contribute()` is the author-focused entry point for metadata-rich extension families. In 1.1, `PluginContributions.animations()` exposes `AnimationContributions.easing(id, definition)`.
+
+`AnimationEasingDefinition` builds immutable easing definitions. `AnimationParameter` describes validated numeric inputs, and `AnimationEasingFrame` supplies clamped progress plus resolved parameter values to the evaluator. See [Animation Easing Extensions](animation-extensions.md) for the full behavioral contract.
 
 ## Generating Javadocs
 

--- a/docs/plugins/authoring.md
+++ b/docs/plugins/authoring.md
@@ -83,3 +83,17 @@ Returned variable updates are copied into VNS state.
 Keep plugin business logic independent from JavaFX. Unit-test handlers directly, then test host behavior using `PluginHost` with a `BundledPluginProvider`. Verify manifests, capabilities, configuration defaults, lifecycle cleanup, malformed arguments, and resources released from `stop()`.
 
 The repository tests in `modules/plugin-runtime/src/test` demonstrate dependency ordering, cleanup, capability enforcement, and failure isolation.
+
+## Add an animation easing
+
+Plugin API 1.1 adds the fluent contribution surface:
+
+```java
+context.contribute().animations().easing("greeter.friendly-pop",
+    AnimationEasingDefinition.easing("Friendly Pop")
+        .parameter("strength", 1.0, AnimationEasingDefinition.range(0.0, 2.0))
+        .evaluate(frame -> frame.progress()
+            + Math.sin(frame.progress() * Math.PI) * frame.parameter("strength") * 0.15));
+```
+
+Add `animation.easing` to the manifest capabilities and set `jvnApi` to `>=1.1.0 <2.0.0`. See [Animation Easing Extensions](animation-extensions.md) for metadata, parameter validation, timeline syntax, editor discovery, testing, and performance rules.

--- a/docs/plugins/extension-points.md
+++ b/docs/plugins/extension-points.md
@@ -2,6 +2,16 @@
 
 All registries use a unique string ID and return a `Registration` handle. The host also tracks ownership and removes every registration when a plugin fails or stops.
 
+New author-focused extension families use `context.contribute()`. Existing low-level registries remain available for their established contracts.
+
+## Animation easing curves
+
+`context.contribute().animations().easing(...)` registers a named easing function with labels, descriptions, categories, documentation, and validated numeric parameters. The `animation.easing` manifest capability is required.
+
+Contributed curves are available through shared timeline parsing and evaluation, including Puppeteer imports, editor previews, JES timelines, and timelines invoked from VNS. The evaluator receives only normalized progress and resolved parameters; it does not receive engine or editor internals.
+
+See [Animation Easing Extensions](animation-extensions.md) for the complete authoring API, DSL grammar, lifecycle, validation, testing guidance, and limitations.
+
 ## Script commands
 
 `ScriptCommand` receives the source language, registered command ID, parsed arguments, current variables, and project directory. It returns whether it handled the call, an optional value, and variable updates.

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -42,5 +42,6 @@ Supported ranges are exact versions, `*`, `1.x`, `1.2.x`, caret ranges such as `
 | `editor.tool` | Editor Tools menu actions |
 | `asset.importer` | Asset importers |
 | `runtime.listener` | Runtime lifecycle listeners |
+| `animation.easing` | Named easing curves and their authoring metadata |
 
 Unknown capabilities, malformed JSON, missing required fields, duplicate plugin IDs, incompatible API ranges, and invalid dependencies prevent loading. Diagnostics include a stable code suitable for tooling.

--- a/docs/scripting/ui/facets.md
+++ b/docs/scripting/ui/facets.md
@@ -13,6 +13,8 @@ Use a Facet when a normal menu row list or a single-title/single-body reactive s
 
 Facets extend JVN's existing overlay-screen lifecycle. They do not introduce another screen stack, input router, or action language. The established `[screen show]` and `[screen call]` commands, modal behavior, timers, buttons, localization, conditions, and return values all continue to apply.
 
+For a workflow that combines reactive UI with reusable scene animation, see [Reusable Authoring With Facets And Motifs](../../guides/facets-and-motifs.md). Motifs can coordinate motion around a Facet, but the current Facet contract does not animate individual nodes.
+
 Implementation:
 
 - model: `modules/core/src/main/java/com/jvn/core/vn/ui/VnFacetSpec.java`

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
 org.gradle.caching=true
 org.gradle.parallel=true
-jvnVersion=0.3.1
+jvnVersion=0.4.0
 # Optional: set jvnBuildDir in this file or pass -PjvnBuildDir=<dir> to relocate workspace build outputs.
 # Default Java version used by toolchains (can be overridden per module)
 javaVersion=21

--- a/modules/core/build.gradle.kts
+++ b/modules/core/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 }
 
 dependencies {
+  api(project(":plugin-api"))
   api("org.slf4j:slf4j-api:2.0.13")
   api("org.jspecify:jspecify:1.0.0")
 

--- a/modules/core/src/main/java/com/jvn/core/animation/Easing.java
+++ b/modules/core/src/main/java/com/jvn/core/animation/Easing.java
@@ -39,6 +39,10 @@ public class Easing {
 
   public static double apply(EasingSpec spec, double t) {
     EasingSpec resolved = spec != null ? spec : EasingSpec.of(Type.LINEAR);
+    if (resolved.isExtension()) {
+      t = Math.max(0, Math.min(1, t));
+      return EasingExtensions.apply(resolved.getExtensionId(), resolved.getNamedParameters(), t);
+    }
     return apply(resolved.getType(), resolved.getParameters(), t);
   }
 
@@ -187,6 +191,11 @@ public class Easing {
 
   public static double applyInterpolation(EasingSpec spec, Interpolation interpolation, double t) {
     EasingSpec resolved = spec != null ? spec : EasingSpec.of(Type.LINEAR);
+    t = Math.max(0, Math.min(1, t));
+    Interpolation mode = interpolation != null ? interpolation : Interpolation.TWEEN;
+    if (mode == Interpolation.HOLD) return t >= 1.0 ? 1.0 : 0.0;
+    if (mode == Interpolation.STEP) return t <= 0.0 ? 0.0 : 1.0;
+    if (resolved.isExtension()) return apply(resolved, t);
     return applyInterpolation(resolved.getType(), interpolation, resolved.getParameters(), t);
   }
 
@@ -323,6 +332,20 @@ public class Easing {
 
   public static String formatSpec(EasingSpec spec) {
     EasingSpec resolved = spec != null ? spec : EasingSpec.of(Type.LINEAR);
+    if (resolved.isExtension()) {
+      StringBuilder value = new StringBuilder(resolved.getExtensionId());
+      if (!resolved.getNamedParameters().isEmpty()) {
+        value.append('(');
+        boolean first = true;
+        for (var entry : resolved.getNamedParameters().entrySet()) {
+          if (!first) value.append(", ");
+          first = false;
+          value.append(entry.getKey()).append(": ").append(formatNumber(entry.getValue()));
+        }
+        value.append(')');
+      }
+      return value.toString();
+    }
     Type type = resolved.getType();
     double[] params = coerceParameters(type, resolved.getParameters());
     return switch (type) {

--- a/modules/core/src/main/java/com/jvn/core/animation/EasingExtensions.java
+++ b/modules/core/src/main/java/com/jvn/core/animation/EasingExtensions.java
@@ -1,0 +1,73 @@
+package com.jvn.core.animation;
+
+import com.jvn.plugin.api.ExtensionEntry;
+import com.jvn.plugin.api.ExtensionRegistry;
+import com.jvn.plugin.api.animation.AnimationEasing;
+import com.jvn.plugin.api.animation.AnimationEasingFrame;
+import com.jvn.plugin.api.animation.AnimationParameter;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+/** Bridge between dependency-light plugin easing contracts and core animation evaluation. */
+public final class EasingExtensions {
+  private static volatile ExtensionRegistry<AnimationEasing> registry;
+
+  private EasingExtensions() {}
+
+  /** Installs the live host view used by parsers, previews, and runtime playback. */
+  public static void install(ExtensionRegistry<AnimationEasing> extensions) {
+    registry = extensions;
+  }
+
+  /** Removes a previously installed host view. Primarily useful for isolated tests. */
+  public static void clear() { registry = null; }
+
+  public static Optional<AnimationEasing> find(String id) {
+    ExtensionRegistry<AnimationEasing> current = registry;
+    if (current == null || id == null || id.isBlank()) return Optional.empty();
+    return current.find(normalizeId(id));
+  }
+
+  public static List<ExtensionEntry<AnimationEasing>> entries() {
+    ExtensionRegistry<AnimationEasing> current = registry;
+    return current == null ? List.of() : current.entries();
+  }
+
+  static Map<String, Double> resolveParameters(AnimationEasing easing, Map<String, Double> supplied) {
+    LinkedHashMap<String, Double> resolved = new LinkedHashMap<>();
+    for (AnimationParameter parameter : easing.parameters()) {
+      double value = supplied != null && supplied.containsKey(parameter.name())
+          ? supplied.get(parameter.name()) : parameter.defaultValue();
+      if (!Double.isFinite(value) || value < parameter.minimum() || value > parameter.maximum()) {
+        throw new IllegalArgumentException("Parameter '" + parameter.name() + "' must be between "
+            + parameter.minimum() + " and " + parameter.maximum());
+      }
+      resolved.put(parameter.name(), value);
+    }
+    if (supplied != null) {
+      for (String name : supplied.keySet()) {
+        if (!resolved.containsKey(name)) throw new IllegalArgumentException("Unknown easing parameter: " + name);
+      }
+    }
+    return Map.copyOf(resolved);
+  }
+
+  static double apply(String id, Map<String, Double> supplied, double progress) {
+    AnimationEasing easing = find(id).orElse(null);
+    if (easing == null) return progress;
+    try {
+      double value = easing.evaluate(new AnimationEasingFrame(
+          progress, resolveParameters(easing, supplied)));
+      return Double.isFinite(value) ? value : progress;
+    } catch (RuntimeException ignored) {
+      return progress;
+    }
+  }
+
+  static String normalizeId(String id) {
+    return id.trim().toLowerCase(Locale.ROOT);
+  }
+}

--- a/modules/core/src/main/java/com/jvn/core/animation/EasingSpec.java
+++ b/modules/core/src/main/java/com/jvn/core/animation/EasingSpec.java
@@ -1,86 +1,90 @@
 package com.jvn.core.animation;
 
+import com.jvn.plugin.api.animation.AnimationEasing;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Collections;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-/**
- * Immutable easing descriptor that carries an easing type and any optional
- * parameter payload required to evaluate it.
- */
+/** Immutable descriptor for either a built-in or contributed easing curve. */
 public final class EasingSpec {
   private static final Pattern FUNCTION_PATTERN =
-      Pattern.compile("^([a-zA-Z_][\\w-]*)\\s*\\((.*)\\)$");
+      Pattern.compile("^([a-zA-Z_][\\w.-]*)\\s*\\((.*)\\)$");
+  private static final Pattern EXTENSION_ID =
+      Pattern.compile("^[a-zA-Z_][a-zA-Z0-9_-]*(?:\\.[a-zA-Z_][a-zA-Z0-9_-]*)+$");
 
   private final Easing.Type type;
   private final double[] parameters;
+  private final String extensionId;
+  private final Map<String, Double> namedParameters;
 
-  private EasingSpec(Easing.Type type, double[] parameters) {
+  private EasingSpec(Easing.Type type, double[] parameters, String extensionId,
+                     Map<String, Double> namedParameters) {
     this.type = type != null ? type : Easing.Type.LINEAR;
     this.parameters = parameters != null ? Arrays.copyOf(parameters, parameters.length) : null;
+    this.extensionId = extensionId;
+    this.namedParameters = namedParameters == null ? Map.of()
+        : Collections.unmodifiableMap(new LinkedHashMap<>(namedParameters));
   }
 
   public static EasingSpec of(Easing.Type type) {
-    return new EasingSpec(type, Easing.coerceParameters(type, null));
+    return new EasingSpec(type, Easing.coerceParameters(type, null), null, null);
   }
 
   public static EasingSpec of(Easing.Type type, double[] parameters) {
-    return new EasingSpec(type, Easing.coerceParameters(type, parameters));
+    return new EasingSpec(type, Easing.coerceParameters(type, parameters), null, null);
+  }
+
+  public static EasingSpec extension(String id, Map<String, Double> parameters) {
+    String normalized = EasingExtensions.normalizeId(id);
+    AnimationEasing easing = EasingExtensions.find(normalized)
+        .orElseThrow(() -> new IllegalArgumentException("Unknown easing extension: " + id));
+    Map<String, Double> resolved = EasingExtensions.resolveParameters(easing, normalizeNames(parameters));
+    return new EasingSpec(Easing.Type.LINEAR, null, normalized, resolved);
   }
 
   public static EasingSpec cubicBezier(double cx1, double cy1, double cx2, double cy2) {
     return of(Easing.Type.CUSTOM, new double[]{cx1, cy1, cx2, cy2});
   }
-
-  public static EasingSpec curve(double... points) {
-    return of(Easing.Type.CURVE, points);
-  }
-
+  public static EasingSpec curve(double... points) { return of(Easing.Type.CURVE, points); }
   public static EasingSpec spring(double stiffness, double damping, double mass, double velocity) {
     return of(Easing.Type.SPRING, new double[]{stiffness, damping, mass, velocity});
   }
-
-  public static EasingSpec dampedSpring(
-      double frequency,
-      double dampingRatio,
-      double response,
-      double velocity
-  ) {
-    return of(Easing.Type.DAMPED_SPRING,
-        new double[]{frequency, dampingRatio, response, velocity});
+  public static EasingSpec dampedSpring(double frequency, double dampingRatio, double response, double velocity) {
+    return of(Easing.Type.DAMPED_SPRING, new double[]{frequency, dampingRatio, response, velocity});
   }
 
   public static EasingSpec tryParse(String raw) {
     if (raw == null || raw.isBlank()) return of(Easing.Type.LINEAR);
-
-    String value = raw.trim();
+    String value = stripQuotes(raw.trim());
     Matcher matcher = FUNCTION_PATTERN.matcher(value);
     if (matcher.matches()) {
-      String function = matcher.group(1).trim().toLowerCase(Locale.ROOT).replace('-', '_');
+      String function = matcher.group(1).trim();
+      String builtIn = function.toLowerCase(Locale.ROOT).replace('-', '_');
+      if (EXTENSION_ID.matcher(function).matches()) {
+        try { return extension(function, parseNamedArguments(matcher.group(2))); }
+        catch (IllegalArgumentException ignored) { return null; }
+      }
       double[] args = parseArguments(matcher.group(2));
       if (args == null) return null;
-      return switch (function) {
-        case "cubic_bezier" -> args.length == 4
-            ? cubicBezier(args[0], args[1], args[2], args[3])
-            : null;
-        case "curve" -> args.length >= 2 && args.length % 2 == 0
-            ? curve(args)
-            : null;
+      return switch (builtIn) {
+        case "cubic_bezier" -> args.length == 4 ? cubicBezier(args[0], args[1], args[2], args[3]) : null;
+        case "curve" -> args.length >= 2 && args.length % 2 == 0 ? curve(args) : null;
         case "spring" -> of(Easing.Type.SPRING, args);
         case "damped_spring" -> of(Easing.Type.DAMPED_SPRING, args);
         default -> null;
       };
     }
-
-    String normalized = normalizeTypeToken(value);
-    try {
-      return of(Easing.Type.valueOf(normalized));
-    } catch (Exception ignored) {
-      // reason: unrecognized enum name from script; caller uses null to signal parse failure
-      return null;
+    if (EXTENSION_ID.matcher(value).matches()) {
+      try { return extension(value, Map.of()); }
+      catch (IllegalArgumentException ignored) { return null; }
     }
+    try { return of(Easing.Type.valueOf(normalizeTypeToken(value))); }
+    catch (Exception ignored) { return null; }
   }
 
   public static EasingSpec parseOrDefault(String raw) {
@@ -88,43 +92,25 @@ public final class EasingSpec {
     return parsed != null ? parsed : of(Easing.Type.LINEAR);
   }
 
-  public Easing.Type getType() {
-    return type;
-  }
+  public Easing.Type getType() { return type; }
+  public boolean isExtension() { return extensionId != null; }
+  public String getExtensionId() { return extensionId; }
+  public Map<String, Double> getNamedParameters() { return namedParameters; }
+  public boolean hasParameters() { return isExtension() ? !namedParameters.isEmpty() : parameters != null && parameters.length > 0; }
+  public double[] getParameters() { return parameters != null ? Arrays.copyOf(parameters, parameters.length) : null; }
+  public String toDslString() { return Easing.formatSpec(this); }
+  @Override public String toString() { return toDslString(); }
 
-  public boolean hasParameters() {
-    return parameters != null && parameters.length > 0;
-  }
-
-  public double[] getParameters() {
-    return hasParameters() ? Arrays.copyOf(parameters, parameters.length) : null;
-  }
-
-  public String toDslString() {
-    return Easing.formatSpec(this);
-  }
-
-  @Override
-  public String toString() {
-    return toDslString();
-  }
-
-  @Override
-  public boolean equals(Object obj) {
+  @Override public boolean equals(Object obj) {
     if (this == obj) return true;
     if (!(obj instanceof EasingSpec other)) return false;
-    return type == other.type && Arrays.equals(parameters, other.parameters);
+    return type == other.type && Arrays.equals(parameters, other.parameters)
+        && Objects.equals(extensionId, other.extensionId) && namedParameters.equals(other.namedParameters);
   }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(type, Arrays.hashCode(parameters));
-  }
+  @Override public int hashCode() { return Objects.hash(type, Arrays.hashCode(parameters), extensionId, namedParameters); }
 
   private static String normalizeTypeToken(String token) {
-    String normalized = camelToSnake(token == null ? "" : token.trim())
-        .toUpperCase(Locale.ROOT)
-        .replace('-', '_');
+    String normalized = camelToSnake(token == null ? "" : token.trim()).toUpperCase(Locale.ROOT).replace('-', '_');
     if ("EASE_IN".equals(normalized)) return "EASE_IN_QUAD";
     if ("EASE_OUT".equals(normalized)) return "EASE_OUT_QUAD";
     if ("EASE_IN_OUT".equals(normalized)) return "EASE_IN_OUT_QUAD";
@@ -132,7 +118,6 @@ public final class EasingSpec {
   }
 
   private static String camelToSnake(String token) {
-    if (token == null || token.isBlank()) return "";
     StringBuilder out = new StringBuilder(token.length() + 8);
     for (int i = 0; i < token.length(); i++) {
       char c = token.charAt(i);
@@ -146,20 +131,39 @@ public final class EasingSpec {
   }
 
   private static double[] parseArguments(String raw) {
-    if (raw == null) return new double[0];
-    String trimmed = raw.trim();
-    if (trimmed.isEmpty()) return new double[0];
-
-    String[] parts = trimmed.split(",");
+    if (raw == null || raw.trim().isEmpty()) return new double[0];
+    String[] parts = raw.split(",");
     double[] values = new double[parts.length];
     for (int i = 0; i < parts.length; i++) {
-      try {
-        values[i] = Double.parseDouble(parts[i].trim());
-      } catch (Exception ignored) {
-        // reason: malformed numeric argument in script easing string; null signals parse failure
-        return null;
-      }
+      try { values[i] = Double.parseDouble(parts[i].trim()); }
+      catch (Exception ignored) { return null; }
     }
     return values;
+  }
+
+  private static Map<String, Double> parseNamedArguments(String raw) {
+    if (raw == null || raw.isBlank()) return Map.of();
+    LinkedHashMap<String, Double> values = new LinkedHashMap<>();
+    for (String part : raw.split(",")) {
+      String[] pair = part.trim().split("\\s*[:=]\\s*", 2);
+      if (pair.length != 2 || pair[0].isBlank()) throw new IllegalArgumentException("Expected name: value");
+      String name = pair[0].trim().toLowerCase(Locale.ROOT).replace('-', '_');
+      if (values.containsKey(name)) throw new IllegalArgumentException("Duplicate easing parameter: " + name);
+      values.put(name, Double.parseDouble(pair[1].trim()));
+    }
+    return values;
+  }
+
+  private static Map<String, Double> normalizeNames(Map<String, Double> parameters) {
+    if (parameters == null || parameters.isEmpty()) return Map.of();
+    LinkedHashMap<String, Double> normalized = new LinkedHashMap<>();
+    parameters.forEach((name, value) -> normalized.put(name.toLowerCase(Locale.ROOT).replace('-', '_'), value));
+    return normalized;
+  }
+
+  private static String stripQuotes(String value) {
+    if (value.length() >= 2 && ((value.startsWith("\"") && value.endsWith("\""))
+        || (value.startsWith("'") && value.endsWith("'")))) return value.substring(1, value.length() - 1);
+    return value;
   }
 }

--- a/modules/core/src/test/java/com/jvn/core/animation/EasingExtensionTest.java
+++ b/modules/core/src/test/java/com/jvn/core/animation/EasingExtensionTest.java
@@ -1,0 +1,83 @@
+package com.jvn.core.animation;
+
+import static com.jvn.plugin.api.animation.AnimationEasingDefinition.easing;
+import static com.jvn.plugin.api.animation.AnimationEasingDefinition.range;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.jvn.plugin.api.ExtensionEntry;
+import com.jvn.plugin.api.ExtensionRegistry;
+import com.jvn.plugin.api.Registration;
+import com.jvn.plugin.api.animation.AnimationEasing;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class EasingExtensionTest {
+  @AfterEach void clear() { EasingExtensions.clear(); }
+
+  @Test
+  void parsesValidatesFormatsAndEvaluatesNamedParameters() {
+    AnimationEasing extension = easing("Elastic Pop")
+        .parameter("overshoot", 1.0, range(0.0, 3.0))
+        .evaluate(frame -> frame.progress() + frame.parameter("overshoot") * 0.1);
+    EasingExtensions.install(registry("studio.elastic-pop", extension));
+
+    EasingSpec spec = EasingSpec.tryParse("studio.elastic-pop(overshoot: 1.4)");
+    assertTrue(spec.isExtension());
+    assertEquals("studio.elastic-pop(overshoot: 1.4)", spec.toDslString());
+    assertEquals(0.64, Easing.apply(spec, 0.5), 0.000001);
+    assertNull(EasingSpec.tryParse("studio.elastic-pop(unknown: 1)"));
+    assertNull(EasingSpec.tryParse("studio.elastic-pop(overshoot: 9)"));
+  }
+
+  @Test
+  void usesMetadataDefaultsAndFallsBackSafelyAfterUninstall() {
+    AnimationEasing extension = easing("Smooth")
+        .parameter("power", 2.0, range(1.0, 4.0))
+        .evaluate(frame -> Math.pow(frame.progress(), frame.parameter("power")));
+    EasingExtensions.install(registry("studio.smooth", extension));
+    EasingSpec spec = EasingSpec.tryParse("studio.smooth");
+    assertEquals(0.25, Easing.apply(spec, 0.5), 0.000001);
+    EasingExtensions.clear();
+    assertEquals(0.5, Easing.apply(spec, 0.5), 0.000001);
+  }
+
+  @Test
+  void survivesTimelineParsingAndDrivesTrackInterpolation() {
+    AnimationEasing extension = easing("Accelerate")
+        .parameter("power", 2.0, range(1.0, 4.0))
+        .evaluate(frame -> Math.pow(frame.progress(), frame.parameter("power")));
+    EasingExtensions.install(registry("studio.accelerate", extension));
+
+    TimelineData data = TimelineDataParser.parse("extension-test", """
+        timeline {
+          move "hero" {
+            x: 100
+            dur: 1000
+            easing: "studio.accelerate(power: 2)"
+          }
+        }
+        """);
+    TimelineData.Track track = data.getTrack("hero");
+    TimelineData.Keyframe end = track.getKeyframes(TimelineData.Property.X).get(1);
+    assertTrue(end.getEasingSpec().isExtension());
+    assertEquals("studio.accelerate", end.getEasingSpec().getExtensionId());
+    assertEquals(25.0, track.getValueAt(TimelineData.Property.X, 500), 0.000001);
+  }
+
+  private static ExtensionRegistry<AnimationEasing> registry(String id, AnimationEasing easing) {
+    ExtensionEntry<AnimationEasing> entry = new ExtensionEntry<>(id, "test", easing);
+    return new ExtensionRegistry<>() {
+      @Override public Registration register(String ignored, AnimationEasing value) {
+        throw new UnsupportedOperationException();
+      }
+      @Override public Optional<AnimationEasing> find(String requested) {
+        return id.equals(requested) ? Optional.of(easing) : Optional.empty();
+      }
+      @Override public List<ExtensionEntry<AnimationEasing>> entries() { return List.of(entry); }
+    };
+  }
+}

--- a/modules/editor/src/main/java/com/jvn/editor/AppBuildInfo.java
+++ b/modules/editor/src/main/java/com/jvn/editor/AppBuildInfo.java
@@ -8,7 +8,7 @@ import java.util.logging.Logger;
 
 public final class AppBuildInfo {
   private static final Logger log = Logger.getLogger(AppBuildInfo.class.getName());
-  private static final String FALLBACK_VERSION = "0.3.1";
+  private static final String FALLBACK_VERSION = "0.4.0";
 
   private AppBuildInfo() {
   }

--- a/modules/editor/src/main/java/com/jvn/editor/EditorApp.java
+++ b/modules/editor/src/main/java/com/jvn/editor/EditorApp.java
@@ -490,6 +490,7 @@ public class EditorApp extends Application {
         .projectDirectory(project == null ? null : project.toPath())
         .build();
     pluginHost.discoverAndStart();
+    com.jvn.core.animation.EasingExtensions.install(pluginHost.registries().animationEasings());
     refreshPluginToolsMenu();
   }
 

--- a/modules/editor/src/main/java/com/jvn/editor/ui/PuppeteerAeroIcon.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/PuppeteerAeroIcon.java
@@ -1,0 +1,195 @@
+package com.jvn.editor.ui;
+
+import javafx.scene.CacheHint;
+import javafx.scene.control.ButtonBase;
+import javafx.scene.effect.DropShadow;
+import javafx.scene.effect.InnerShadow;
+import javafx.scene.layout.Region;
+import javafx.scene.layout.StackPane;
+import javafx.scene.paint.Color;
+import javafx.scene.paint.CycleMethod;
+import javafx.scene.paint.LinearGradient;
+import javafx.scene.paint.Stop;
+import javafx.scene.shape.Circle;
+import javafx.scene.shape.Rectangle;
+
+/** Compact Aero artwork shared by Puppeteer's floating command dockers. */
+public final class PuppeteerAeroIcon extends StackPane {
+  public enum Kind {
+    COPY, PASTE, HISTORY, DUPLICATE, ADD_ALL, SAVE_CLIP, LOAD_CLIP, CHARACTER_SLOT,
+    PREVIOUS, NEXT, FOCUS, ZOOM_FIT, DISTRIBUTE, REVERSE, STRETCH, COMPRESS,
+    RIPPLE, COMPACT_EXPORT,
+    REWIND, PLAY, PAUSE, STOP, UNDO, REDO,
+    FIT_DURATION, LOOP, LOOP_IN, LOOP_OUT, CLEAR,
+    PRESET, SNAP, RUNTIME_PREVIEW, VIEWPORT_STABILIZE, AUTO_KEY,
+    SNAP_GRID, SNAP_ENTITY, ORBIT, ORBIT_ALIGN, HELP,
+    ADD_AUDIO_CUE, ADD_EXPRESSION_CUE, MANAGE_EVENTS,
+    SYNC, REGISTER, RECORD_GIF, COPY_CODE, VERIFY
+  }
+
+  private record Palette(Color light, Color mid, Color dark, Color glow) {}
+
+  private final Kind kind;
+  private final double iconSize;
+
+  private PuppeteerAeroIcon(Kind kind, double requestedSize) {
+    this.kind = kind == null ? Kind.COPY : kind;
+    this.iconSize = Math.max(18, Math.min(28, requestedSize));
+    Palette palette = paletteFor(this.kind);
+
+    Rectangle plate = new Rectangle(iconSize * 0.91, iconSize * 0.91);
+    plate.setArcWidth(iconSize * 0.34);
+    plate.setArcHeight(iconSize * 0.34);
+    plate.setFill(new LinearGradient(0, 0, 0, 1, true, CycleMethod.NO_CYCLE,
+        new Stop(0, palette.light()),
+        new Stop(0.18, palette.mid()),
+        new Stop(0.58, palette.dark()),
+        new Stop(1, palette.dark().deriveColor(0, 0.78, 0.48, 1))));
+    plate.setStroke(Color.rgb(218, 234, 247, 0.76));
+    plate.setStrokeWidth(Math.max(0.75, iconSize * 0.045));
+    plate.setEffect(new InnerShadow(iconSize * 0.16, Color.rgb(1, 7, 13, 0.82)));
+
+    Rectangle highlight = new Rectangle(iconSize * 0.69, iconSize * 0.25);
+    highlight.setArcWidth(iconSize * 0.20);
+    highlight.setArcHeight(iconSize * 0.20);
+    highlight.setTranslateY(-iconSize * 0.23);
+    highlight.setFill(new LinearGradient(0, 0, 1, 0, true, CycleMethod.NO_CYCLE,
+        new Stop(0, Color.rgb(255, 255, 255, 0.13)),
+        new Stop(0.42, Color.rgb(255, 255, 255, 0.48)),
+        new Stop(1, Color.rgb(255, 255, 255, 0.08))));
+    highlight.setMouseTransparent(true);
+
+    Region glyph = glyphFor(this.kind, iconSize * 0.54);
+    glyph.setMouseTransparent(true);
+    glyph.setEffect(new DropShadow(Math.max(1.2, iconSize * 0.08), 0, iconSize * 0.035,
+        Color.rgb(0, 0, 0, 0.92)));
+
+    Circle status = new Circle(iconSize * 0.055, palette.glow().deriveColor(0, 0.75, 1.45, 0.9));
+    status.setTranslateX(iconSize * 0.31);
+    status.setTranslateY(iconSize * 0.31);
+    status.setEffect(new DropShadow(iconSize * 0.13, palette.glow()));
+
+    setMinSize(iconSize, iconSize);
+    setPrefSize(iconSize, iconSize);
+    setMaxSize(iconSize, iconSize);
+    setMouseTransparent(true);
+    setCache(true);
+    setCacheHint(CacheHint.SPEED);
+    getStyleClass().add("puppeteer-aero-icon");
+    getChildren().setAll(plate, highlight, glyph, status);
+    parentProperty().addListener((observable, oldParent, newParent) -> {
+      if (newParent instanceof ButtonBase button) installButtonTreatment(button, palette);
+    });
+  }
+
+  public static PuppeteerAeroIcon of(Kind kind) {
+    return new PuppeteerAeroIcon(kind, 23);
+  }
+
+  public static PuppeteerAeroIcon of(Kind kind, double size) {
+    return new PuppeteerAeroIcon(kind, size);
+  }
+
+  public Kind kind() { return kind; }
+
+  public double iconSize() { return iconSize; }
+
+  private void installButtonTreatment(ButtonBase button, Palette palette) {
+    if (!button.getStyleClass().contains("puppeteer-aero-button")) {
+      button.getStyleClass().add("puppeteer-aero-button");
+    }
+    button.hoverProperty().addListener((obs, before, hovered) -> updateEffect(button, palette));
+    button.pressedProperty().addListener((obs, before, pressed) -> updateEffect(button, palette));
+    updateEffect(button, palette);
+  }
+
+  private void updateEffect(ButtonBase button, Palette palette) {
+    if (button.isPressed()) {
+      setScaleX(0.92);
+      setScaleY(0.92);
+      setEffect(new DropShadow(iconSize * 0.16, palette.glow()));
+    } else if (button.isHover()) {
+      setScaleX(1.07);
+      setScaleY(1.07);
+      setEffect(new DropShadow(iconSize * 0.36, palette.glow()));
+    } else {
+      setScaleX(1);
+      setScaleY(1);
+      setEffect(null);
+    }
+  }
+
+  private static Region glyphFor(Kind kind, double size) {
+    String white = "#f4fbff";
+    Region glyph = switch (kind) {
+      case COPY -> CssIcon.copy(white);
+      case PASTE -> CssIcon.contentPaste(white);
+      case HISTORY -> CssIcon.timeline(white);
+      case DUPLICATE -> CssIcon.controlPointDuplicate(white);
+      case ADD_ALL -> CssIcon.plusBold(white);
+      case SAVE_CLIP -> CssIcon.libraryAdd(white);
+      case LOAD_CLIP -> CssIcon.input(white);
+      case CHARACTER_SLOT -> CssIcon.emojiPeople(white);
+      case PREVIOUS -> CssIcon.fastRewind(white);
+      case NEXT -> CssIcon.fastForward(white);
+      case FOCUS -> CssIcon.myLocation(white);
+      case ZOOM_FIT -> CssIcon.zoomOutMap(white);
+      case DISTRIBUTE -> CssIcon.formatAlignJustify(white);
+      case REVERSE -> CssIcon.swapHoriz(white);
+      case STRETCH -> CssIcon.openInFull(white);
+      case COMPRESS -> CssIcon.closeFullscreen(white);
+      case RIPPLE -> CssIcon.link(white);
+      case COMPACT_EXPORT -> CssIcon.folderZip(white);
+      case REWIND -> CssIcon.skipPrevious(white);
+      case PLAY -> CssIcon.play(white);
+      case PAUSE -> CssIcon.pause(white);
+      case STOP -> CssIcon.stop(white);
+      case UNDO -> CssIcon.undo(white);
+      case REDO -> CssIcon.redo(white);
+      case FIT_DURATION -> CssIcon.rectSelect(white);
+      case LOOP, SYNC -> CssIcon.loop(white);
+      case LOOP_IN -> CssIcon.verticalAlignBottom(white);
+      case LOOP_OUT -> CssIcon.verticalAlignTop(white);
+      case CLEAR -> CssIcon.clearX(white);
+      case PRESET -> CssIcon.folder(white);
+      case SNAP -> CssIcon.grid4x4(white);
+      case RUNTIME_PREVIEW -> CssIcon.movie(white);
+      case VIEWPORT_STABILIZE -> CssIcon.myLocation(white);
+      case AUTO_KEY, RECORD_GIF -> CssIcon.fiberSmartRecord(white);
+      case SNAP_GRID -> CssIcon.borderAll(white);
+      case SNAP_ENTITY -> CssIcon.joinInner(white);
+      case ORBIT -> CssIcon.threeSixty(white);
+      case ORBIT_ALIGN -> CssIcon.explore(white);
+      case HELP -> CssIcon.speech(white);
+      case ADD_AUDIO_CUE -> CssIcon.plusBold(white);
+      case ADD_EXPRESSION_CUE -> CssIcon.theater(white);
+      case MANAGE_EVENTS, VERIFY -> CssIcon.list(white);
+      case REGISTER -> CssIcon.save(white);
+      case COPY_CODE -> CssIcon.copy(white);
+    };
+    double base = Math.max(1, Math.max(glyph.getPrefWidth(), glyph.getPrefHeight()));
+    double scale = size / base;
+    glyph.setScaleX(scale);
+    glyph.setScaleY(scale);
+    return glyph;
+  }
+
+  private static Palette paletteFor(Kind kind) {
+    return switch (kind) {
+      case ADD_ALL, SAVE_CLIP, LOAD_CLIP, PLAY, REGISTER, ADD_AUDIO_CUE, ADD_EXPRESSION_CUE, VERIFY ->
+          palette("#83dca9", "#23875f", "#0d3d31", "#62e2a2");
+      case PREVIOUS, NEXT, FOCUS, ZOOM_FIT, REWIND, UNDO, REDO, SYNC, COPY_CODE,
+          VIEWPORT_STABILIZE -> palette("#91d8ff", "#318ec2", "#123d5c", "#62c8ff");
+      case DISTRIBUTE, REVERSE, STRETCH, COMPRESS -> palette("#c7b7f7", "#715aa8", "#30264f", "#ac8cff");
+      case RIPPLE, COMPACT_EXPORT, PAUSE, LOOP, LOOP_IN, LOOP_OUT, PRESET ->
+          palette("#ffd277", "#bd7621", "#51300f", "#ffc04f");
+      case RUNTIME_PREVIEW, ORBIT, ORBIT_ALIGN -> palette("#d0b3ff", "#7954ad", "#34224f", "#b98cff");
+      case STOP, CLEAR, AUTO_KEY, RECORD_GIF -> palette("#ffaaa5", "#b84747", "#521d22", "#ff716d");
+      default -> palette("#c9d8e5", "#60788d", "#263744", "#a9d7f5");
+    };
+  }
+
+  private static Palette palette(String light, String mid, String dark, String glow) {
+    return new Palette(Color.web(light), Color.web(mid), Color.web(dark), Color.web(glow));
+  }
+}

--- a/modules/editor/src/main/java/com/jvn/editor/ui/actioneditor/PuppeteerEasingCatalog.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/actioneditor/PuppeteerEasingCatalog.java
@@ -7,12 +7,14 @@ import java.util.Locale;
 
 import com.jvn.core.animation.Easing;
 import com.jvn.core.animation.EasingSpec;
+import com.jvn.core.animation.EasingExtensions;
 
 final class PuppeteerEasingCatalog {
 
     enum Source {
         BUILTIN,
-        PRESET
+        PRESET,
+        PLUGIN
     }
 
     record Entry(
@@ -27,8 +29,12 @@ final class PuppeteerEasingCatalog {
             return source == Source.PRESET;
         }
 
+        boolean isPlugin() {
+            return source == Source.PLUGIN;
+        }
+
         String badge() {
-            return isPreset() ? "Preset" : group;
+            return isPreset() ? "Preset" : isPlugin() ? "Plugin" : group;
         }
 
         boolean matches(String query) {
@@ -49,6 +55,19 @@ final class PuppeteerEasingCatalog {
                 Source.BUILTIN,
                 option.defaultSpec(),
                 buildSearchText(option.label(), option.group(), option.defaultSpec(), false)));
+        }
+        for (var extension : EasingExtensions.entries()) {
+            var easing = extension.extension();
+            EasingSpec spec = EasingSpec.extension(extension.id(), java.util.Map.of());
+            entries.add(new Entry(
+                "plugin:" + extension.id(),
+                easing.label(),
+                easing.category(),
+                Source.PLUGIN,
+                spec,
+                String.join(" ", easing.label(), easing.description(), easing.category(),
+                    extension.id(), spec.toDslString(), "plugin extension")
+                    .toLowerCase(Locale.ROOT)));
         }
         if (presets != null && !presets.isEmpty()) {
             List<PuppeteerEasingPresetStore.Preset> sorted = new ArrayList<>(presets);
@@ -88,7 +107,8 @@ final class PuppeteerEasingCatalog {
             if (entry.spec().equals(resolved)) return entry;
         }
         for (Entry entry : entries) {
-            if (!entry.isPreset() && entry.spec().getType() == resolved.getType()) return entry;
+            if (!entry.isPreset() && !entry.isPlugin()
+                && !resolved.isExtension() && entry.spec().getType() == resolved.getType()) return entry;
         }
         return entries.get(0);
     }

--- a/modules/editor/src/main/java/com/jvn/editor/ui/actioneditor/PuppeteerWindow.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/actioneditor/PuppeteerWindow.java
@@ -931,12 +931,12 @@ public class PuppeteerWindow extends Stage {
         });
 
         // --- Transport controls ---
-        btnRewind = makeToolbarIconButton(com.jvn.editor.ui.CssIcon.skipPrevious("#7ab3e0"), "Rewind (Home)");
-        btnPlay = makeToolbarIconButton(com.jvn.editor.ui.CssIcon.play("#57c464"), "Play (Space)");
-        btnPause = makeToolbarIconButton(com.jvn.editor.ui.CssIcon.pause("#f0c030"), "Pause (Space)");
-        btnStop = makeToolbarIconButton(com.jvn.editor.ui.CssIcon.stop("#e05050"), "Stop");
-        btnUndo = makeToolbarIconButton(com.jvn.editor.ui.CssIcon.undo("#7ab3e0"), "Undo (Ctrl/Cmd+Z)");
-        btnRedo = makeToolbarIconButton(com.jvn.editor.ui.CssIcon.redo("#7ab3e0"), "Redo (Ctrl/Cmd+Shift+Z)");
+        btnRewind = makeToolbarIconButton(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.REWIND), "Rewind (Home)");
+        btnPlay = makeToolbarIconButton(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.PLAY), "Play (Space)");
+        btnPause = makeToolbarIconButton(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.PAUSE), "Pause (Space)");
+        btnStop = makeToolbarIconButton(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.STOP), "Stop");
+        btnUndo = makeToolbarIconButton(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.UNDO), "Undo (Ctrl/Cmd+Z)");
+        btnRedo = makeToolbarIconButton(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.REDO), "Redo (Ctrl/Cmd+Shift+Z)");
 
         btnPlay.setOnAction(e -> play());
         btnPause.setOnAction(e -> pause());
@@ -980,7 +980,7 @@ public class PuppeteerWindow extends Stage {
             }
         });
 
-        Button btnFitDuration = makeToolbarIconButton(com.jvn.editor.ui.CssIcon.rectSelect(), "Fit duration to content");
+        Button btnFitDuration = makeToolbarIconButton(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.FIT_DURATION), "Fit duration to content");
         btnFitDuration.setOnAction(e -> {
             this.project.fitDurationToContent();
             tfDuration.setText(String.valueOf((int) this.project.getTotalDurationMs()));
@@ -989,7 +989,7 @@ public class PuppeteerWindow extends Stage {
             refreshExportPreviewAndMarkDirty();
         });
 
-        cbLoop = makeToolbarIconToggle(com.jvn.editor.ui.CssIcon.loop("#3cbcaa"), "Loop timeline playback");
+        cbLoop = makeToolbarIconToggle(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.LOOP), "Loop timeline playback");
         cbLoop.setSelected(this.project.isLooping());
         cbLoop.setOnAction(e -> {
             this.project.setLooping(cbLoop.isSelected());
@@ -997,7 +997,7 @@ public class PuppeteerWindow extends Stage {
             updateStatusBar();
         });
 
-        Button btnLoopIn = makeToolbarIconButton(com.jvn.editor.ui.CssIcon.verticalAlignBottom("#3cbcaa"), "Set loop IN at playhead");
+        Button btnLoopIn = makeToolbarIconButton(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.LOOP_IN), "Set loop IN at playhead");
         btnLoopIn.setOnAction(e -> {
             double inMs = project.getPlayheadMs();
             double outMs = project.hasLoopRegion() ? project.getLoopEndMs() : project.getTotalDurationMs();
@@ -1008,7 +1008,7 @@ public class PuppeteerWindow extends Stage {
             }
         });
 
-        Button btnLoopOut = makeToolbarIconButton(com.jvn.editor.ui.CssIcon.verticalAlignTop("#3cbcaa"), "Set loop OUT at playhead");
+        Button btnLoopOut = makeToolbarIconButton(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.LOOP_OUT), "Set loop OUT at playhead");
         btnLoopOut.setOnAction(e -> {
             double outMs = project.getPlayheadMs();
             double inMs = project.hasLoopRegion() ? project.getLoopStartMs() : 0;
@@ -1019,7 +1019,7 @@ public class PuppeteerWindow extends Stage {
             }
         });
 
-        Button btnLoopClear = makeToolbarIconButton(com.jvn.editor.ui.CssIcon.clearX(), "Clear loop region");
+        Button btnLoopClear = makeToolbarIconButton(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.CLEAR), "Clear loop region");
         btnLoopClear.setOnAction(e -> {
             project.clearLoopRegion();
             timelinePanel.refresh();
@@ -1031,7 +1031,7 @@ public class PuppeteerWindow extends Stage {
         durationBox.setAlignment(Pos.CENTER_LEFT);
 
         // --- Presets ---
-        Button presetButton = makeToolbarIconButton(com.jvn.editor.ui.CssIcon.folder(), "Apply animation preset to selected entity");
+        Button presetButton = makeToolbarIconButton(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.PRESET), "Apply animation preset to selected entity");
         presetButton.setOnAction(e -> showPresetMenuOverlay());
 
         // --- Property target + snapping ---
@@ -1057,23 +1057,23 @@ public class PuppeteerWindow extends Stage {
         HBox propertyBox = new HBox(4, cbProperty);
         propertyBox.setAlignment(Pos.CENTER_LEFT);
 
-        Button btnCopyKeyframes = makeToolbarIconButton(com.jvn.editor.ui.CssIcon.copy(), "Copy selected keyframes (Ctrl/Cmd+Alt+C)");
+        Button btnCopyKeyframes = makeToolbarIconButton(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.COPY), "Copy selected keyframes (Ctrl/Cmd+Alt+C)");
         btnCopyKeyframes.setOnAction(e -> copySelectedKeyframesToClipboard());
-        Button btnPasteKeyframes = makeToolbarIconButton(com.jvn.editor.ui.CssIcon.contentPaste(), "Paste keyframes at playhead (Ctrl/Cmd+Alt+V)");
+        Button btnPasteKeyframes = makeToolbarIconButton(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.PASTE), "Paste keyframes at playhead (Ctrl/Cmd+Alt+V)");
         btnPasteKeyframes.setOnAction(e -> pasteCopiedKeyframesAtPlayhead());
-        Button btnClipboardHistory = makeToolbarIconButton(com.jvn.editor.ui.CssIcon.timeline(), "Clipboard history");
+        Button btnClipboardHistory = makeToolbarIconButton(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.HISTORY), "Clipboard history");
         btnClipboardHistory.setOnAction(e -> showClipboardHistoryPopup());
-        Button btnDuplicateKeyframes = makeToolbarIconButton(com.jvn.editor.ui.CssIcon.controlPointDuplicate(), "Duplicate selected keyframes by snap step (Ctrl/Cmd+Alt+D)");
+        Button btnDuplicateKeyframes = makeToolbarIconButton(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.DUPLICATE), "Duplicate selected keyframes by snap step (Ctrl/Cmd+Alt+D)");
         btnDuplicateKeyframes.setOnAction(e -> duplicateSelectedKeyframesBySnapStep());
-        Button btnSaveClip = makeToolbarIconButton(com.jvn.editor.ui.CssIcon.libraryAdd(), "Save selection as reusable clip");
+        Button btnSaveClip = makeToolbarIconButton(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.SAVE_CLIP), "Save selection as reusable clip");
         btnSaveClip.setOnAction(e -> saveSelectionAsClip());
-        Button btnLoadClip = makeToolbarIconButton(com.jvn.editor.ui.CssIcon.input(), "Load and apply a saved clip at playhead");
+        Button btnLoadClip = makeToolbarIconButton(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.LOAD_CLIP), "Load and apply a saved clip at playhead");
         btnLoadClip.setOnAction(e -> loadAndApplyClip());
 
-        Button slotButton = makeToolbarIconButton(com.jvn.editor.ui.CssIcon.emojiPeople(), "Place selected entity at a VN character slot");
+        Button slotButton = makeToolbarIconButton(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.CHARACTER_SLOT), "Place selected entity at a VN character slot");
         slotButton.setOnAction(e -> showSlotMenuOverlay());
 
-        Button btnBatchKeyframe = makeToolbarIconButton(com.jvn.editor.ui.CssIcon.plus(), "Add keyframe for ALL entities at playhead (batch)");
+        Button btnBatchKeyframe = makeToolbarIconButton(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.ADD_ALL), "Add keyframe for ALL entities at playhead (batch)");
         btnBatchKeyframe.setOnAction(e -> {
             PropertyType prop = cbProperty.getValue();
             if (prop == null) prop = PropertyType.X;
@@ -1081,48 +1081,48 @@ public class PuppeteerWindow extends Stage {
             refreshExportPreviewAndMarkDirty();
         });
 
-        Button btnZoomFit = makeToolbarIconButton(com.jvn.editor.ui.CssIcon.zoomOutMap(), "Zoom timeline to fit content");
+        Button btnZoomFit = makeToolbarIconButton(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.ZOOM_FIT), "Zoom timeline to fit content");
         btnZoomFit.setOnAction(e -> timelinePanel.zoomToFit());
-        Button btnFocusSelection = makeToolbarIconButton(com.jvn.editor.ui.CssIcon.myLocation(), "Zoom timeline to the current selection or active track");
+        Button btnFocusSelection = makeToolbarIconButton(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.FOCUS), "Zoom timeline to the current selection or active track");
         btnFocusSelection.setOnAction(e -> timelinePanel.zoomToSelection());
-        Button btnPrevKeyframe = makeToolbarIconButton(com.jvn.editor.ui.CssIcon.fastRewind("#7ab3e0"), "Jump playhead to previous keyframe (Page Up)");
+        Button btnPrevKeyframe = makeToolbarIconButton(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.PREVIOUS), "Jump playhead to previous keyframe (Page Up)");
         btnPrevKeyframe.setOnAction(e -> timelinePanel.jumpPlayheadToPreviousKeyframe());
-        Button btnNextKeyframe = makeToolbarIconButton(com.jvn.editor.ui.CssIcon.fastForward("#7ab3e0"), "Jump playhead to next keyframe (Page Down)");
+        Button btnNextKeyframe = makeToolbarIconButton(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.NEXT), "Jump playhead to next keyframe (Page Down)");
         btnNextKeyframe.setOnAction(e -> timelinePanel.jumpPlayheadToNextKeyframe());
 
-        ToggleButton cbRipple = makeToolbarIconToggle(com.jvn.editor.ui.CssIcon.link("#f0a830"), "Ripple-retime: shift following keys when nudging a selection");
+        ToggleButton cbRipple = makeToolbarIconToggle(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.RIPPLE), "Ripple-retime: shift following keys when nudging a selection");
         cbRipple.setSelected(timelinePanel.isRippleRetimeEnabled());
         cbRipple.setOnAction(e -> timelinePanel.setRippleRetimeEnabled(cbRipple.isSelected()));
 
-        Button btnDistributeKeys = makeToolbarIconButton(com.jvn.editor.ui.CssIcon.formatAlignJustify(), "Distribute selected keyframes evenly across their current range");
+        Button btnDistributeKeys = makeToolbarIconButton(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.DISTRIBUTE), "Distribute selected keyframes evenly across their current range");
         btnDistributeKeys.setOnAction(e -> {
             if (timelinePanel.distributeSelectedKeyframes()) {
                 refreshExportPreviewAndMarkDirty();
             }
         });
 
-        Button btnReverseKeys = makeToolbarIconButton(com.jvn.editor.ui.CssIcon.swapHoriz(), "Reverse selected keyframes within their current range");
+        Button btnReverseKeys = makeToolbarIconButton(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.REVERSE), "Reverse selected keyframes within their current range");
         btnReverseKeys.setOnAction(e -> {
             if (timelinePanel.reverseSelectedKeyframes()) {
                 refreshExportPreviewAndMarkDirty();
             }
         });
 
-        Button btnStretchKeys = makeToolbarIconButton(com.jvn.editor.ui.CssIcon.openInFull(), "Stretch selected keyframes 25% wider");
+        Button btnStretchKeys = makeToolbarIconButton(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.STRETCH), "Stretch selected keyframes 25% wider");
         btnStretchKeys.setOnAction(e -> {
             if (timelinePanel.stretchSelectedKeyframes(1.25)) {
                 refreshExportPreviewAndMarkDirty();
             }
         });
 
-        Button btnCompressKeys = makeToolbarIconButton(com.jvn.editor.ui.CssIcon.closeFullscreen(), "Compress selected keyframes to 80% of their current range");
+        Button btnCompressKeys = makeToolbarIconButton(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.COMPRESS), "Compress selected keyframes to 80% of their current range");
         btnCompressKeys.setOnAction(e -> {
             if (timelinePanel.stretchSelectedKeyframes(0.8)) {
                 refreshExportPreviewAndMarkDirty();
             }
         });
 
-        cbCompactExport = makeToolbarIconToggle(com.jvn.editor.ui.CssIcon.folderZip(), "Use compact export format");
+        cbCompactExport = makeToolbarIconToggle(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.COMPACT_EXPORT), "Use compact export format");
         cbCompactExport.setSelected(false);
         cbCompactExport.setOnAction(e -> setCompactExportEnabled(cbCompactExport.isSelected()));
 
@@ -1152,7 +1152,7 @@ public class PuppeteerWindow extends Stage {
         );
         keyframeOpsSecondaryRow.setAlignment(Pos.CENTER_LEFT);
 
-        cbSnap = makeToolbarIconToggle(com.jvn.editor.ui.CssIcon.grid4x4(), "Enable snapping");
+        cbSnap = makeToolbarIconToggle(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.SNAP), "Enable snapping");
         cbSnap.setSelected(timelinePanel.isSnapEnabled());
         cbSnap.setOnAction(e -> setTimelineSnapEnabled(cbSnap.isSelected()));
 
@@ -1199,31 +1199,31 @@ public class PuppeteerWindow extends Stage {
         });
 
         cbRuntimePreview = makeToolbarIconToggle(
-            com.jvn.editor.ui.CssIcon.movie("#9b72d4"),
+            puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.RUNTIME_PREVIEW),
             "Runtime data preview: render through TimelineData/TimelineRunner"
         );
         cbRuntimePreview.setSelected(runtimeParityPreview);
         cbRuntimePreview.setOnAction(e -> setRuntimeParityPreviewEnabled(cbRuntimePreview.isSelected()));
 
         cbViewportStabilize = makeToolbarIconToggle(
-            com.jvn.editor.ui.CssIcon.myLocation("#8bd2ff"),
+            puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.VIEWPORT_STABILIZE),
             "Stabilize preview viewport: lock framing so animated bounds cannot shake the view"
         );
         cbViewportStabilize.setSelected(viewportStabilizationEnabled);
         cbViewportStabilize.setOnAction(e -> setViewportStabilizationEnabled(cbViewportStabilize.isSelected()));
 
         // --- Auto-key toggle ---
-        cbAutoKey = makeToolbarIconToggle(com.jvn.editor.ui.CssIcon.fiberSmartRecord("#e05050"), "Auto-key: automatically insert keyframe on drag");
+        cbAutoKey = makeToolbarIconToggle(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.AUTO_KEY), "Auto-key: automatically insert keyframe on drag");
         cbAutoKey.setSelected(false);
         cbAutoKey.setOnAction(e -> setAutoKeyEnabled(cbAutoKey.isSelected()));
         Label lblAutoKey = new Label("Auto");
         lblAutoKey.setStyle("-fx-text-fill: #a0a0a0; -fx-font-size: 10px;");
 
         // --- Snap-to-grid / snap-to-entity toggles ---
-        cbSnapGrid = makeToolbarIconToggle(com.jvn.editor.ui.CssIcon.borderAll(), "Snap entities to grid when dragging");
+        cbSnapGrid = makeToolbarIconToggle(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.SNAP_GRID), "Snap entities to grid when dragging");
         cbSnapGrid.setSelected(false);
         cbSnapGrid.setOnAction(e -> setPreviewSnapToGridEnabled(cbSnapGrid.isSelected()));
-        cbSnapEntity = makeToolbarIconToggle(com.jvn.editor.ui.CssIcon.joinInner(), "Snap to nearby entity positions");
+        cbSnapEntity = makeToolbarIconToggle(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.SNAP_ENTITY), "Snap to nearby entity positions");
         cbSnapEntity.setSelected(false);
         cbSnapEntity.setOnAction(e -> setPreviewSnapToEntityEnabled(cbSnapEntity.isSelected()));
 
@@ -1232,15 +1232,15 @@ public class PuppeteerWindow extends Stage {
         HBox previewSnapBox = new HBox(4, cbSnapGrid, cbSnapEntity, cbRuntimePreview, cbViewportStabilize, cbSpeed, cbWheelMode);
         previewSnapBox.setAlignment(Pos.CENTER_LEFT);
 
-        cbOrbitTool = makeToolbarIconToggle(com.jvn.editor.ui.CssIcon.threeSixty("#9b72d4"), "Enable orbit-anchor tool. Shift+click preview to place anchor. Alt+Shift+click another entity to link the anchor at the exact cursor point (joint/nail).");
+        cbOrbitTool = makeToolbarIconToggle(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.ORBIT), "Enable orbit-anchor tool. Shift+click preview to place anchor. Alt+Shift+click another entity to link the anchor at the exact cursor point (joint/nail).");
         cbOrbitTool.setSelected(animationPreview.isOrbitToolEnabled());
         cbOrbitTool.setOnAction(e -> animationPreview.setOrbitToolEnabled(cbOrbitTool.isSelected()));
 
-        cbOrbitAlign = makeToolbarIconToggle(com.jvn.editor.ui.CssIcon.explore(), "When orbiting, update entity rotation to face outward.");
+        cbOrbitAlign = makeToolbarIconToggle(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.ORBIT_ALIGN), "When orbiting, update entity rotation to face outward.");
         cbOrbitAlign.setSelected(animationPreview.isOrbitAlignRotation());
         cbOrbitAlign.setOnAction(e -> animationPreview.setOrbitAlignRotation(cbOrbitAlign.isSelected()));
 
-        Button btnClearAnchor = makeToolbarIconButton(com.jvn.editor.ui.CssIcon.clearX(), "Clear orbit anchor for selected entity");
+        Button btnClearAnchor = makeToolbarIconButton(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.CLEAR), "Clear orbit anchor for selected entity");
         btnClearAnchor.setOnAction(e -> {
             animationPreview.clearOrbitAnchorForSelectedEntity();
             updatePreview();
@@ -1250,13 +1250,13 @@ public class PuppeteerWindow extends Stage {
         orbitBox.setAlignment(Pos.CENTER_LEFT);
 
         // --- Help button ---
-        Button btnHelp = makeToolbarIconButton(com.jvn.editor.ui.CssIcon.speech(), "Show keyboard shortcuts");
+        Button btnHelp = makeToolbarIconButton(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.HELP), "Show keyboard shortcuts");
         btnHelp.setOnAction(e -> showShortcutsOverlay());
 
         // --- Audio + event cues ---
-        Button btnAddCue = makeToolbarIconButton(com.jvn.editor.ui.CssIcon.plus(), "Add audio cue at playhead");
+        Button btnAddCue = makeToolbarIconButton(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.ADD_AUDIO_CUE), "Add audio cue at playhead");
         btnAddCue.setOnAction(e -> showAddAudioCueDialog());
-        Button btnClearCues = makeToolbarIconButton(com.jvn.editor.ui.CssIcon.clearX(), "Remove all timeline audio cues");
+        Button btnClearCues = makeToolbarIconButton(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.CLEAR), "Remove all timeline audio cues");
         btnClearCues.setOnAction(e -> {
             if (project.getAudioCues().isEmpty()) return;
             overlayDialog.showDialog(
@@ -1271,11 +1271,11 @@ public class PuppeteerWindow extends Stage {
                 })
             );
         });
-        Button btnAddExpressionCue = makeToolbarIconButton(com.jvn.editor.ui.CssIcon.theater("#7bd88f"), "Add expression keyframe at playhead");
+        Button btnAddExpressionCue = makeToolbarIconButton(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.ADD_EXPRESSION_CUE), "Add expression keyframe at playhead");
         btnAddExpressionCue.setOnAction(e -> showExpressionKeyframeDialog());
-        Button btnManageEvents = makeToolbarIconButton(com.jvn.editor.ui.CssIcon.list(), "Manage timeline event cues");
+        Button btnManageEvents = makeToolbarIconButton(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.MANAGE_EVENTS), "Manage timeline event cues");
         btnManageEvents.setOnAction(e -> showEventCueManagerDialog(null));
-        Button btnClearEvents = makeToolbarIconButton(com.jvn.editor.ui.CssIcon.clearX(), "Remove all timeline event cues");
+        Button btnClearEvents = makeToolbarIconButton(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.CLEAR), "Remove all timeline event cues");
         btnClearEvents.setOnAction(e -> {
             if (project.getEditorEventCues().isEmpty()) return;
             overlayDialog.showDialog(
@@ -1306,10 +1306,10 @@ public class PuppeteerWindow extends Stage {
         tfTimelineName.setStyle(STYLE_TEXT_FIELD);
         tfTimelineName.setTooltip(new Tooltip("Name for @external jes_timeline"));
 
-        Button btnSync = makeToolbarIconButton(com.jvn.editor.ui.CssIcon.loop("#a8d0f0"), "Sync snapshot from VNS script");
+        Button btnSync = makeToolbarIconButton(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.SYNC), "Sync snapshot from VNS script");
         btnSync.setOnAction(e -> requestSyncSnapshot());
 
-        Button btnRegister = makeToolbarSuccessIconButton(com.jvn.editor.ui.CssIcon.save(), "Register timeline for VNS interop");
+        Button btnRegister = makeToolbarSuccessIconButton(puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.REGISTER), "Register timeline for VNS interop");
         btnRegister.setOnAction(e -> requestRegisterTimeline());
 
         HBox nameBox = new HBox(4, btnSync, tfTimelineName, btnRegister);
@@ -1338,10 +1338,10 @@ public class PuppeteerWindow extends Stage {
 
         // --- Export cluster ---
         Button btnExportGif = makeToolbarIconButton(
-            com.jvn.editor.ui.CssIcon.fiberSmartRecord("#e57373"), "Record preview as GIF animation");
+            puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.RECORD_GIF), "Record preview as GIF animation");
         btnExportGif.setOnAction(e -> showRecordGifDialog());
         Button btnExportCopyCode = makeToolbarIconButton(
-            com.jvn.editor.ui.CssIcon.copy("#a8d0f0"), "Copy exported JES code to clipboard");
+            puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.COPY_CODE), "Copy exported JES code to clipboard");
         btnExportCopyCode.setOnAction(e -> copyExportedCodeToClipboard());
         HBox exportBox = new HBox(4, btnExportGif, btnExportCopyCode);
         exportBox.setAlignment(Pos.CENTER_LEFT);
@@ -1349,7 +1349,7 @@ public class PuppeteerWindow extends Stage {
 
         // --- Diagnostics cluster ---
         Button btnVerify = makeToolbarIconButton(
-            com.jvn.editor.ui.CssIcon.list("#90d090"), "Verify runtime timeline registration");
+            puppeteerAeroIcon(com.jvn.editor.ui.PuppeteerAeroIcon.Kind.VERIFY), "Verify runtime timeline registration");
         btnVerify.setOnAction(e -> showRuntimeVerificationReport());
         CollapsibleToolbarCluster diagnosticsCluster = registerToolbarCluster("diagnostics", "Diagnostics", btnVerify);
 
@@ -11393,6 +11393,11 @@ public class PuppeteerWindow extends Stage {
         btn.setMaxSize(36, 32);
         btn.setFocusTraversable(false);
         return btn;
+    }
+
+    private static com.jvn.editor.ui.PuppeteerAeroIcon puppeteerAeroIcon(
+        com.jvn.editor.ui.PuppeteerAeroIcon.Kind kind) {
+        return com.jvn.editor.ui.PuppeteerAeroIcon.of(kind, 23);
     }
 
     private static Button makeToolbarSuccessIconButton(javafx.scene.layout.Region iconClass, String tooltip) {

--- a/modules/editor/src/main/resources/com/jvn/editor/editor.css
+++ b/modules/editor/src/main/resources/com/jvn/editor/editor.css
@@ -3556,6 +3556,32 @@ The editor.css file defines the visual styling for the editor module, including 
   -fx-effect: dropshadow(gaussian, rgba(210, 210, 210, 0.22), 10, 0.26, 0, 0);
 }
 
+/* Floating-docker commands carry their surface in the compact Aero artwork itself. */
+.puppeteer-toolbar-icon-button.puppeteer-aero-button,
+.puppeteer-toolbar-icon-toggle.puppeteer-aero-button {
+  -fx-background-color: linear-gradient(to bottom, rgba(255,255,255,0.045), rgba(0,0,0,0.16));
+  -fx-border-color: rgba(143, 162, 178, 0.34);
+  -fx-background-radius: 9;
+  -fx-border-radius: 9;
+}
+
+.puppeteer-toolbar-icon-button.puppeteer-aero-button:hover,
+.puppeteer-toolbar-icon-toggle.puppeteer-aero-button:hover {
+  -fx-background-color: linear-gradient(to bottom, rgba(148,205,240,0.12), rgba(26,53,70,0.18));
+  -fx-border-color: rgba(174, 218, 244, 0.62);
+}
+
+.puppeteer-toolbar-icon-button.puppeteer-aero-button:pressed,
+.puppeteer-toolbar-icon-toggle.puppeteer-aero-button:pressed {
+  -fx-background-color: rgba(0,0,0,0.28);
+  -fx-border-color: rgba(215, 235, 247, 0.54);
+}
+
+.puppeteer-toolbar-icon-toggle.puppeteer-aero-button:selected {
+  -fx-background-color: linear-gradient(to bottom, rgba(255,190,70,0.22), rgba(96,52,8,0.25));
+  -fx-border-color: rgba(255, 198, 91, 0.78);
+}
+
 .puppeteer-toolbar-icon-menu > .label {
   -fx-padding: 0;
 }

--- a/modules/editor/src/test/java/com/jvn/editor/AppBuildInfoTest.java
+++ b/modules/editor/src/test/java/com/jvn/editor/AppBuildInfoTest.java
@@ -8,14 +8,14 @@ class AppBuildInfoTest {
 
   @Test
   void displayVersionLabelUsesFallbackForDev() {
-    assertEquals("v0.3.1", AppBuildInfo.displayVersionLabel("dev"));
-    assertEquals("v0.3.1", AppBuildInfo.displayVersionLabel("vdev"));
-    assertEquals("v0.3.1", AppBuildInfo.displayVersionLabel(""));
+    assertEquals("v0.4.0", AppBuildInfo.displayVersionLabel("dev"));
+    assertEquals("v0.4.0", AppBuildInfo.displayVersionLabel("vdev"));
+    assertEquals("v0.4.0", AppBuildInfo.displayVersionLabel(""));
   }
 
   @Test
   void displayVersionLabelMapsSnapshotToAlpha() {
-    assertEquals("v0.3.1 Alpha", AppBuildInfo.displayVersionLabel("0.3.1-SNAPSHOT"));
+    assertEquals("v0.4.0 Alpha", AppBuildInfo.displayVersionLabel("0.4.0-SNAPSHOT"));
   }
 
   @Test

--- a/modules/editor/src/test/java/com/jvn/editor/ui/AeroIconTest.java
+++ b/modules/editor/src/test/java/com/jvn/editor/ui/AeroIconTest.java
@@ -19,6 +19,10 @@ class AeroIconTest {
 
   @BeforeAll
   static void startToolkit() throws Exception {
+    if (isHeadlessLinux()) {
+      toolkitAvailable = false;
+      return;
+    }
     CountDownLatch ready = new CountDownLatch(1);
     try {
       Platform.startup(ready::countDown);
@@ -28,6 +32,11 @@ class AeroIconTest {
     } catch (RuntimeException unavailable) {
       toolkitAvailable = false;
     }
+  }
+
+  private static boolean isHeadlessLinux() {
+    return System.getProperty("os.name", "").toLowerCase().contains("linux")
+        && System.getenv().getOrDefault("DISPLAY", "").isBlank();
   }
 
   @Test

--- a/modules/editor/src/test/java/com/jvn/editor/ui/PuppeteerAeroIconTest.java
+++ b/modules/editor/src/test/java/com/jvn/editor/ui/PuppeteerAeroIconTest.java
@@ -19,6 +19,10 @@ class PuppeteerAeroIconTest {
 
   @BeforeAll
   static void startToolkit() throws Exception {
+    if (isHeadlessLinux()) {
+      toolkitAvailable = false;
+      return;
+    }
     CountDownLatch ready = new CountDownLatch(1);
     try {
       Platform.startup(ready::countDown);
@@ -28,6 +32,11 @@ class PuppeteerAeroIconTest {
     } catch (RuntimeException unavailable) {
       toolkitAvailable = false;
     }
+  }
+
+  private static boolean isHeadlessLinux() {
+    return System.getProperty("os.name", "").toLowerCase().contains("linux")
+        && System.getenv().getOrDefault("DISPLAY", "").isBlank();
   }
 
   @Test

--- a/modules/editor/src/test/java/com/jvn/editor/ui/PuppeteerAeroIconTest.java
+++ b/modules/editor/src/test/java/com/jvn/editor/ui/PuppeteerAeroIconTest.java
@@ -1,0 +1,83 @@
+package com.jvn.editor.ui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.scene.image.WritableImage;
+import javafx.scene.layout.StackPane;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class PuppeteerAeroIconTest {
+  private static boolean toolkitAvailable;
+
+  @BeforeAll
+  static void startToolkit() throws Exception {
+    CountDownLatch ready = new CountDownLatch(1);
+    try {
+      Platform.startup(ready::countDown);
+      toolkitAvailable = ready.await(5, TimeUnit.SECONDS);
+    } catch (IllegalStateException alreadyStarted) {
+      toolkitAvailable = true;
+    } catch (RuntimeException unavailable) {
+      toolkitAvailable = false;
+    }
+  }
+
+  @Test
+  void everyKeyframeCommandRendersACompactAeroSurface() throws Exception {
+    Assumptions.assumeTrue(toolkitAvailable, "JavaFX toolkit is unavailable in this environment");
+    for (PuppeteerAeroIcon.Kind kind : PuppeteerAeroIcon.Kind.values()) {
+      WritableImage image = onFxThread(() -> {
+        PuppeteerAeroIcon icon = PuppeteerAeroIcon.of(kind);
+        StackPane root = new StackPane(icon);
+        new Scene(root, 32, 32);
+        root.applyCss();
+        root.layout();
+        return root.snapshot(null, new WritableImage(32, 32));
+      });
+      assertTrue(nonTransparentPixels(image) > 180, kind + " should render a visible Aero plate and glyph");
+    }
+  }
+
+  @Test
+  void sizeIsClampedAndKindIsPreserved() throws Exception {
+    Assumptions.assumeTrue(toolkitAvailable, "JavaFX toolkit is unavailable in this environment");
+    PuppeteerAeroIcon small = onFxThread(() -> PuppeteerAeroIcon.of(PuppeteerAeroIcon.Kind.RIPPLE, 2));
+    PuppeteerAeroIcon large = onFxThread(() -> PuppeteerAeroIcon.of(PuppeteerAeroIcon.Kind.RIPPLE, 200));
+    assertEquals(18, small.iconSize());
+    assertEquals(28, large.iconSize());
+    assertEquals(PuppeteerAeroIcon.Kind.RIPPLE, small.kind());
+    assertTrue(small.isCache());
+  }
+
+  private static int nonTransparentPixels(WritableImage image) {
+    int count = 0;
+    for (int y = 0; y < image.getHeight(); y++) {
+      for (int x = 0; x < image.getWidth(); x++) {
+        if (image.getPixelReader().getArgb(x, y) >>> 24 != 0) count++;
+      }
+    }
+    return count;
+  }
+
+  private static <T> T onFxThread(java.util.concurrent.Callable<T> work) throws Exception {
+    CountDownLatch done = new CountDownLatch(1);
+    AtomicReference<T> result = new AtomicReference<>();
+    AtomicReference<Throwable> failure = new AtomicReference<>();
+    Platform.runLater(() -> {
+      try { result.set(work.call()); }
+      catch (Throwable error) { failure.set(error); }
+      finally { done.countDown(); }
+    });
+    assertTrue(done.await(10, TimeUnit.SECONDS), "JavaFX work timed out");
+    if (failure.get() != null) throw new AssertionError(failure.get());
+    return result.get();
+  }
+}

--- a/modules/editor/src/test/java/com/jvn/editor/ui/actioneditor/PuppeteerEasingCatalogTest.java
+++ b/modules/editor/src/test/java/com/jvn/editor/ui/actioneditor/PuppeteerEasingCatalogTest.java
@@ -7,11 +7,20 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterEach;
 
 import com.jvn.core.animation.Easing;
 import com.jvn.core.animation.EasingSpec;
+import com.jvn.core.animation.EasingExtensions;
+import com.jvn.plugin.api.ExtensionEntry;
+import com.jvn.plugin.api.ExtensionRegistry;
+import com.jvn.plugin.api.Registration;
+import com.jvn.plugin.api.animation.AnimationEasing;
+import java.util.Optional;
+import static com.jvn.plugin.api.animation.AnimationEasingDefinition.easing;
 
 class PuppeteerEasingCatalogTest {
+    @AfterEach void clearExtensions() { EasingExtensions.clear(); }
 
     @Test
     void buildEntriesIncludesBuiltinsAndProjectPresets() {
@@ -63,5 +72,38 @@ class PuppeteerEasingCatalogTest {
 
         List<PuppeteerEasingCatalog.Entry> byDsl = PuppeteerEasingCatalog.filter(entries, "cubic_bezier");
         assertTrue(byDsl.stream().anyMatch(entry -> "Soft Landing".equals(entry.label())));
+    }
+
+    @Test
+    void includesPluginMetadataAndMatchesExtensionSpecs() {
+        AnimationEasing pluginEasing = easing("Elastic Pop")
+            .description("Playful hero entrance")
+            .category("Expressive")
+            .evaluate(frame -> frame.progress());
+        EasingExtensions.install(registry("studio.elastic-pop", pluginEasing));
+
+        List<PuppeteerEasingCatalog.Entry> entries = PuppeteerEasingCatalog.buildEntries(List.of());
+        PuppeteerEasingCatalog.Entry plugin = entries.stream()
+            .filter(PuppeteerEasingCatalog.Entry::isPlugin)
+            .findFirst().orElseThrow();
+        assertEquals("Elastic Pop", plugin.label());
+        assertEquals("Expressive", plugin.group());
+        assertEquals("Plugin", plugin.badge());
+        assertEquals(plugin, PuppeteerEasingCatalog.matchForSpec(
+            entries, EasingSpec.tryParse("studio.elastic-pop")));
+        assertTrue(PuppeteerEasingCatalog.filter(entries, "hero entrance").contains(plugin));
+    }
+
+    private static ExtensionRegistry<AnimationEasing> registry(String id, AnimationEasing easing) {
+        ExtensionEntry<AnimationEasing> entry = new ExtensionEntry<>(id, "test", easing);
+        return new ExtensionRegistry<>() {
+            @Override public Registration register(String ignored, AnimationEasing value) {
+                throw new UnsupportedOperationException();
+            }
+            @Override public Optional<AnimationEasing> find(String requested) {
+                return id.equals(requested) ? Optional.of(easing) : Optional.empty();
+            }
+            @Override public List<ExtensionEntry<AnimationEasing>> entries() { return List.of(entry); }
+        };
     }
 }

--- a/modules/hub/src/main/java/com/jvn/hub/JvnHub.java
+++ b/modules/hub/src/main/java/com/jvn/hub/JvnHub.java
@@ -4041,7 +4041,7 @@ public final class JvnHub {
   private static String displayVersionLabel(String rawVersion) {
     String raw = rawVersion == null ? "" : rawVersion.trim();
     if (raw.isBlank() || raw.equalsIgnoreCase("dev") || raw.equalsIgnoreCase("vdev")) {
-      return "v0.3.1";
+      return "v0.4.0";
     }
 
     String version = raw.startsWith("v") || raw.startsWith("V") ? raw.substring(1) : raw;
@@ -4060,7 +4060,7 @@ public final class JvnHub {
     int plus = version.indexOf('+');
     if (plus >= 0) version = version.substring(0, plus);
     version = version.trim();
-    if (version.isBlank()) version = "0.3.1";
+    if (version.isBlank()) version = "0.4.0";
     return "v" + version + (maturity == null ? "" : " " + maturity);
   }
 
@@ -4710,7 +4710,7 @@ public final class JvnHub {
     private boolean underMaintenance = false;
 
     LauncherButton(String text) {
-      super(text, uiIcon(VectorIcon.Kind.ROCKET, 16, TEXT_PRIMARY), BORDER_NEUTRAL);
+      super(text, WindowsSevenActionIcon.of(WindowsSevenActionIcon.Kind.LAUNCHER), BORDER_NEUTRAL);
       stripeTimer = new javax.swing.Timer(70, e -> {
         stripeOffset = (stripeOffset + 2) % STRIPE_PERIOD;
         repaint();
@@ -4722,7 +4722,9 @@ public final class JvnHub {
       LauncherMaintenanceState safeState = state == null ? LauncherMaintenanceState.available() : state;
       underMaintenance = safeState.underMaintenance();
       setForeground(underMaintenance ? ACCENT_MAINTENANCE : TEXT_PRIMARY);
-      setIcon(uiIcon(VectorIcon.Kind.ROCKET, 16, underMaintenance ? ACCENT_MAINTENANCE : TEXT_PRIMARY));
+      setIcon(WindowsSevenActionIcon.of(
+          underMaintenance ? WindowsSevenActionIcon.Kind.LAUNCHER_MAINTENANCE
+              : WindowsSevenActionIcon.Kind.LAUNCHER));
       setToolTipText(underMaintenance
           ? safeState.resolvedMessage()
           : "Launch the standalone JVN launcher.");
@@ -5135,7 +5137,7 @@ public final class JvnHub {
   /** Colorful glass-and-metal action glyphs inspired by the Windows 7 desktop era. */
   private static final class WindowsSevenActionIcon implements Icon {
     enum Kind {
-      EDITOR, BUILD, SHORTCUT, UPDATE, TESTS, OPTIONS,
+      EDITOR, LAUNCHER, LAUNCHER_MAINTENANCE, BUILD, SHORTCUT, UPDATE, TESTS, OPTIONS,
       MORE, CANCEL, QUIT,
       DEVELOPER, DEVELOPER_ACTIVE, SAFE, SAFE_ACTIVE,
       DIAGNOSTICS, ABOUT, DOCUMENTATION, ANNOUNCEMENTS
@@ -5150,7 +5152,7 @@ public final class JvnHub {
     }
 
     static WindowsSevenActionIcon of(Kind kind) {
-      return new WindowsSevenActionIcon(kind, ui(24));
+      return new WindowsSevenActionIcon(kind, ui(26));
     }
 
     static WindowsSevenActionIcon of(Kind kind, int logicalSize) {
@@ -5170,6 +5172,8 @@ public final class JvnHub {
         g.setStroke(new BasicStroke(1.25f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
         switch (kind) {
           case EDITOR -> paintEditor(g);
+          case LAUNCHER -> paintLauncher(g, false);
+          case LAUNCHER_MAINTENANCE -> paintLauncher(g, true);
           case BUILD -> paintBuild(g);
           case SHORTCUT -> paintShortcut(g);
           case UPDATE -> paintUpdate(g);
@@ -5209,6 +5213,43 @@ public final class JvnHub {
       g.drawRoundRect(16, 7, 3, 12, 2, 2);
       g.setColor(Color.decode("#f8d8b4"));
       g.fillPolygon(new int[] {16, 20, 18}, new int[] {20, 20, 23}, 3);
+    }
+
+    private static void paintLauncher(Graphics2D g, boolean maintenance) {
+      Color top = maintenance ? Color.decode("#ffd36e") : Color.decode("#74ddff");
+      Color bottom = maintenance ? Color.decode("#b76513") : Color.decode("#1769b5");
+      glassOrb(g, top, bottom);
+
+      Path2D rocket = new Path2D.Float();
+      rocket.moveTo(13, 5);
+      rocket.curveTo(17, 6, 19, 9, 19, 12);
+      rocket.lineTo(14, 17);
+      rocket.lineTo(10, 17);
+      rocket.lineTo(6, 21);
+      rocket.lineTo(7, 15);
+      rocket.lineTo(12, 10);
+      rocket.curveTo(12, 8, 12, 6, 13, 5);
+      rocket.closePath();
+      g.setPaint(new LinearGradientPaint(
+          7f, 5f, 18f, 19f,
+          new float[] {0f, 0.45f, 1f},
+          new Color[] {Color.WHITE, Color.decode("#dceaf3"), Color.decode("#8297a8")}));
+      g.fill(rocket);
+      g.setColor(maintenance ? Color.decode("#7b3b0c") : Color.decode("#174b74"));
+      g.setStroke(new BasicStroke(1.05f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
+      g.draw(rocket);
+      g.setPaint(new RadialGradientPaint(
+          new Point2D.Float(15f, 10f), 3.2f,
+          new float[] {0f, 0.62f, 1f},
+          new Color[] {Color.WHITE, Color.decode("#7fdcff"), Color.decode("#1765a2")}));
+      g.fillOval(13, 8, 4, 4);
+      g.setColor(new Color(255, 255, 255, 190));
+      g.drawOval(13, 8, 4, 4);
+      g.setPaint(new LinearGradientPaint(
+          7f, 17f, 7f, 23f,
+          new float[] {0f, 0.5f, 1f},
+          new Color[] {Color.decode("#fff4a0"), Color.decode("#ff9b28"), new Color(214, 48, 18, 40)}));
+      g.fillPolygon(new int[] {8, 11, 7}, new int[] {17, 18, 23}, 3);
     }
 
     private static void paintBuild(Graphics2D g) {
@@ -5427,21 +5468,48 @@ public final class JvnHub {
     private static void glassTile(Graphics2D g, int x, int y, int width, int height,
                                   Color top, Color bottom) {
       shadow(g, x, y, width, height, 4);
-      g.setPaint(new java.awt.GradientPaint(x, y, top, x, y + height, bottom));
+      g.setPaint(new LinearGradientPaint(
+          x, y, x, y + height,
+          new float[] {0f, 0.14f, 0.55f, 1f},
+          new Color[] {
+              brighter(top, 0.26f),
+              top,
+              blend(top, bottom, 0.58f),
+              darker(bottom, 0.18f)
+          }));
       g.fillRoundRect(x, y, width, height, 4, 4);
-      g.setColor(brighter(top, 0.42f));
+      g.setColor(new Color(255, 255, 255, 185));
       g.drawRoundRect(x, y, width - 1, height - 1, 4, 4);
+      g.setColor(new Color(0, 18, 34, 105));
+      g.drawRoundRect(x + 1, y + 1, width - 3, height - 3, 3, 3);
       gloss(g, x + 1, y + 1, width - 2, Math.max(4, height / 2), 3);
+      g.setColor(new Color(255, 255, 255, 72));
+      g.drawLine(x + 3, y + height - 2, x + width - 4, y + height - 2);
     }
 
     private static void glassOrb(Graphics2D g, Color top, Color bottom) {
       shadow(g, 3, 3, 18, 18, 18);
-      g.setPaint(new java.awt.GradientPaint(4, 3, top, 19, 21, bottom));
+      g.setPaint(new RadialGradientPaint(
+          new Point2D.Float(8.5f, 6.5f), 18f,
+          new float[] {0f, 0.30f, 0.72f, 1f},
+          new Color[] {
+              brighter(top, 0.38f),
+              top,
+              blend(top, bottom, 0.64f),
+              darker(bottom, 0.25f)
+          }));
       g.fillOval(3, 3, 18, 18);
-      g.setColor(brighter(top, 0.45f));
+      g.setColor(new Color(255, 255, 255, 205));
       g.drawOval(3, 3, 17, 17);
-      g.setColor(new Color(255, 255, 255, 105));
+      g.setColor(new Color(0, 18, 34, 100));
+      g.drawOval(4, 4, 15, 15);
+      g.setPaint(new LinearGradientPaint(
+          0f, 4f, 0f, 11f,
+          new float[] {0f, 1f},
+          new Color[] {new Color(255, 255, 255, 175), new Color(255, 255, 255, 12)}));
       g.fillOval(6, 4, 12, 7);
+      g.setColor(new Color(255, 255, 255, 70));
+      g.drawArc(6, 7, 12, 11, 205, 128);
     }
 
     private static Color brighter(Color color, float amount) {
@@ -5452,13 +5520,42 @@ public final class JvnHub {
           Math.round(color.getBlue() + (255 - color.getBlue()) * safe));
     }
 
+    private static Color darker(Color color, float amount) {
+      float safe = Math.max(0f, Math.min(1f, amount));
+      return new Color(
+          Math.round(color.getRed() * (1f - safe)),
+          Math.round(color.getGreen() * (1f - safe)),
+          Math.round(color.getBlue() * (1f - safe)),
+          color.getAlpha());
+    }
+
+    private static Color blend(Color first, Color second, float secondWeight) {
+      float weight = Math.max(0f, Math.min(1f, secondWeight));
+      float firstWeight = 1f - weight;
+      return new Color(
+          Math.round(first.getRed() * firstWeight + second.getRed() * weight),
+          Math.round(first.getGreen() * firstWeight + second.getGreen() * weight),
+          Math.round(first.getBlue() * firstWeight + second.getBlue() * weight));
+    }
+
     private static void shadow(Graphics2D g, int x, int y, int width, int height, int arc) {
-      g.setColor(new Color(0, 0, 0, 85));
-      g.fillRoundRect(x + 1, y + 2, width, height, arc, arc);
+      g.setColor(new Color(0, 0, 0, 24));
+      g.fillRoundRect(x - 1, y + 1, width + 2, height + 3, arc + 2, arc + 2);
+      g.setColor(new Color(0, 0, 0, 48));
+      g.fillRoundRect(x, y + 2, width, height + 1, arc + 1, arc + 1);
+      g.setColor(new Color(0, 0, 0, 82));
+      g.fillRoundRect(x + 1, y + 2, width - 2, height, arc, arc);
     }
 
     private static void gloss(Graphics2D g, int x, int y, int width, int height, int arc) {
-      g.setPaint(new java.awt.GradientPaint(0, y, new Color(255, 255, 255, 145), 0, y + height, new Color(255, 255, 255, 12)));
+      g.setPaint(new LinearGradientPaint(
+          0f, y, 0f, y + height,
+          new float[] {0f, 0.48f, 1f},
+          new Color[] {
+              new Color(255, 255, 255, 180),
+              new Color(255, 255, 255, 76),
+              new Color(255, 255, 255, 5)
+          }));
       g.fillRoundRect(x, y, width, height, arc, arc);
     }
   }

--- a/modules/hub/src/test/java/com/jvn/hub/JvnHubDisplayScaleTest.java
+++ b/modules/hub/src/test/java/com/jvn/hub/JvnHubDisplayScaleTest.java
@@ -44,7 +44,7 @@ class JvnHubDisplayScaleTest {
 
   @Test
   void sourceBuildIndicatorUsesTheHubOrangeAccent() {
-    String label = JvnHub.formatVersionLabel("0.3.1");
+    String label = JvnHub.formatVersionLabel("0.4.0");
     if (label.startsWith("<html>")) {
       org.junit.jupiter.api.Assertions.assertTrue(label.contains("color:#ff9933"));
       org.junit.jupiter.api.Assertions.assertTrue(label.contains("Running from source"));

--- a/modules/plugin-api/README.md
+++ b/modules/plugin-api/README.md
@@ -2,7 +2,7 @@
 
 Dependency-light public API for JVN extensions. Plugin projects should compile against this module and avoid dependencies on `core`, `runtime`, or `editor` unless an extension specification explicitly permits one.
 
-The current API contract is `1.0.0`. See [Plugin documentation](../../docs/plugins/README.md).
+The current API contract is `1.1.0`. See [Plugin documentation](../../docs/plugins/README.md).
 
 Generate the annotated API reference with:
 

--- a/modules/plugin-api/src/main/java/com/jvn/plugin/api/PluginCapability.java
+++ b/modules/plugin-api/src/main/java/com/jvn/plugin/api/PluginCapability.java
@@ -9,7 +9,9 @@ public enum PluginCapability {
   /** Permission to register asset importers. */
   ASSET_IMPORTER("asset.importer"),
   /** Permission to observe runtime lifecycle events. */
-  RUNTIME_LISTENER("runtime.listener");
+  RUNTIME_LISTENER("runtime.listener"),
+  /** Permission to contribute named easing curves. */
+  ANIMATION_EASING("animation.easing");
 
   private final String id;
 

--- a/modules/plugin-api/src/main/java/com/jvn/plugin/api/PluginContext.java
+++ b/modules/plugin-api/src/main/java/com/jvn/plugin/api/PluginContext.java
@@ -49,4 +49,10 @@ public interface PluginContext {
    * @return capability-checked owned registries
    */
   PluginRegistries registries();
+  /** Provides the fluent authoring API for new extension families.
+   * @return plugin-owned contribution surface
+   */
+  default PluginContributions contribute() {
+    throw new UnsupportedOperationException("This host does not provide the contribution API");
+  }
 }

--- a/modules/plugin-api/src/main/java/com/jvn/plugin/api/PluginContributions.java
+++ b/modules/plugin-api/src/main/java/com/jvn/plugin/api/PluginContributions.java
@@ -1,0 +1,12 @@
+package com.jvn.plugin.api;
+
+import com.jvn.plugin.api.animation.AnimationContributions;
+
+/** Author-focused entrypoint for contributing extensions. */
+public interface PluginContributions {
+  /**
+   * Returns the plugin-owned animation authoring surface.
+   * @return animation contributions
+   */
+  AnimationContributions animations();
+}

--- a/modules/plugin-api/src/main/java/com/jvn/plugin/api/PluginRegistries.java
+++ b/modules/plugin-api/src/main/java/com/jvn/plugin/api/PluginRegistries.java
@@ -4,6 +4,7 @@ import com.jvn.plugin.api.asset.AssetImporter;
 import com.jvn.plugin.api.editor.EditorTool;
 import com.jvn.plugin.api.runtime.RuntimeListener;
 import com.jvn.plugin.api.script.ScriptCommand;
+import com.jvn.plugin.api.animation.AnimationEasing;
 
 /** Supported extension families. Access is checked against manifest capabilities. */
 public interface PluginRegistries {
@@ -23,4 +24,10 @@ public interface PluginRegistries {
    * @return owned registry
    */
   ExtensionRegistry<RuntimeListener> runtimeListeners();
+  /** Returns contributed easing curves; requires {@code animation.easing} for plugin access.
+   * @return owned registry
+   */
+  default ExtensionRegistry<AnimationEasing> animationEasings() {
+    throw new UnsupportedOperationException("This host does not provide animation easing extensions");
+  }
 }

--- a/modules/plugin-api/src/main/java/com/jvn/plugin/api/animation/AnimationContributions.java
+++ b/modules/plugin-api/src/main/java/com/jvn/plugin/api/animation/AnimationContributions.java
@@ -1,0 +1,14 @@
+package com.jvn.plugin.api.animation;
+
+import com.jvn.plugin.api.Registration;
+
+/** Fluent animation contribution surface owned by the calling plugin. */
+public interface AnimationContributions {
+  /**
+   * Contributes a named easing curve owned by the calling plugin.
+   * @param id stable, qualified script-facing ID
+   * @param easing metadata and evaluator
+   * @return idempotent early-unregistration handle
+   */
+  Registration easing(String id, AnimationEasing easing);
+}

--- a/modules/plugin-api/src/main/java/com/jvn/plugin/api/animation/AnimationEasing.java
+++ b/modules/plugin-api/src/main/java/com/jvn/plugin/api/animation/AnimationEasing.java
@@ -1,0 +1,38 @@
+package com.jvn.plugin.api.animation;
+
+import java.util.List;
+
+/** A named, metadata-rich easing curve contributed by a plugin. */
+public interface AnimationEasing {
+  /**
+   * Returns the author-facing display name.
+   * @return display name
+   */
+  String label();
+  /**
+   * Returns a concise author-facing explanation.
+   * @return explanation or empty text
+   */
+  default String description() { return ""; }
+  /**
+   * Returns the editor catalog category.
+   * @return category
+   */
+  default String category() { return "Plugin"; }
+  /**
+   * Returns optional external documentation.
+   * @return URL or empty text
+   */
+  default String documentationUrl() { return ""; }
+  /**
+   * Returns the accepted numeric inputs.
+   * @return immutable parameter descriptors
+   */
+  default List<AnimationParameter> parameters() { return List.of(); }
+  /**
+   * Evaluates the curve for one sample.
+   * @param frame clamped progress and validated parameters
+   * @return interpolated progress; finite overshoot values are allowed
+   */
+  double evaluate(AnimationEasingFrame frame);
+}

--- a/modules/plugin-api/src/main/java/com/jvn/plugin/api/animation/AnimationEasingDefinition.java
+++ b/modules/plugin-api/src/main/java/com/jvn/plugin/api/animation/AnimationEasingDefinition.java
@@ -1,0 +1,128 @@
+package com.jvn.plugin.api.animation;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.ToDoubleFunction;
+
+/** Fluent builder for authoring an {@link AnimationEasing}. */
+public final class AnimationEasingDefinition {
+  private AnimationEasingDefinition() {}
+
+  /**
+   * Starts an easing definition.
+   * @param label author-facing name
+   * @return a new easing builder
+   */
+  public static Builder easing(String label) { return new Builder(label); }
+
+  /**
+   * Creates an inclusive parameter range.
+   * @param minimum inclusive minimum
+   * @param maximum inclusive maximum
+   * @return validated range
+   */
+  public static Range range(double minimum, double maximum) { return new Range(minimum, maximum); }
+
+  /**
+   * Inclusive numeric parameter range.
+   * @param minimum inclusive minimum
+   * @param maximum inclusive maximum
+   */
+  public record Range(double minimum, double maximum) {
+    /** Validates a finite, ordered range. */
+    public Range {
+      if (!Double.isFinite(minimum) || !Double.isFinite(maximum) || minimum > maximum) {
+        throw new IllegalArgumentException("Invalid animation parameter range");
+      }
+    }
+  }
+
+  /** Fluent builder completed by {@link #evaluate(ToDoubleFunction)}. */
+  public static final class Builder {
+    private final String label;
+    private String description = "";
+    private String category = "Plugin";
+    private String documentationUrl = "";
+    private final List<AnimationParameter> parameters = new ArrayList<>();
+
+    private Builder(String label) {
+      if (label == null || label.isBlank()) throw new IllegalArgumentException("Easing label is required");
+      this.label = label.trim();
+    }
+
+    /**
+     * Sets the author-facing explanation.
+     * @param value explanation
+     * @return this builder
+     */
+    public Builder description(String value) { description = clean(value); return this; }
+    /**
+     * Sets the editor catalog category.
+     * @param value category
+     * @return this builder
+     */
+    public Builder category(String value) { category = clean(value); return this; }
+    /**
+     * Sets optional external documentation.
+     * @param url documentation URL
+     * @return this builder
+     */
+    public Builder documentation(String url) { documentationUrl = clean(url); return this; }
+
+    /**
+     * Adds a numeric parameter using its script name as the display label.
+     * @param name script-facing name
+     * @param defaultValue default value
+     * @param range accepted range
+     * @return this builder
+     */
+    public Builder parameter(String name, double defaultValue, Range range) {
+      return parameter(name, name, "", defaultValue, range);
+    }
+
+    /**
+     * Adds a fully described numeric parameter.
+     * @param name script-facing name
+     * @param parameterLabel author-facing label
+     * @param parameterDescription author-facing explanation
+     * @param defaultValue default value
+     * @param range accepted range
+     * @return this builder
+     */
+    public Builder parameter(
+        String name, String parameterLabel, String parameterDescription,
+        double defaultValue, Range range
+    ) {
+      Objects.requireNonNull(range, "range");
+      AnimationParameter parameter = new AnimationParameter(
+          name, parameterLabel, parameterDescription, defaultValue, range.minimum(), range.maximum());
+      if (parameters.stream().anyMatch(existing -> existing.name().equals(parameter.name()))) {
+        throw new IllegalArgumentException("Duplicate animation parameter: " + parameter.name());
+      }
+      parameters.add(parameter);
+      return this;
+    }
+
+    /**
+     * Completes the immutable easing definition.
+     * @param evaluator pure, fast evaluation function
+     * @return contributed easing contract
+     */
+    public AnimationEasing evaluate(ToDoubleFunction<AnimationEasingFrame> evaluator) {
+      Objects.requireNonNull(evaluator, "evaluator");
+      List<AnimationParameter> snapshot = List.copyOf(parameters);
+      String resolvedCategory = category.isBlank() ? "Plugin" : category;
+      return new AnimationEasing() {
+        @Override public String label() { return label; }
+        @Override public String description() { return description; }
+        @Override public String category() { return resolvedCategory; }
+        @Override public String documentationUrl() { return documentationUrl; }
+        @Override public List<AnimationParameter> parameters() { return snapshot; }
+        @Override public double evaluate(AnimationEasingFrame frame) { return evaluator.applyAsDouble(frame); }
+      };
+    }
+
+    private static String clean(String value) { return value == null ? "" : value.trim(); }
+  }
+}

--- a/modules/plugin-api/src/main/java/com/jvn/plugin/api/animation/AnimationEasingFrame.java
+++ b/modules/plugin-api/src/main/java/com/jvn/plugin/api/animation/AnimationEasingFrame.java
@@ -1,0 +1,27 @@
+package com.jvn.plugin.api.animation;
+
+import java.util.Map;
+
+/**
+ * Immutable input supplied while evaluating a contributed easing curve.
+ * @param progress normalized input progress, clamped to {@code [0, 1]}
+ * @param parameters immutable resolved parameter values
+ */
+public record AnimationEasingFrame(double progress, Map<String, Double> parameters) {
+  /** Normalizes an evaluation frame. */
+  public AnimationEasingFrame {
+    progress = Math.max(0.0, Math.min(1.0, progress));
+    parameters = parameters == null ? Map.of() : Map.copyOf(parameters);
+  }
+
+  /** Returns a resolved parameter value.
+   * @param name parameter name
+   * @return configured or default value supplied by the host
+   * @throws IllegalArgumentException when the extension did not declare the name
+   */
+  public double parameter(String name) {
+    Double value = parameters.get(name);
+    if (value == null) throw new IllegalArgumentException("Unknown animation parameter: " + name);
+    return value;
+  }
+}

--- a/modules/plugin-api/src/main/java/com/jvn/plugin/api/animation/AnimationParameter.java
+++ b/modules/plugin-api/src/main/java/com/jvn/plugin/api/animation/AnimationParameter.java
@@ -1,0 +1,40 @@
+package com.jvn.plugin.api.animation;
+
+/**
+ * Describes one named numeric input accepted by an animation extension.
+ * @param name stable script-facing parameter name
+ * @param label author-facing display label
+ * @param description concise author-facing explanation
+ * @param defaultValue value used when scripts omit the parameter
+ * @param minimum inclusive minimum
+ * @param maximum inclusive maximum
+ */
+public record AnimationParameter(
+    String name,
+    String label,
+    String description,
+    double defaultValue,
+    double minimum,
+    double maximum
+) {
+  /** Validates and normalizes a parameter descriptor. */
+  public AnimationParameter {
+    name = requireToken(name, "Parameter name");
+    label = label == null || label.isBlank() ? name : label.trim();
+    description = description == null ? "" : description.trim();
+    if (!Double.isFinite(defaultValue) || !Double.isFinite(minimum) || !Double.isFinite(maximum)) {
+      throw new IllegalArgumentException("Animation parameter values must be finite");
+    }
+    if (minimum > maximum) throw new IllegalArgumentException("Parameter minimum exceeds maximum: " + name);
+    if (defaultValue < minimum || defaultValue > maximum) {
+      throw new IllegalArgumentException("Parameter default is outside its range: " + name);
+    }
+  }
+
+  private static String requireToken(String value, String label) {
+    if (value == null || !value.matches("[A-Za-z_][A-Za-z0-9_-]*")) {
+      throw new IllegalArgumentException(label + " must be an identifier");
+    }
+    return value.trim().toLowerCase(java.util.Locale.ROOT).replace('-', '_');
+  }
+}

--- a/modules/plugin-api/src/main/java/com/jvn/plugin/api/animation/package-info.java
+++ b/modules/plugin-api/src/main/java/com/jvn/plugin/api/animation/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Dependency-light contracts for named animation contributions.
+ *
+ * <p>Evaluators receive immutable, validated frame data and never receive engine, scene, renderer,
+ * or editor implementation objects.</p>
+ */
+package com.jvn.plugin.api.animation;

--- a/modules/plugin-api/src/main/java/com/jvn/plugin/api/package-info.java
+++ b/modules/plugin-api/src/main/java/com/jvn/plugin/api/package-info.java
@@ -3,7 +3,7 @@
  *
  * <p>Plugin authors implement {@link com.jvn.plugin.api.JvnPlugin}, declare capabilities in
  * {@code jvn-plugin.json}, and register extensions through
- * {@link com.jvn.plugin.api.PluginContext#registries()}. Types outside {@code com.jvn.plugin.api}
+ * {@link com.jvn.plugin.api.PluginContext#contribute()}. Types outside {@code com.jvn.plugin.api}
  * are not covered by the plugin compatibility policy.</p>
  *
  * <p>The host provides lifecycle isolation and registration ownership, but plugin code executes in

--- a/modules/plugin-example/README.md
+++ b/modules/plugin-example/README.md
@@ -1,6 +1,6 @@
 # JVN example plugin
 
-Reference plugin demonstrating script commands, editor tools, and runtime listeners without accessing engine or editor internals.
+Reference plugin demonstrating script commands, editor tools, runtime listeners, and a named easing extension without accessing engine or editor internals.
 
 ```bash
 ./gradlew :plugin-example:jar
@@ -12,6 +12,12 @@ After restarting JVN, run the editor action under **Tools → Plugins**, or call
 
 ```vns
 [plugin hello.greet Ada]
+```
+
+The plugin also contributes `hello.elastic-pop`, available in Puppeteer's easing catalog and timeline source:
+
+```jes
+easing: "hello.elastic-pop(overshoot: 1.4, settle: 0.8)"
 ```
 
 See [Plugin authoring](../../docs/plugins/authoring.md) for a guided implementation.

--- a/modules/plugin-example/src/main/java/com/jvn/example/plugin/HelloPlugin.java
+++ b/modules/plugin-example/src/main/java/com/jvn/example/plugin/HelloPlugin.java
@@ -7,6 +7,8 @@ import com.jvn.plugin.api.editor.EditorToolContext;
 import com.jvn.plugin.api.runtime.RuntimeEvent;
 import com.jvn.plugin.api.runtime.RuntimeListener;
 import com.jvn.plugin.api.script.ScriptCommandResult;
+import static com.jvn.plugin.api.animation.AnimationEasingDefinition.easing;
+import static com.jvn.plugin.api.animation.AnimationEasingDefinition.range;
 
 /** Small, intentionally framework-neutral reference plugin. */
 public final class HelloPlugin implements JvnPlugin {
@@ -15,6 +17,19 @@ public final class HelloPlugin implements JvnPlugin {
   @Override
   public void initialize(PluginContext context) {
     this.context = context;
+    context.contribute().animations().easing("hello.elastic-pop",
+        easing("Elastic Pop")
+            .description("A playful overshooting entrance curve from the example plugin.")
+            .category("Expressive")
+            .parameter("overshoot", 1.2, range(0.0, 3.0))
+            .parameter("settle", 0.7, range(0.1, 2.0))
+            .evaluate(frame -> {
+              double t = frame.progress();
+              double overshoot = frame.parameter("overshoot");
+              double settle = frame.parameter("settle");
+              return 1.0 - Math.exp(-6.0 * settle * t)
+                  * Math.cos((Math.PI * 2.0 + overshoot) * t);
+            }));
     context.registries().scriptCommands().register("hello.greet", invocation -> {
       String name = invocation.arguments().isEmpty() ? "world" : invocation.arguments().get(0);
       return new ScriptCommandResult(true, "Hello, " + name + "!", java.util.Map.of("plugin.lastGreeting", name));

--- a/modules/plugin-example/src/main/resources/jvn-plugin.json
+++ b/modules/plugin-example/src/main/resources/jvn-plugin.json
@@ -2,13 +2,14 @@
   "id": "com.jvn.example.hello",
   "name": "JVN Hello Plugin",
   "version": "1.0.0",
-  "jvnApi": "1.x",
+  "jvnApi": ">=1.1.0 <2.0.0",
   "entrypoint": "com.jvn.example.plugin.HelloPlugin",
   "description": "Reference implementation for the supported JVN plugin extension points.",
   "vendor": "Java Vector Nexus",
   "capabilities": [
     "script.command",
     "editor.tool",
-    "runtime.listener"
+    "runtime.listener",
+    "animation.easing"
   ]
 }

--- a/modules/plugin-runtime/src/main/java/com/jvn/plugin/runtime/DefaultPluginContext.java
+++ b/modules/plugin-runtime/src/main/java/com/jvn/plugin/runtime/DefaultPluginContext.java
@@ -4,6 +4,7 @@ import com.jvn.plugin.api.PluginContext;
 import com.jvn.plugin.api.PluginDescriptor;
 import com.jvn.plugin.api.PluginEnvironment;
 import com.jvn.plugin.api.PluginRegistries;
+import com.jvn.plugin.api.PluginContributions;
 import java.nio.file.Path;
 import java.util.Map;
 import org.slf4j.Logger;
@@ -16,5 +17,6 @@ record DefaultPluginContext(
     Path projectDirectory,
     Map<String, String> configuration,
     Logger logger,
-    PluginRegistries registries
+    PluginRegistries registries,
+    PluginContributions contribute
 ) implements PluginContext {}

--- a/modules/plugin-runtime/src/main/java/com/jvn/plugin/runtime/DefaultPluginRegistries.java
+++ b/modules/plugin-runtime/src/main/java/com/jvn/plugin/runtime/DefaultPluginRegistries.java
@@ -4,6 +4,9 @@ import com.jvn.plugin.api.ExtensionRegistry;
 import com.jvn.plugin.api.PluginRegistries;
 import com.jvn.plugin.api.PluginCapability;
 import com.jvn.plugin.api.PluginDescriptor;
+import com.jvn.plugin.api.PluginContributions;
+import com.jvn.plugin.api.animation.AnimationEasing;
+import com.jvn.plugin.api.animation.AnimationParameter;
 import com.jvn.plugin.api.asset.AssetImporter;
 import com.jvn.plugin.api.editor.EditorTool;
 import com.jvn.plugin.api.runtime.RuntimeListener;
@@ -14,6 +17,7 @@ public final class DefaultPluginRegistries {
   private final OwnedExtensionRegistry<EditorTool> tools = new OwnedExtensionRegistry<>();
   private final OwnedExtensionRegistry<AssetImporter> importers = new OwnedExtensionRegistry<>();
   private final OwnedExtensionRegistry<RuntimeListener> listeners = new OwnedExtensionRegistry<>();
+  private final OwnedExtensionRegistry<AnimationEasing> easings = new OwnedExtensionRegistry<>();
 
   PluginRegistries forPlugin(PluginDescriptor descriptor) {
     String pluginId = descriptor.id();
@@ -22,6 +26,21 @@ public final class DefaultPluginRegistries {
       @Override public ExtensionRegistry<EditorTool> editorTools() { require(PluginCapability.EDITOR_TOOL); return tools.forPlugin(pluginId); }
       @Override public ExtensionRegistry<AssetImporter> assetImporters() { require(PluginCapability.ASSET_IMPORTER); return importers.forPlugin(pluginId); }
       @Override public ExtensionRegistry<RuntimeListener> runtimeListeners() { require(PluginCapability.RUNTIME_LISTENER); return listeners.forPlugin(pluginId); }
+      @Override public ExtensionRegistry<AnimationEasing> animationEasings() {
+        require(PluginCapability.ANIMATION_EASING);
+        ExtensionRegistry<AnimationEasing> owned = easings.forPlugin(pluginId);
+        return new ExtensionRegistry<>() {
+          @Override public com.jvn.plugin.api.Registration register(String id, AnimationEasing easing) {
+            if (id == null || !id.matches("[A-Za-z_][A-Za-z0-9_-]*(?:\\.[A-Za-z_][A-Za-z0-9_-]*)+")) {
+              throw new IllegalArgumentException("Animation easing id must be a qualified identifier: " + id);
+            }
+            validateEasing(easing);
+            return owned.register(id, easing);
+          }
+          @Override public java.util.Optional<AnimationEasing> find(String id) { return owned.find(id); }
+          @Override public java.util.List<com.jvn.plugin.api.ExtensionEntry<AnimationEasing>> entries() { return owned.entries(); }
+        };
+      }
       private void require(PluginCapability capability) {
         if (!descriptor.capabilities().contains(capability)) {
           throw new IllegalStateException("Plugin " + pluginId + " did not declare capability " + capability.id());
@@ -36,7 +55,13 @@ public final class DefaultPluginRegistries {
       @Override public ExtensionRegistry<EditorTool> editorTools() { return tools.forPlugin("host"); }
       @Override public ExtensionRegistry<AssetImporter> assetImporters() { return importers.forPlugin("host"); }
       @Override public ExtensionRegistry<RuntimeListener> runtimeListeners() { return listeners.forPlugin("host"); }
+      @Override public ExtensionRegistry<AnimationEasing> animationEasings() { return easings.forPlugin("host"); }
     };
+  }
+
+  PluginContributions contributionsFor(PluginDescriptor descriptor) {
+    PluginRegistries owned = forPlugin(descriptor);
+    return () -> (id, easing) -> owned.animationEasings().register(id, easing);
   }
 
   void removePlugin(String pluginId) {
@@ -44,5 +69,22 @@ public final class DefaultPluginRegistries {
     tools.removePlugin(pluginId);
     importers.removePlugin(pluginId);
     listeners.removePlugin(pluginId);
+    easings.removePlugin(pluginId);
+  }
+
+  private static void validateEasing(AnimationEasing easing) {
+    if (easing == null) throw new IllegalArgumentException("Animation easing is required");
+    if (easing.label() == null || easing.label().isBlank()) {
+      throw new IllegalArgumentException("Animation easing label is required");
+    }
+    java.util.List<AnimationParameter> parameters = easing.parameters();
+    if (parameters == null) throw new IllegalArgumentException("Animation easing parameters are required");
+    java.util.Set<String> names = new java.util.LinkedHashSet<>();
+    for (AnimationParameter parameter : parameters) {
+      if (parameter == null) throw new IllegalArgumentException("Animation easing parameters cannot contain null");
+      if (!names.add(parameter.name())) {
+        throw new IllegalArgumentException("Duplicate animation easing parameter: " + parameter.name());
+      }
+    }
   }
 }

--- a/modules/plugin-runtime/src/main/java/com/jvn/plugin/runtime/PluginHost.java
+++ b/modules/plugin-runtime/src/main/java/com/jvn/plugin/runtime/PluginHost.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
 
 /** Discovers, validates, starts, and stops plugins for one JVN process. */
 public final class PluginHost implements AutoCloseable {
-  public static final String API_VERSION = "1.0.0";
+  public static final String API_VERSION = "1.1.0";
   private static final Logger log = LoggerFactory.getLogger(PluginHost.class);
 
   private final String jvnVersion;
@@ -245,7 +245,8 @@ public final class PluginHost implements AutoCloseable {
       Map<String, String> configuration = loadConfiguration(dataDirectory.resolve("config.properties"));
       Logger pluginLogger = LoggerFactory.getLogger("jvn.plugin." + descriptor.id());
       PluginContext context = new DefaultPluginContext(descriptor, environment, jvnVersion, dataDirectory,
-          projectDirectory, configuration, pluginLogger, registries.forPlugin(descriptor));
+          projectDirectory, configuration, pluginLogger, registries.forPlugin(descriptor),
+          registries.contributionsFor(descriptor));
       Active loaded = new Active(candidate);
       active.put(descriptor.id(), loaded);
       candidate.plugin.initialize(context);

--- a/modules/plugin-runtime/src/test/java/com/jvn/plugin/runtime/PluginHostTest.java
+++ b/modules/plugin-runtime/src/test/java/com/jvn/plugin/runtime/PluginHostTest.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import static com.jvn.plugin.api.animation.AnimationEasingDefinition.easing;
 
 class PluginHostTest {
   @TempDir Path temp;
@@ -69,6 +70,41 @@ class PluginHostTest {
     host.start();
     assertTrue(host.diagnostics().stream().anyMatch(d -> d.code().equals("dependency-missing")));
     assertEquals(PluginState.DISCOVERED, host.plugins().get(0).state());
+  }
+
+  @Test
+  void ownsFluentAnimationContributionsAndCleansThemUp() {
+    PluginHost host = host();
+    host.addBundled(provider(
+        descriptor("motion", List.of(), Set.of(PluginCapability.ANIMATION_EASING)),
+        new JvnPlugin() {
+          @Override public void initialize(PluginContext context) {
+            context.contribute().animations().easing("motion.smooth",
+                easing("Smooth").evaluate(frame -> frame.progress() * frame.progress()));
+          }
+        }));
+
+    host.start();
+    assertEquals("Smooth", host.registries().animationEasings()
+        .find("motion.smooth").orElseThrow().label());
+    host.close();
+    assertTrue(host.registries().animationEasings().entries().isEmpty());
+  }
+
+  @Test
+  void rejectsUnqualifiedAnimationIdsDuringInitialization() {
+    PluginHost host = host();
+    host.addBundled(provider(
+        descriptor("motion", List.of(), Set.of(PluginCapability.ANIMATION_EASING)),
+        new JvnPlugin() {
+          @Override public void initialize(PluginContext context) {
+            context.contribute().animations().easing("smooth",
+                easing("Smooth").evaluate(frame -> frame.progress()));
+          }
+        }));
+    host.start();
+    assertEquals(PluginState.FAILED, host.plugins().get(0).state());
+    assertTrue(host.diagnostics().stream().anyMatch(d -> d.code().equals("initialize-failed")));
   }
 
   private PluginHost host() {

--- a/modules/runtime/src/main/java/com/jvn/runtime/JvnApp.java
+++ b/modules/runtime/src/main/java/com/jvn/runtime/JvnApp.java
@@ -236,6 +236,7 @@ public class JvnApp {
         .projectDirectory(assetRootDir == null ? null : assetRootDir.toPath())
         .build();
     pluginHost.discoverAndStart();
+    com.jvn.core.animation.EasingExtensions.install(pluginHost.registries().animationEasings());
     Runtime.getRuntime().addShutdownHook(new Thread(pluginHost::close, "jvn-plugin-shutdown"));
     if (!pluginHost.plugins().isEmpty()) {
       log.info("Plugins -> discovered={}, diagnostics={}", pluginHost.plugins().size(), pluginHost.diagnostics().size());


### PR DESCRIPTION
## What changed

- adds Plugin API 1.1 and the fluent `context.contribute().animations().easing(...)` authoring surface
- adds metadata-rich, parameterized easing definitions with capability enforcement and owned lifecycle cleanup
- carries qualified easing IDs through DSL parsing, timeline data, runtime playback, and editor previews
- discovers contributed curves in the Puppeteer easing catalog
- expands the example plugin and adds end-to-end runtime, parser, lifecycle, and editor tests
- adds comprehensive animation-extension documentation plus the Facets and Motifs authoring guide

## Why

Extensibility should be a defining engine capability. Animation is the first vertical slice because it crosses runtime behavior, scripting, tooling, previews, and authoring ergonomics while retaining a narrow, stable plugin contract.

## Developer impact

Plugins targeting API 1.1 can declare `animation.easing` and register qualified curve IDs such as `studio.elastic-pop`. Existing Plugin API implementations retain compatibility through default methods.

## Validation

- `./gradlew test :plugin-api:javadoc`
- `node scripts/doc-lint.mjs --strict`
- Plugin API Javadocs verified with zero warnings
- `git diff --check`