### PR TITLE
Redesign VNS tools with Aero controls

### DIFF
--- a/docs/editor/core/editor.md
+++ b/docs/editor/core/editor.md
@@ -163,11 +163,16 @@ This matters for workflow-critical utilities such as **Build & Publish...**, **S
   - run from the project entry point (`Shift+F5`)
   - open the label/symbol navigator (`Cmd/Ctrl+Shift+O`)
   - open the VNS snippet picker (`Cmd/Ctrl+J`)
+  - find text in the current script (`Cmd/Ctrl+F`)
+  - search all editor actions in the command palette (`Cmd/Ctrl+Shift+P`)
+  - toggle line wrapping (`Cmd/Ctrl+Shift+W`)
+  - compare the current buffer with the saved version (`Cmd/Ctrl+Shift+D`)
+  - open the diagnostics panel
   - open the runtime preview in a separate window
   - open the standard `?` help panel for these controls
-- native Aero command artwork shared with Build Project and Run Project, transparent
-  42 × 40 hit targets, icon-owned hover glow, accessible action names, and distinct
-  primary silhouettes for label-run, entry-run, symbol search, snippets, and preview
+- native Aero command artwork shared with Build Project and Run Project, grouped
+  44 × 42 hit targets, glass-and-metal hover chrome, accessible action names, and
+  distinct silhouettes for each run, navigation, authoring, review, and preview action
 - all text authoring stays in the main tabbed editor; the legacy Text Editor
   workspace and standalone text window are no longer exposed
 - lint for:

--- a/modules/editor/src/main/java/com/jvn/editor/EditorApp.java
+++ b/modules/editor/src/main/java/com/jvn/editor/EditorApp.java
@@ -3964,6 +3964,7 @@ public class EditorApp extends Application {
       }
     });
     editor.setOnStatus(s -> status.setText(s));
+    editor.setOnOpenDiagnostics(this::selectVnsDiagnosticsTab);
     editor.setCommandStack(commands);
     editor.setOnDiagnosticsTextChanged(text -> {
       if (editor != getActiveFileTab()) return;

--- a/modules/editor/src/main/java/com/jvn/editor/ui/AeroIcon.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/AeroIcon.java
@@ -16,6 +16,8 @@ import javafx.scene.paint.RadialGradient;
 import javafx.scene.paint.Stop;
 import javafx.scene.shape.Circle;
 import javafx.scene.shape.Ellipse;
+import javafx.scene.shape.Arc;
+import javafx.scene.shape.ArcType;
 import javafx.scene.shape.Line;
 import javafx.scene.shape.Polygon;
 import javafx.scene.shape.Polyline;
@@ -36,7 +38,8 @@ public final class AeroIcon extends StackPane {
     PUPPETEER, SCRIPT_EDITOR, SETTINGS,
     NEW_PROJECT, OPEN_PROJECT, RUN, BUILD, REFRESH, ENTRY_SCRIPT, MANIFEST,
     README, DOCUMENTATION, REVEAL, ARROW_BACK, HELP, NO_PROJECT,
-    VNS_RUN_LABEL, VNS_RUN_ENTRY, VNS_SYMBOLS, VNS_SNIPPET, VNS_PREVIEW
+    VNS_RUN_LABEL, VNS_RUN_ENTRY, VNS_SYMBOLS, VNS_SNIPPET, VNS_FIND,
+    VNS_COMMANDS, VNS_WORD_WRAP, VNS_DIFF, VNS_DIAGNOSTICS, VNS_PREVIEW
   }
 
   private record Palette(Color top, Color bottom, Color edge) {}
@@ -48,7 +51,8 @@ public final class AeroIcon extends StackPane {
   private AeroIcon(Kind kind, double size) {
     this.kind = kind == null ? Kind.PROJECT : kind;
     this.iconSize = clampSize(size);
-    Region glyph = glyphFor(this.kind, Math.max(10, iconSize * 0.72));
+    double artworkScale = isVnsCommand(this.kind) ? 0.88 : 0.72;
+    Region glyph = glyphFor(this.kind, Math.max(10, iconSize * artworkScale));
     glyph.setMouseTransparent(true);
 
     setMinSize(iconSize, iconSize);
@@ -133,7 +137,8 @@ public final class AeroIcon extends StackPane {
       case BUILD -> sized(CssIcon.download(color), size);
       case REFRESH -> sized(CssIcon.refresh(color), size);
       case ENTRY_SCRIPT -> sized(CssIcon.speech(color), size);
-      case VNS_RUN_LABEL, VNS_RUN_ENTRY, VNS_SYMBOLS, VNS_SNIPPET, VNS_PREVIEW ->
+      case VNS_RUN_LABEL, VNS_RUN_ENTRY, VNS_SYMBOLS, VNS_SNIPPET, VNS_FIND,
+          VNS_COMMANDS, VNS_WORD_WRAP, VNS_DIFF, VNS_DIAGNOSTICS, VNS_PREVIEW ->
           vnsCommandGlyph(kind, size, palette);
       case MANIFEST, README -> sized(CssIcon.document(color), size);
       case ARROW_BACK -> sized(CssIcon.arrowLeft(color), size);
@@ -157,6 +162,11 @@ public final class AeroIcon extends StackPane {
         || kind == Kind.VNS_RUN_ENTRY
         || kind == Kind.VNS_SYMBOLS
         || kind == Kind.VNS_SNIPPET
+        || kind == Kind.VNS_FIND
+        || kind == Kind.VNS_COMMANDS
+        || kind == Kind.VNS_WORD_WRAP
+        || kind == Kind.VNS_DIFF
+        || kind == Kind.VNS_DIAGNOSTICS
         || kind == Kind.VNS_PREVIEW;
   }
 
@@ -166,6 +176,11 @@ public final class AeroIcon extends StackPane {
       case VNS_RUN_ENTRY -> vnsRunEntryGlyph(size, palette);
       case VNS_SYMBOLS -> vnsSymbolsGlyph(size, palette);
       case VNS_SNIPPET -> vnsSnippetGlyph(size, palette);
+      case VNS_FIND -> vnsFindGlyph(size, palette);
+      case VNS_COMMANDS -> vnsCommandsGlyph(size, palette);
+      case VNS_WORD_WRAP -> vnsWordWrapGlyph(size, palette);
+      case VNS_DIFF -> vnsDiffGlyph(size, palette);
+      case VNS_DIAGNOSTICS -> vnsDiagnosticsGlyph(size, palette);
       case VNS_PREVIEW -> vnsPreviewGlyph(size, palette);
       default -> throw new IllegalArgumentException("Not a VNS command icon: " + kind);
     };
@@ -173,128 +188,362 @@ public final class AeroIcon extends StackPane {
 
   private static Region vnsRunLabelGlyph(double size, Palette palette) {
     Pane art = vnsCanvas(size);
-    Polygon tag = new Polygon(
-        size * 0.05, size * 0.24,
-        size * 0.58, size * 0.24,
-        size * 0.78, size * 0.50,
-        size * 0.58, size * 0.76,
-        size * 0.05, size * 0.76);
-    polishShape(tag, palette, size);
-    Circle pin = new Circle(size * 0.20, size * 0.50, size * 0.065, Color.web("#f4fffd"));
-    pin.setEffect(new DropShadow(size * 0.08, Color.web("#63e8cf")));
-    Polygon play = new Polygon(
-        size * 0.48, size * 0.30,
-        size * 0.96, size * 0.50,
-        size * 0.48, size * 0.70);
-    play.setFill(commandGradient("#effff4", "#48d983"));
-    play.setStroke(Color.web("#f2fff6"));
-    play.setStrokeWidth(Math.max(0.7, size * 0.045));
-    play.setEffect(new DropShadow(size * 0.13, Color.web("#25b967")));
-    art.getChildren().addAll(tag, pin, play, vnsGlint(size, 0.12, 0.31));
+    Rectangle page = vnsDocument(size, palette, 0.05, 0.08, 0.65, 0.82);
+    Polygon fold = vnsPageFold(size, palette, 0.49, 0.08, 0.21);
+    Line ruleTop = styledLine(
+        size * 0.16, size * 0.26, size * 0.54, size * 0.26,
+        Color.rgb(236, 255, 252, 0.76), Math.max(0.7, size * 0.035));
+    Line ruleBottom = styledLine(
+        size * 0.16, size * 0.70, size * 0.49, size * 0.70,
+        Color.rgb(204, 255, 246, 0.52), Math.max(0.6, size * 0.03));
+
+    Polygon label = new Polygon(
+        size * 0.10, size * 0.36,
+        size * 0.55, size * 0.36,
+        size * 0.68, size * 0.50,
+        size * 0.55, size * 0.64,
+        size * 0.10, size * 0.64);
+    label.setFill(commandGradient("#45d7c3", "#116f6b"));
+    label.setStroke(Color.web("#d8fff8"));
+    label.setStrokeWidth(Math.max(0.7, size * 0.035));
+    label.setEffect(new InnerShadow(Math.max(0.8, size * 0.05), Color.rgb(0, 54, 54, 0.72)));
+    Circle pin = new Circle(size * 0.19, size * 0.50, size * 0.055, Color.web("#f5fffc"));
+    pin.setStroke(Color.web("#55cdbd"));
+    pin.setStrokeWidth(Math.max(0.4, size * 0.02));
+
+    StackPane playOrb = vnsOrb(size, "#effff4", "#35c66f", "#12643d");
+    playOrb.resizeRelocate(size * 0.58, size * 0.53, size * 0.39, size * 0.39);
+    Polygon play = playTriangle(size * 0.16, Color.WHITE);
+    playOrb.getChildren().add(play);
+    art.getChildren().addAll(page, fold, ruleTop, ruleBottom, label, pin, playOrb);
     return art;
   }
 
   private static Region vnsRunEntryGlyph(double size, Palette palette) {
     Pane art = vnsCanvas(size);
-    Line pole = styledLine(size * 0.16, size * 0.10, size * 0.16, size * 0.90,
-        Color.web("#eaf8f0"), Math.max(1.2, size * 0.075));
+    Line poleShadow = styledLine(
+        size * 0.17, size * 0.09, size * 0.17, size * 0.91,
+        Color.rgb(0, 28, 20, 0.72), Math.max(2.2, size * 0.11));
+    Line pole = styledLine(size * 0.15, size * 0.07, size * 0.15, size * 0.91,
+        Color.web("#f3fff8"), Math.max(1.1, size * 0.06));
     Polygon flag = new Polygon(
-        size * 0.18, size * 0.14,
-        size * 0.72, size * 0.25,
-        size * 0.18, size * 0.48);
-    polishShape(flag, palette, size);
-    Polygon play = new Polygon(
-        size * 0.36, size * 0.45,
-        size * 0.94, size * 0.68,
-        size * 0.36, size * 0.91);
-    play.setFill(commandGradient("#f1fff5", "#4bd883"));
-    play.setStroke(Color.web("#f3fff6"));
-    play.setStrokeWidth(Math.max(0.7, size * 0.045));
-    play.setEffect(new DropShadow(size * 0.13, Color.web("#2fbb6c")));
-    art.getChildren().addAll(pole, flag, play, vnsGlint(size, 0.27, 0.20));
+        size * 0.18, size * 0.11,
+        size * 0.78, size * 0.18,
+        size * 0.67, size * 0.34,
+        size * 0.78, size * 0.49,
+        size * 0.18, size * 0.43);
+    flag.setFill(commandGradient("#b8f5cb", "#23814b"));
+    flag.setStroke(Color.web("#e8fff0"));
+    flag.setStrokeWidth(Math.max(0.8, size * 0.04));
+    flag.setEffect(new InnerShadow(Math.max(0.8, size * 0.05), Color.rgb(7, 72, 36, 0.64)));
+    Line seam = styledLine(
+        size * 0.46, size * 0.15, size * 0.46, size * 0.46,
+        Color.rgb(234, 255, 241, 0.54), Math.max(0.5, size * 0.025));
+
+    StackPane playOrb = vnsOrb(size, "#f4fff7", "#42ce78", "#12613b");
+    playOrb.resizeRelocate(size * 0.43, size * 0.53, size * 0.46, size * 0.46);
+    playOrb.getChildren().add(playTriangle(size * 0.19, Color.WHITE));
+    art.getChildren().addAll(poleShadow, pole, flag, seam, playOrb);
     return art;
   }
 
   private static Region vnsSymbolsGlyph(double size, Palette palette) {
     Pane art = vnsCanvas(size);
-    Text at = new Text("@");
-    at.setFont(Font.font("System", FontWeight.BOLD, size * 0.70));
-    at.setFill(commandGradient(toCss(palette.edge()), toCss(palette.bottom())));
-    at.setStroke(palette.edge().deriveColor(0, 0.7, 0.72, 0.9));
-    at.setStrokeWidth(Math.max(0.35, size * 0.022));
-    at.relocate(size * 0.01, size * 0.03);
+    Rectangle index = new Rectangle(size * 0.08, size * 0.12, size * 0.66, size * 0.74);
+    index.setArcWidth(size * 0.12);
+    index.setArcHeight(size * 0.12);
+    index.setFill(commandGradient("#a7e9ff", "#1e5b91"));
+    index.setStroke(Color.web("#e1f8ff"));
+    index.setStrokeWidth(Math.max(0.8, size * 0.04));
+    index.setEffect(new InnerShadow(Math.max(1, size * 0.06), Color.rgb(8, 40, 70, 0.74)));
 
-    Circle lens = new Circle(size * 0.73, size * 0.65, size * 0.145, Color.rgb(23, 32, 40, 0.72));
-    lens.setStroke(Color.web("#ffd079"));
-    lens.setStrokeWidth(Math.max(1.05, size * 0.06));
-    lens.setEffect(new DropShadow(size * 0.09, Color.web("#d58a28")));
+    for (int i = 0; i < 3; i++) {
+      Rectangle tab = new Rectangle(
+          size * 0.68, size * (0.20 + i * 0.17), size * 0.13, size * 0.10);
+      tab.setArcWidth(size * 0.04);
+      tab.setArcHeight(size * 0.04);
+      tab.setFill(i == 1 ? Color.web("#ffd470") : Color.web("#7ed9f7"));
+      tab.setStroke(Color.rgb(235, 250, 255, 0.78));
+      tab.setStrokeWidth(Math.max(0.35, size * 0.018));
+      art.getChildren().add(tab);
+    }
+
+    Text at = new Text("@");
+    at.setFont(Font.font("System", FontWeight.BOLD, size * 0.57));
+    at.setFill(commandGradient("#f4fbff", "#74cfee"));
+    at.setStroke(Color.web("#174c77"));
+    at.setStrokeWidth(Math.max(0.35, size * 0.022));
+    at.relocate(size * 0.15, size * 0.16);
+
+    Circle lens = new Circle(size * 0.70, size * 0.69, size * 0.17,
+        new RadialGradient(
+            0, 0, 0.35, 0.30, 0.86, true, CycleMethod.NO_CYCLE,
+            new Stop(0, Color.rgb(225, 249, 255, 0.72)),
+            new Stop(0.62, Color.rgb(55, 134, 175, 0.46)),
+            new Stop(1, Color.rgb(12, 43, 67, 0.80))));
+    lens.setStroke(Color.web("#ffd886"));
+    lens.setStrokeWidth(Math.max(1.1, size * 0.055));
+    lens.setEffect(new DropShadow(size * 0.10, Color.rgb(0, 0, 0, 0.72)));
     Line handle = styledLine(
-        size * 0.83, size * 0.75, size * 0.94, size * 0.87,
-        Color.web("#ffe6ad"), Math.max(1.1, size * 0.062));
-    art.getChildren().addAll(at, lens, handle, vnsGlint(size, 0.68, 0.60));
+        size * 0.82, size * 0.81, size * 0.94, size * 0.93,
+        Color.web("#ffd886"), Math.max(1.5, size * 0.075));
+    art.getChildren().add(0, index);
+    art.getChildren().addAll(at, lens, handle, vnsGlint(size, 0.64, 0.63));
     return art;
   }
 
   private static Region vnsSnippetGlyph(double size, Palette palette) {
     Pane art = vnsCanvas(size);
+    Rectangle page = vnsDocument(size, palette, 0.05, 0.08, 0.70, 0.82);
+    Polygon fold = vnsPageFold(size, palette, 0.52, 0.08, 0.23);
     Polyline left = new Polyline(
-        size * 0.31, size * 0.18,
-        size * 0.07, size * 0.50,
-        size * 0.31, size * 0.82);
+        size * 0.33, size * 0.33,
+        size * 0.18, size * 0.49,
+        size * 0.33, size * 0.65);
     Polyline right = new Polyline(
-        size * 0.53, size * 0.18,
-        size * 0.77, size * 0.50,
-        size * 0.53, size * 0.82);
+        size * 0.46, size * 0.33,
+        size * 0.61, size * 0.49,
+        size * 0.46, size * 0.65);
     for (Polyline bracket : new Polyline[] {left, right}) {
       bracket.setFill(Color.TRANSPARENT);
-      bracket.setStroke(palette.edge());
-      bracket.setStrokeWidth(Math.max(1.7, size * 0.10));
+      bracket.setStroke(Color.web("#f1edff"));
+      bracket.setStrokeWidth(Math.max(1.5, size * 0.075));
       bracket.setStrokeLineCap(StrokeLineCap.ROUND);
       bracket.setStrokeLineJoin(StrokeLineJoin.ROUND);
-      bracket.setEffect(new DropShadow(size * 0.11, palette.bottom()));
+      bracket.setEffect(new DropShadow(size * 0.08, Color.web("#3d2b7a")));
     }
-    Circle plusCore = new Circle(size * 0.79, size * 0.72, size * 0.20,
-        commandGradient("#ffe7a9", "#bc6d22"));
-    plusCore.setStroke(Color.web("#fff3d1"));
-    plusCore.setStrokeWidth(Math.max(0.7, size * 0.04));
+    StackPane plusOrb = vnsOrb(size, "#fff4c4", "#e69a35", "#8c4715");
+    plusOrb.resizeRelocate(size * 0.59, size * 0.58, size * 0.38, size * 0.38);
     Line plusH = styledLine(
-        size * 0.69, size * 0.72, size * 0.89, size * 0.72,
-        Color.WHITE, Math.max(1.2, size * 0.075));
+        0, size * 0.19, size * 0.18, size * 0.19,
+        Color.WHITE, Math.max(1.2, size * 0.065));
     Line plusV = styledLine(
-        size * 0.79, size * 0.62, size * 0.79, size * 0.82,
-        Color.WHITE, Math.max(1.2, size * 0.075));
-    art.getChildren().addAll(left, right, plusCore, plusH, plusV);
+        size * 0.09, size * 0.10, size * 0.09, size * 0.28,
+        Color.WHITE, Math.max(1.2, size * 0.065));
+    plusOrb.getChildren().addAll(plusH, plusV);
+    art.getChildren().addAll(page, fold, left, right, plusOrb);
+    return art;
+  }
+
+  private static Region vnsFindGlyph(double size, Palette palette) {
+    Pane art = vnsCanvas(size);
+    Rectangle page = vnsDocument(size, palette, 0.05, 0.08, 0.66, 0.82);
+    Polygon fold = vnsPageFold(size, palette, 0.49, 0.08, 0.22);
+    for (int i = 0; i < 3; i++) {
+      Line rule = styledLine(
+          size * 0.16, size * (0.31 + i * 0.15),
+          size * (i == 1 ? 0.48 : 0.55), size * (0.31 + i * 0.15),
+          Color.rgb(235, 250, 255, 0.66), Math.max(0.65, size * 0.032));
+      art.getChildren().add(rule);
+    }
+    Circle lens = new Circle(size * 0.68, size * 0.66, size * 0.22,
+        new RadialGradient(
+            0, 0, 0.34, 0.28, 0.88, true, CycleMethod.NO_CYCLE,
+            new Stop(0, Color.rgb(243, 253, 255, 0.76)),
+            new Stop(0.58, Color.rgb(82, 176, 218, 0.46)),
+            new Stop(1, Color.rgb(13, 54, 83, 0.84))));
+    lens.setStroke(Color.web("#e8f9ff"));
+    lens.setStrokeWidth(Math.max(1.25, size * 0.065));
+    lens.setEffect(new DropShadow(Math.max(1.4, size * 0.09), Color.rgb(0, 0, 0, 0.76)));
+    Line handle = styledLine(
+        size * 0.83, size * 0.82, size * 0.96, size * 0.95,
+        Color.web("#d8edf6"), Math.max(1.8, size * 0.09));
+    art.getChildren().add(0, fold);
+    art.getChildren().add(0, page);
+    art.getChildren().addAll(lens, handle, vnsGlint(size, 0.61, 0.59));
+    return art;
+  }
+
+  private static Region vnsCommandsGlyph(double size, Palette palette) {
+    Pane art = vnsCanvas(size);
+    Rectangle window = new Rectangle(size * 0.04, size * 0.10, size * 0.82, size * 0.76);
+    window.setArcWidth(size * 0.14);
+    window.setArcHeight(size * 0.14);
+    window.setFill(commandGradient("#b9c9f6", "#324f88"));
+    window.setStroke(Color.web("#eef4ff"));
+    window.setStrokeWidth(Math.max(0.9, size * 0.045));
+    window.setEffect(new InnerShadow(Math.max(1, size * 0.06), Color.rgb(17, 28, 65, 0.72)));
+    Rectangle titleBar = new Rectangle(size * 0.08, size * 0.14, size * 0.74, size * 0.16);
+    titleBar.setArcWidth(size * 0.08);
+    titleBar.setArcHeight(size * 0.08);
+    titleBar.setFill(commandGradient("#f0f5ff", "#8faade"));
+    Circle titleDot = new Circle(size * 0.15, size * 0.22, size * 0.035, Color.web("#eb8b62"));
+
+    Text prompt = new Text(">");
+    prompt.setFont(Font.font("Monospaced", FontWeight.BOLD, size * 0.31));
+    prompt.setFill(Color.web("#f5fbff"));
+    prompt.relocate(size * 0.13, size * 0.34);
+    for (int i = 0; i < 3; i++) {
+      Line row = styledLine(
+          size * 0.37, size * (0.46 + i * 0.13),
+          size * (i == 0 ? 0.73 : 0.66), size * (0.46 + i * 0.13),
+          i == 0 ? Color.web("#fff0a8") : Color.rgb(235, 244, 255, 0.64),
+          Math.max(0.75, size * 0.038));
+      art.getChildren().add(row);
+    }
+    StackPane sparkOrb = vnsOrb(size, "#fff7cb", "#e8a22e", "#884712");
+    sparkOrb.resizeRelocate(size * 0.65, size * 0.61, size * 0.32, size * 0.32);
+    Text spark = new Text("✦");
+    spark.setFont(Font.font("System", FontWeight.BOLD, size * 0.17));
+    spark.setFill(Color.WHITE);
+    sparkOrb.getChildren().add(spark);
+    art.getChildren().add(0, titleDot);
+    art.getChildren().add(0, titleBar);
+    art.getChildren().add(0, window);
+    art.getChildren().addAll(prompt, sparkOrb);
+    return art;
+  }
+
+  private static Region vnsWordWrapGlyph(double size, Palette palette) {
+    Pane art = vnsCanvas(size);
+    Rectangle page = vnsDocument(size, palette, 0.05, 0.08, 0.72, 0.82);
+    Polygon fold = vnsPageFold(size, palette, 0.54, 0.08, 0.23);
+    for (int i = 0; i < 3; i++) {
+      Line rule = styledLine(
+          size * 0.15, size * (0.31 + i * 0.16),
+          size * (i == 1 ? 0.54 : 0.63), size * (0.31 + i * 0.16),
+          Color.rgb(239, 248, 255, i == 2 ? 0.54 : 0.74),
+          Math.max(0.7, size * 0.035));
+      art.getChildren().add(rule);
+    }
+
+    Arc wrap = new Arc(
+        size * 0.60, size * 0.60, size * 0.30, size * 0.25,
+        86, -216);
+    wrap.setType(ArcType.OPEN);
+    wrap.setFill(Color.TRANSPARENT);
+    wrap.setStroke(Color.web("#ffd572"));
+    wrap.setStrokeWidth(Math.max(1.5, size * 0.075));
+    wrap.setStrokeLineCap(StrokeLineCap.ROUND);
+    wrap.setEffect(new DropShadow(size * 0.08, Color.rgb(89, 46, 8, 0.72)));
+    Polygon arrow = new Polygon(
+        size * 0.34, size * 0.69,
+        size * 0.52, size * 0.67,
+        size * 0.43, size * 0.82);
+    arrow.setFill(commandGradient("#fff4bd", "#d68b28"));
+    arrow.setStroke(Color.web("#fff2c4"));
+    arrow.setStrokeWidth(Math.max(0.45, size * 0.022));
+    art.getChildren().add(0, page);
+    art.getChildren().add(1, fold);
+    art.getChildren().addAll(wrap, arrow);
+    return art;
+  }
+
+  private static Region vnsDiffGlyph(double size, Palette palette) {
+    Pane art = vnsCanvas(size);
+    Rectangle removed = new Rectangle(size * 0.04, size * 0.15, size * 0.58, size * 0.72);
+    removed.setArcWidth(size * 0.10);
+    removed.setArcHeight(size * 0.10);
+    removed.setFill(commandGradient("#f6b1a7", "#8f3c45"));
+    removed.setStroke(Color.web("#ffe2dc"));
+    removed.setStrokeWidth(Math.max(0.75, size * 0.038));
+    removed.setEffect(new InnerShadow(Math.max(0.9, size * 0.055), Color.rgb(79, 15, 26, 0.68)));
+
+    Rectangle added = new Rectangle(size * 0.27, size * 0.07, size * 0.66, size * 0.76);
+    added.setArcWidth(size * 0.10);
+    added.setArcHeight(size * 0.10);
+    added.setFill(commandGradient("#a5ecc2", "#28755a"));
+    added.setStroke(Color.web("#e0fff0"));
+    added.setStrokeWidth(Math.max(0.8, size * 0.04));
+    added.setEffect(new InnerShadow(Math.max(0.9, size * 0.055), Color.rgb(11, 67, 49, 0.66)));
+
+    Line minus = styledLine(
+        size * 0.10, size * 0.63, size * 0.29, size * 0.63,
+        Color.web("#fff0eb"), Math.max(1.2, size * 0.06));
+    Line plusH = styledLine(
+        size * 0.61, size * 0.38, size * 0.84, size * 0.38,
+        Color.WHITE, Math.max(1.2, size * 0.06));
+    Line plusV = styledLine(
+        size * 0.725, size * 0.265, size * 0.725, size * 0.495,
+        Color.WHITE, Math.max(1.2, size * 0.06));
+    Line changeOne = styledLine(
+        size * 0.38, size * 0.59, size * 0.78, size * 0.59,
+        Color.rgb(231, 255, 242, 0.64), Math.max(0.6, size * 0.03));
+    Line changeTwo = styledLine(
+        size * 0.38, size * 0.70, size * 0.67, size * 0.70,
+        Color.rgb(231, 255, 242, 0.50), Math.max(0.6, size * 0.03));
+    art.getChildren().addAll(removed, minus, added, plusH, plusV, changeOne, changeTwo);
+    return art;
+  }
+
+  private static Region vnsDiagnosticsGlyph(double size, Palette palette) {
+    Pane art = vnsCanvas(size);
+    Rectangle panel = new Rectangle(size * 0.04, size * 0.08, size * 0.80, size * 0.80);
+    panel.setArcWidth(size * 0.14);
+    panel.setArcHeight(size * 0.14);
+    panel.setFill(commandGradient("#b8eaff", "#245c84"));
+    panel.setStroke(Color.web("#e9f9ff"));
+    panel.setStrokeWidth(Math.max(0.9, size * 0.045));
+    panel.setEffect(new InnerShadow(Math.max(1, size * 0.06), Color.rgb(8, 45, 72, 0.74)));
+    Rectangle header = new Rectangle(size * 0.08, size * 0.13, size * 0.72, size * 0.15);
+    header.setArcWidth(size * 0.08);
+    header.setArcHeight(size * 0.08);
+    header.setFill(commandGradient("#f3fbff", "#82b8d7"));
+
+    for (int i = 0; i < 3; i++) {
+      double y = size * (0.41 + i * 0.16);
+      Circle status = new Circle(size * 0.17, y, size * 0.045,
+          i == 2 ? Color.web("#ffd16a") : Color.web("#77e39e"));
+      status.setStroke(Color.rgb(246, 255, 249, 0.78));
+      status.setStrokeWidth(Math.max(0.35, size * 0.018));
+      Line row = styledLine(
+          size * 0.28, y, size * (i == 1 ? 0.62 : 0.69), y,
+          Color.rgb(238, 249, 255, 0.68), Math.max(0.65, size * 0.032));
+      art.getChildren().addAll(status, row);
+    }
+
+    StackPane warningOrb = vnsOrb(size, "#fff8c9", "#e7a42c", "#8d4c15");
+    warningOrb.resizeRelocate(size * 0.64, size * 0.61, size * 0.34, size * 0.34);
+    Text warning = new Text("!");
+    warning.setFont(Font.font("System", FontWeight.BOLD, size * 0.20));
+    warning.setFill(Color.WHITE);
+    warningOrb.getChildren().add(warning);
+    art.getChildren().add(0, panel);
+    art.getChildren().add(1, header);
+    art.getChildren().add(warningOrb);
     return art;
   }
 
   private static Region vnsPreviewGlyph(double size, Palette palette) {
     Pane art = vnsCanvas(size);
-    Rectangle window = new Rectangle(size * 0.04, size * 0.18, size * 0.76, size * 0.62);
+    Rectangle stem = new Rectangle(size * 0.37, size * 0.72, size * 0.13, size * 0.13);
+    stem.setFill(commandGradient("#eef9ff", "#5f788a"));
+    Ellipse foot = new Ellipse(size * 0.435, size * 0.87, size * 0.25, size * 0.06);
+    foot.setFill(commandGradient("#eef9ff", "#536b7d"));
+    foot.setStroke(Color.web("#dff4ff"));
+    foot.setStrokeWidth(Math.max(0.45, size * 0.022));
+
+    Rectangle window = new Rectangle(size * 0.03, size * 0.10, size * 0.81, size * 0.66);
     window.setArcWidth(size * 0.14);
     window.setArcHeight(size * 0.14);
-    window.setFill(commandGradient(toCss(palette.top()), toCss(palette.bottom())));
-    window.setStroke(palette.edge());
-    window.setStrokeWidth(Math.max(0.8, size * 0.05));
-    Line chrome = styledLine(
-        size * 0.08, size * 0.31, size * 0.75, size * 0.31,
-        Color.rgb(240, 252, 255, 0.60), Math.max(0.65, size * 0.035));
-    Circle status = new Circle(size * 0.14, size * 0.25, size * 0.035, Color.web("#ffca69"));
+    window.setFill(commandGradient("#9ee9ff", "#123e66"));
+    window.setStroke(Color.web("#e7faff"));
+    window.setStrokeWidth(Math.max(0.9, size * 0.045));
+    window.setEffect(new InnerShadow(Math.max(1, size * 0.06), Color.rgb(5, 31, 55, 0.80)));
+    Rectangle screen = new Rectangle(size * 0.09, size * 0.20, size * 0.68, size * 0.47);
+    screen.setArcWidth(size * 0.08);
+    screen.setArcHeight(size * 0.08);
+    screen.setFill(commandGradient("#2379a7", "#071e35"));
+    screen.setStroke(Color.rgb(215, 247, 255, 0.58));
+    screen.setStrokeWidth(Math.max(0.45, size * 0.022));
     Polygon play = new Polygon(
-        size * 0.27, size * 0.40,
-        size * 0.59, size * 0.56,
-        size * 0.27, size * 0.72);
-    play.setFill(Color.web("#70efa8"));
-    play.setEffect(new DropShadow(size * 0.10, Color.web("#28b96b")));
+        size * 0.31, size * 0.30,
+        size * 0.58, size * 0.44,
+        size * 0.31, size * 0.58);
+    play.setFill(commandGradient("#eaffef", "#4bd77e"));
+    play.setStroke(Color.rgb(239, 255, 244, 0.84));
+    play.setStrokeWidth(Math.max(0.4, size * 0.02));
+    play.setEffect(new DropShadow(size * 0.09, Color.web("#2bc16d")));
     Line diagonal = styledLine(
-        size * 0.64, size * 0.38, size * 0.96, size * 0.06,
-        Color.web("#f1fbff"), Math.max(1.4, size * 0.08));
+        size * 0.69, size * 0.35, size * 0.96, size * 0.08,
+        Color.web("#f3fbff"), Math.max(1.3, size * 0.07));
     Line arrowTop = styledLine(
-        size * 0.77, size * 0.06, size * 0.96, size * 0.06,
-        Color.web("#f1fbff"), Math.max(1.4, size * 0.08));
+        size * 0.79, size * 0.08, size * 0.96, size * 0.08,
+        Color.web("#f3fbff"), Math.max(1.3, size * 0.07));
     Line arrowSide = styledLine(
-        size * 0.96, size * 0.06, size * 0.96, size * 0.25,
-        Color.web("#f1fbff"), Math.max(1.4, size * 0.08));
-    art.getChildren().addAll(window, chrome, status, play, diagonal, arrowTop, arrowSide);
+        size * 0.96, size * 0.08, size * 0.96, size * 0.25,
+        Color.web("#f3fbff"), Math.max(1.3, size * 0.07));
+    art.getChildren().addAll(stem, foot, window, screen, play, diagonal, arrowTop, arrowSide);
     return art;
   }
 
@@ -304,6 +553,65 @@ public final class AeroIcon extends StackPane {
     pane.setPrefSize(size, size);
     pane.setMaxSize(size, size);
     return pane;
+  }
+
+  private static Rectangle vnsDocument(
+      double size, Palette palette, double x, double y, double width, double height) {
+    Rectangle page = new Rectangle(size * x, size * y, size * width, size * height);
+    page.setArcWidth(size * 0.10);
+    page.setArcHeight(size * 0.10);
+    page.setFill(new LinearGradient(
+        0, 0, 0, 1, true, CycleMethod.NO_CYCLE,
+        new Stop(0, mix(palette.top(), Color.WHITE, 0.36)),
+        new Stop(0.18, palette.top()),
+        new Stop(1, palette.bottom())));
+    page.setStroke(palette.edge());
+    page.setStrokeWidth(Math.max(0.8, size * 0.04));
+    page.setEffect(new InnerShadow(Math.max(0.9, size * 0.055),
+        palette.bottom().deriveColor(0, 0.8, 0.55, 0.72)));
+    return page;
+  }
+
+  private static Polygon vnsPageFold(
+      double size, Palette palette, double x, double y, double foldSize) {
+    Polygon fold = new Polygon(
+        size * x, size * y,
+        size * (x + foldSize), size * (y + foldSize),
+        size * x, size * (y + foldSize));
+    fold.setFill(commandGradient(toCss(mix(palette.edge(), Color.WHITE, 0.24)),
+        toCss(mix(palette.bottom(), Color.WHITE, 0.18))));
+    fold.setStroke(Color.rgb(245, 251, 255, 0.74));
+    fold.setStrokeWidth(Math.max(0.4, size * 0.02));
+    return fold;
+  }
+
+  private static StackPane vnsOrb(double size, String highlight, String middle, String edge) {
+    Circle rim = new Circle();
+    rim.setRadius(size * 0.19);
+    rim.setFill(new RadialGradient(
+        0, 0, 0.33, 0.26, 0.90, true, CycleMethod.NO_CYCLE,
+        new Stop(0, Color.web(highlight)),
+        new Stop(0.44, Color.web(middle)),
+        new Stop(1, Color.web(edge))));
+    rim.setStroke(Color.rgb(255, 255, 255, 0.88));
+    rim.setStrokeWidth(Math.max(0.7, size * 0.035));
+    rim.setEffect(new DropShadow(Math.max(1.4, size * 0.09), 0, size * 0.035,
+        Color.rgb(0, 0, 0, 0.78)));
+    Ellipse shine = new Ellipse(size * 0.19, size * 0.075);
+    shine.setFill(Color.rgb(255, 255, 255, 0.48));
+    StackPane orb = new StackPane(rim, shine);
+    StackPane.setAlignment(shine, Pos.TOP_CENTER);
+    StackPane.setMargin(shine, new Insets(size * 0.055, 0, 0, 0));
+    return orb;
+  }
+
+  private static Polygon playTriangle(double size, Color color) {
+    Polygon play = new Polygon(0, 0, size, size * 0.5, 0, size);
+    play.setFill(color);
+    play.setStroke(Color.rgb(16, 76, 42, 0.45));
+    play.setStrokeWidth(Math.max(0.35, size * 0.055));
+    play.setTranslateX(size * 0.08);
+    return play;
   }
 
   private static void polishShape(Shape shape, Palette palette, double size) {
@@ -403,6 +711,16 @@ public final class AeroIcon extends StackPane {
           new Badge(sized(CssIcon.search("#ffffff"), glyphSize), Color.web("#c98225"));
       case VNS_SNIPPET ->
           new Badge(sized(CssIcon.plusBold("#ffffff"), glyphSize), Color.web("#b46a25"));
+      case VNS_FIND ->
+          new Badge(sized(CssIcon.search("#ffffff"), glyphSize), Color.web("#278bc5"));
+      case VNS_COMMANDS ->
+          new Badge(sized(CssIcon.sparkles("#ffffff"), glyphSize), Color.web("#b46a25"));
+      case VNS_WORD_WRAP ->
+          new Badge(sized(CssIcon.refresh("#ffffff"), glyphSize), Color.web("#c98225"));
+      case VNS_DIFF ->
+          new Badge(sized(CssIcon.branchPlus("#ffffff"), glyphSize), Color.web("#2c9a5a"));
+      case VNS_DIAGNOSTICS ->
+          new Badge(sized(CssIcon.check("#ffffff"), glyphSize), Color.web("#278bc5"));
       case VNS_PREVIEW ->
           new Badge(sized(CssIcon.popOut("#ffffff"), glyphSize), Color.web("#278bc5"));
       case BUILD -> new Badge(sized(CssIcon.wrench("#ffffff"), glyphSize), Color.web("#287fb4"));
@@ -607,6 +925,16 @@ public final class AeroIcon extends StackPane {
           palette("#79d8ff", "#2267ad", "#c9f2ff");
       case VNS_SNIPPET ->
           palette("#c4b4ff", "#6450a8", "#eee9ff");
+      case VNS_FIND ->
+          palette("#8bdfff", "#26689f", "#dff7ff");
+      case VNS_COMMANDS ->
+          palette("#b9c9f6", "#324f88", "#eef4ff");
+      case VNS_WORD_WRAP ->
+          palette("#b8d9ef", "#4a708b", "#eef8ff");
+      case VNS_DIFF ->
+          palette("#a5ecc2", "#28755a", "#e0fff0");
+      case VNS_DIAGNOSTICS ->
+          palette("#b8eaff", "#245c84", "#e9f9ff");
       case VNS_PREVIEW ->
           palette("#72ddff", "#19547a", "#dff8ff");
       case LAYOUT, LAYERS, MANIFEST, README ->

--- a/modules/editor/src/main/java/com/jvn/editor/ui/FileEditorTab.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/FileEditorTab.java
@@ -43,6 +43,7 @@ import javafx.scene.control.ContentDisplay;
 import javafx.scene.control.Label;
 import javafx.scene.control.MenuButton;
 import javafx.scene.control.MenuItem;
+import javafx.scene.control.Separator;
 import javafx.scene.control.SplitPane;
 import javafx.scene.control.ToggleButton;
 import javafx.scene.control.ToggleGroup;
@@ -92,6 +93,7 @@ public class FileEditorTab extends BorderPane {
   private Consumer<String> onStatus;
   private Consumer<String> onVnsTextChanged;
   private Consumer<String> onDiagnosticsTextChanged;
+  private Runnable onOpenDiagnostics;
   private Consumer<StoryboardOverlayState> onStoryboardOverlayAdjusted;
   private com.jvn.editor.commands.CommandStack commands;
   private File projectRoot;
@@ -614,6 +616,10 @@ public class FileEditorTab extends BorderPane {
     }
   }
 
+  public void setOnOpenDiagnostics(Runnable listener) {
+    this.onOpenDiagnostics = listener;
+  }
+
   private void installVnsTextChangedHandler() {
     if (vnsEditor == null) return;
     vnsEditor.setOnTextChanged(text -> {
@@ -1053,7 +1059,7 @@ public class FileEditorTab extends BorderPane {
       Button runLabel = new Button();
       configureVnsAeroButton(
           runLabel,
-          AeroIcon.of(AeroIcon.Kind.VNS_RUN_LABEL, 30),
+          AeroIcon.of(AeroIcon.Kind.VNS_RUN_LABEL, 32),
           "Run from current label",
           "Start at the nearest @label above the caret and open the runtime preview (F5)");
       runLabel.setOnAction(e -> vnsEditor.launchFromCurrentLabel());
@@ -1061,7 +1067,7 @@ public class FileEditorTab extends BorderPane {
       Button runStart = new Button();
       configureVnsAeroButton(
           runStart,
-          AeroIcon.of(AeroIcon.Kind.VNS_RUN_ENTRY, 30),
+          AeroIcon.of(AeroIcon.Kind.VNS_RUN_ENTRY, 32),
           "Run from script entry",
           "Start at the project entry point and open the runtime preview (Shift+F5)");
       runStart.setOnAction(e -> vnsEditor.launchFromStart());
@@ -1069,7 +1075,7 @@ public class FileEditorTab extends BorderPane {
       Button symbols = new Button();
       configureVnsAeroButton(
           symbols,
-          AeroIcon.of(AeroIcon.Kind.VNS_SYMBOLS, 30),
+          AeroIcon.of(AeroIcon.Kind.VNS_SYMBOLS, 32),
           "Go to VNS symbol",
           "Find an @label declaration in this script (Ctrl/Cmd+Shift+O)");
       symbols.setOnAction(e -> vnsEditor.showSymbolNavigator());
@@ -1077,15 +1083,58 @@ public class FileEditorTab extends BorderPane {
       Button snippets = new Button();
       configureVnsAeroButton(
           snippets,
-          AeroIcon.of(AeroIcon.Kind.VNS_SNIPPET, 30),
+          AeroIcon.of(AeroIcon.Kind.VNS_SNIPPET, 32),
           "Insert VNS snippet",
           "Open the VNS command and declaration palette (Ctrl/Cmd+J)");
       snippets.setOnAction(e -> vnsEditor.showSnippetPicker());
 
+      Button find = new Button();
+      configureVnsAeroButton(
+          find,
+          AeroIcon.of(AeroIcon.Kind.VNS_FIND, 32),
+          "Find in VNS script",
+          "Find text in this script (Ctrl/Cmd+F)");
+      find.setOnAction(e -> vnsEditor.showSearchBar());
+
+      Button commands = new Button();
+      configureVnsAeroButton(
+          commands,
+          AeroIcon.of(AeroIcon.Kind.VNS_COMMANDS, 32),
+          "Open VNS command palette",
+          "Search all VNS editor commands (Ctrl/Cmd+Shift+P)");
+      commands.setOnAction(e -> vnsEditor.showCommandPalette());
+
+      ToggleButton wordWrap = new ToggleButton();
+      configureVnsAeroToggle(
+          wordWrap,
+          AeroIcon.of(AeroIcon.Kind.VNS_WORD_WRAP, 32),
+          "Toggle VNS word wrap",
+          "Wrap long script lines in the editor (Ctrl/Cmd+Shift+W)");
+      wordWrap.setSelected(vnsEditor.isWordWrapEnabled());
+      wordWrap.setOnAction(e -> wordWrap.setSelected(vnsEditor.toggleWordWrap()));
+
+      Button diff = new Button();
+      configureVnsAeroButton(
+          diff,
+          AeroIcon.of(AeroIcon.Kind.VNS_DIFF, 32),
+          "Compare VNS script with saved version",
+          "Show changes since the script was last saved or loaded (Ctrl/Cmd+Shift+D)");
+      diff.setOnAction(e -> vnsEditor.showDiffView());
+
+      Button diagnostics = new Button();
+      configureVnsAeroButton(
+          diagnostics,
+          AeroIcon.of(AeroIcon.Kind.VNS_DIAGNOSTICS, 32),
+          "Open VNS diagnostics",
+          "Inspect errors, warnings, and source locations for this script");
+      diagnostics.setOnAction(e -> {
+        if (onOpenDiagnostics != null) onOpenDiagnostics.run();
+      });
+
       Button openPreview = new Button();
       configureVnsAeroButton(
           openPreview,
-          AeroIcon.of(AeroIcon.Kind.VNS_PREVIEW, 30),
+          AeroIcon.of(AeroIcon.Kind.VNS_PREVIEW, 32),
           "Open runtime preview",
           "Open the live game preview in a separate resizable window");
       openPreview.setOnAction(e -> setPreviewDockPosition(PreviewDockPosition.WINDOW));
@@ -1106,12 +1155,36 @@ public class FileEditorTab extends BorderPane {
           Insert snippet
           Opens the VNS command and declaration palette. Shortcut: Ctrl/Cmd+J.
 
+          Find in script
+          Opens the editor search bar. Shortcut: Ctrl/Cmd+F.
+
+          Command palette
+          Searches all VNS editor commands. Shortcut: Ctrl/Cmd+Shift+P.
+
+          Word wrap
+          Wraps long script lines without changing the file. Shortcut: Ctrl/Cmd+Shift+W.
+
+          Compare with saved
+          Shows changes since the file was last saved or loaded. Shortcut: Ctrl/Cmd+Shift+D.
+
+          Diagnostics
+          Opens the diagnostics panel for errors, warnings, and source navigation.
+
           Open runtime preview
           Opens the live game preview in its own resizable window.
           """);
+      help.setGraphic(AeroIcon.of(AeroIcon.Kind.HELP, 30));
+      help.setMinSize(44, 42);
+      help.setPrefSize(44, 42);
+      help.setMaxSize(44, 42);
       help.getStyleClass().add("vns-tools-help-button");
 
-      toolbarActions = new Node[] {runLabel, runStart, symbols, snippets, openPreview, help};
+      toolbarActions = new Node[] {
+          runLabel, runStart, vnsToolSeparator(),
+          symbols, snippets, find, commands, vnsToolSeparator(),
+          wordWrap, diff, diagnostics, vnsToolSeparator(),
+          openPreview, vnsToolSeparator(), help
+      };
     } else {
       toolbarActions = new Node[] {
           previewModePreviewButton, previewModeCodeButton, previewModeSplitButton, previewDockMenu
@@ -1498,7 +1571,7 @@ public class FileEditorTab extends BorderPane {
 
   private Region previewWorkspaceTitleIcon() {
     return switch (kind) {
-      case VNS -> CssIcon.speech("#d7e1f0");
+      case VNS -> AeroIcon.of(AeroIcon.Kind.SCRIPT_EDITOR, 26);
       case THEME -> CssIcon.palette("#d7e1f0");
       case TIMELINE -> CssIcon.play("#d7e1f0");
       default -> CssIcon.visibility("#d7e1f0");
@@ -1579,11 +1652,34 @@ public class FileEditorTab extends BorderPane {
     button.setTooltip(new Tooltip(tooltipText));
     button.setContentDisplay(ContentDisplay.GRAPHIC_ONLY);
     button.setAccessibleText(accessibleText);
-    button.setMinSize(42, 40);
-    button.setPrefSize(42, 40);
-    button.setMaxSize(42, 40);
+    button.setMinSize(44, 42);
+    button.setPrefSize(44, 42);
+    button.setMaxSize(44, 42);
     button.setFocusTraversable(false);
     button.getStyleClass().add("vns-tools-aero-button");
+  }
+
+  private static void configureVnsAeroToggle(
+      ToggleButton button, AeroIcon icon, String accessibleText, String tooltipText) {
+    button.setText("");
+    button.setGraphic(icon);
+    button.setTooltip(new Tooltip(tooltipText));
+    button.setContentDisplay(ContentDisplay.GRAPHIC_ONLY);
+    button.setAccessibleText(accessibleText);
+    button.setMinSize(44, 42);
+    button.setPrefSize(44, 42);
+    button.setMaxSize(44, 42);
+    button.setFocusTraversable(false);
+    button.getStyleClass().add("vns-tools-aero-button");
+  }
+
+  private static Separator vnsToolSeparator() {
+    Separator separator = new Separator(Orientation.VERTICAL);
+    separator.setMinHeight(28);
+    separator.setPrefHeight(28);
+    separator.setMaxHeight(28);
+    separator.getStyleClass().add("vns-tools-separator");
+    return separator;
   }
 
   private static void configureIconMenuButton(MenuButton button, Node icon, String tooltipText) {

--- a/modules/editor/src/main/java/com/jvn/editor/ui/VnsCodeEditor.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/VnsCodeEditor.java
@@ -3219,7 +3219,8 @@ public class VnsCodeEditor extends BorderPane {
       {"Show Diff", "Compare with saved version (Ctrl+Shift+D)"},
   };
 
-  private void showCommandPalette() {
+  /** Opens the searchable VNS editor command palette. */
+  public void showCommandPalette() {
     Popup popup = new Popup();
     popup.setAutoHide(true);
 
@@ -3374,15 +3375,22 @@ public class VnsCodeEditor extends BorderPane {
   // ═══════════════════════════════════════════════════════════════════
   //  FEATURE: Word Wrap Toggle (Ctrl+Shift+W)
   // ═══════════════════════════════════════════════════════════════════
-  private void toggleWordWrap() {
+  /** Toggles line wrapping and returns the new state for toolbar controls. */
+  public boolean toggleWordWrap() {
     wordWrapEnabled = !wordWrapEnabled;
     codeArea.setWrapText(wordWrapEnabled);
+    return wordWrapEnabled;
+  }
+
+  public boolean isWordWrapEnabled() {
+    return wordWrapEnabled;
   }
 
   // ═══════════════════════════════════════════════════════════════════
   //  FEATURE: Diff View (Ctrl+Shift+D) — compare with saved snapshot
   // ═══════════════════════════════════════════════════════════════════
-  private void showDiffView() {
+  /** Compares the current script with the last saved or loaded snapshot. */
+  public void showDiffView() {
     String current = codeArea.getText();
     if (current == null) current = "";
     String saved = savedTextSnapshot;

--- a/modules/editor/src/main/resources/com/jvn/editor/editor-light.css
+++ b/modules/editor/src/main/resources/com/jvn/editor/editor-light.css
@@ -3350,22 +3350,47 @@
 }
 
 .vns-tools-strip {
-  -fx-spacing: 10;
-  -fx-padding: 9 12 9 12;
-  -fx-background-color: linear-gradient(to bottom, #f6f8fa, #e9edf0);
-  -fx-border-color: transparent transparent #c3cbd1 transparent;
+  -fx-spacing: 7;
+  -fx-padding: 8 12 8 12;
+  -fx-background-color:
+    linear-gradient(to bottom, rgba(255,255,255,0.76), transparent 46%),
+    linear-gradient(to bottom, #f7f9fb, #e6ebef);
+  -fx-border-color: transparent transparent #bcc6ce transparent;
 }
 
-.vns-tools-aero-button,
-.vns-tools-aero-button:hover,
-.vns-tools-aero-button:focused,
-.vns-tools-aero-button:pressed {
+.vns-tools-aero-button {
   -fx-background-color: transparent;
   -fx-border-color: transparent;
   -fx-background-insets: 0;
   -fx-border-insets: 0;
   -fx-padding: 5;
   -fx-effect: none;
+  -fx-background-radius: 5;
+  -fx-border-radius: 5;
+}
+
+.vns-tools-aero-button:hover {
+  -fx-background-color:
+    linear-gradient(to bottom, rgba(255,255,255,0.86), rgba(141,201,234,0.32));
+  -fx-border-color: rgba(74,137,174,0.38);
+}
+
+.vns-tools-aero-button:pressed {
+  -fx-background-color:
+    linear-gradient(to bottom, rgba(102,167,204,0.34), rgba(230,247,255,0.66));
+  -fx-border-color: rgba(48,119,160,0.48);
+}
+
+.vns-tools-aero-button:selected {
+  -fx-background-color:
+    linear-gradient(to bottom, rgba(255,255,255,0.92), rgba(98,177,219,0.46));
+  -fx-border-color: rgba(42,118,161,0.58);
+}
+
+.vns-tools-separator > .line {
+  -fx-border-color: transparent #ffffff transparent #b9c2c9;
+  -fx-border-width: 0 1 0 1;
+  -fx-padding: 0;
 }
 
 .vns-tools-help-button {

--- a/modules/editor/src/main/resources/com/jvn/editor/editor.css
+++ b/modules/editor/src/main/resources/com/jvn/editor/editor.css
@@ -3497,22 +3497,47 @@ The editor.css file defines the visual styling for the editor module, including 
 }
 
 .vns-tools-strip {
-  -fx-spacing: 10;
-  -fx-padding: 9 12 9 12;
-  -fx-background-color: linear-gradient(to bottom, #151719, #101112);
-  -fx-border-color: transparent transparent #303438 transparent;
+  -fx-spacing: 7;
+  -fx-padding: 8 12 8 12;
+  -fx-background-color:
+    linear-gradient(to bottom, rgba(255,255,255,0.035), transparent 42%),
+    linear-gradient(to bottom, #181b1e, #0d0f11);
+  -fx-border-color: transparent transparent #343a40 transparent;
 }
 
-.vns-tools-aero-button,
-.vns-tools-aero-button:hover,
-.vns-tools-aero-button:focused,
-.vns-tools-aero-button:pressed {
+.vns-tools-aero-button {
   -fx-background-color: transparent;
   -fx-border-color: transparent;
   -fx-background-insets: 0;
   -fx-border-insets: 0;
   -fx-padding: 5;
   -fx-effect: none;
+  -fx-background-radius: 5;
+  -fx-border-radius: 5;
+}
+
+.vns-tools-aero-button:hover {
+  -fx-background-color:
+    linear-gradient(to bottom, rgba(166,224,255,0.16), rgba(72,143,184,0.08));
+  -fx-border-color: rgba(185,229,255,0.20);
+}
+
+.vns-tools-aero-button:pressed {
+  -fx-background-color:
+    linear-gradient(to bottom, rgba(45,96,126,0.22), rgba(140,210,246,0.10));
+  -fx-border-color: rgba(145,208,241,0.26);
+}
+
+.vns-tools-aero-button:selected {
+  -fx-background-color:
+    linear-gradient(to bottom, rgba(156,220,255,0.24), rgba(43,112,151,0.16));
+  -fx-border-color: rgba(167,222,252,0.44);
+}
+
+.vns-tools-separator > .line {
+  -fx-border-color: transparent #3b4146 transparent #0a0b0c;
+  -fx-border-width: 0 1 0 1;
+  -fx-padding: 0;
 }
 
 .vns-tools-help-button {

--- a/modules/editor/src/test/java/com/jvn/editor/ui/AeroIconTest.java
+++ b/modules/editor/src/test/java/com/jvn/editor/ui/AeroIconTest.java
@@ -93,6 +93,11 @@ class AeroIconTest {
         AeroIcon.Kind.VNS_RUN_ENTRY,
         AeroIcon.Kind.VNS_SYMBOLS,
         AeroIcon.Kind.VNS_SNIPPET,
+        AeroIcon.Kind.VNS_FIND,
+        AeroIcon.Kind.VNS_COMMANDS,
+        AeroIcon.Kind.VNS_WORD_WRAP,
+        AeroIcon.Kind.VNS_DIFF,
+        AeroIcon.Kind.VNS_DIAGNOSTICS,
         AeroIcon.Kind.VNS_PREVIEW
     }) {
       Button button = onFxThread(() -> {
@@ -109,7 +114,7 @@ class AeroIconTest {
   }
 
   @Test
-  void vnsCommandsHaveFiveDistinctPrimarySilhouettes() throws Exception {
+  void vnsCommandsHaveDistinctPrimarySilhouettes() throws Exception {
     Assumptions.assumeTrue(toolkitAvailable, "JavaFX toolkit is unavailable in this environment");
 
     Set<Long> artworkHashes = new HashSet<>();
@@ -118,6 +123,11 @@ class AeroIconTest {
         AeroIcon.Kind.VNS_RUN_ENTRY,
         AeroIcon.Kind.VNS_SYMBOLS,
         AeroIcon.Kind.VNS_SNIPPET,
+        AeroIcon.Kind.VNS_FIND,
+        AeroIcon.Kind.VNS_COMMANDS,
+        AeroIcon.Kind.VNS_WORD_WRAP,
+        AeroIcon.Kind.VNS_DIFF,
+        AeroIcon.Kind.VNS_DIAGNOSTICS,
         AeroIcon.Kind.VNS_PREVIEW
     }) {
       WritableImage image = onFxThread(() -> {
@@ -130,7 +140,7 @@ class AeroIconTest {
       });
       artworkHashes.add(pixelHash(image));
     }
-    assertEquals(5, artworkHashes.size(), "Every VNS command needs a distinct readable silhouette");
+    assertEquals(10, artworkHashes.size(), "Every VNS command needs a distinct readable silhouette");
   }
 
   @Test

--- a/modules/editor/src/test/java/com/jvn/editor/ui/FileEditorTabVnsLaunchTest.java
+++ b/modules/editor/src/test/java/com/jvn/editor/ui/FileEditorTabVnsLaunchTest.java
@@ -4,10 +4,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.scene.control.ButtonBase;
+import javafx.scene.control.ToggleButton;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -52,6 +57,49 @@ class FileEditorTabVnsLaunchTest {
       try {
         tab.runFromLabel(null);
         assertTrue(tab.isDetachedPreviewVisible());
+      } finally {
+        tab.dispose();
+      }
+      return null;
+    });
+  }
+
+  @Test
+  void vnsStripExposesWorkingReviewControls(@TempDir Path tempDir) throws Exception {
+    Assumptions.assumeTrue(toolkitAvailable, "JavaFX toolkit is unavailable in this environment");
+    Path script = tempDir.resolve("review_controls.vns");
+    Files.writeString(script, "@scenario review_controls\n@label start\nnarrator: Hello.\n");
+
+    onFxThread(() -> {
+      FileEditorTab tab = new FileEditorTab(script.toFile());
+      AtomicBoolean diagnosticsOpened = new AtomicBoolean();
+      tab.setOnOpenDiagnostics(() -> diagnosticsOpened.set(true));
+      new Scene(tab, 1400, 180);
+      tab.applyCss();
+      tab.layout();
+      try {
+        Set<javafx.scene.Node> controls = tab.lookupAll(".vns-tools-aero-button");
+        ButtonBase diagnostics = controls.stream()
+            .filter(ButtonBase.class::isInstance)
+            .map(ButtonBase.class::cast)
+            .filter(button -> "Open VNS diagnostics".equals(button.getAccessibleText()))
+            .findFirst()
+            .orElseThrow();
+        ToggleButton wordWrap = controls.stream()
+            .filter(ToggleButton.class::isInstance)
+            .map(ToggleButton.class::cast)
+            .filter(button -> "Toggle VNS word wrap".equals(button.getAccessibleText()))
+            .findFirst()
+            .orElseThrow();
+        assertTrue(controls.stream()
+            .filter(ButtonBase.class::isInstance)
+            .map(ButtonBase.class::cast)
+            .anyMatch(button -> "Compare VNS script with saved version".equals(button.getAccessibleText())));
+
+        diagnostics.fire();
+        wordWrap.fire();
+        assertTrue(diagnosticsOpened.get());
+        assertTrue(wordWrap.isSelected());
       } finally {
         tab.dispose();
       }


### PR DESCRIPTION
## What changed

- Rebuilt the VNS tool strip as ten distinct Windows 7-style Aero vector icons with glass, bevel, highlight, shadow, and metallic treatments.
- Grouped commands into Run, Navigate/Author, Review/View, Preview, and Help sections with consistent 44 × 42 hit targets.
- Added direct controls for Find, the command palette, word wrap, saved-version diff, and Diagnostics.
- Wired Diagnostics into the shared editor panel and made word wrap a stateful toggle.
- Added dark/light hover and selected styling, accessibility labels, updated help/docs, and JavaFX coverage for icon distinction and the new controls.

## Why

The previous VNS strip used flatter, less consistent artwork and hid several high-frequency authoring/review actions behind shortcuts or menus. This brings it in line with the editor's Aero visual language and makes the core VNS workflow easier to discover.

## Validation

- `./gradlew :editor:compileJava :editor:test --tests com.jvn.editor.ui.AeroIconTest --tests com.jvn.editor.ui.FileEditorTabVnsLaunchTest` — passed.
- Final JavaFX visual snapshot reviewed at the target toolbar width; all icons are distinct and unclipped.
- The two unrelated `GameBuildPublisherViewFxTest` cases that timed out in the combined macOS JavaFX suite both pass when run in isolation. The combined suite can trigger a macOS Glass shutdown crash/toolkit timeout unrelated to this diff.