### PR TITLE
Fix hidden VNS preview audio

### DIFF
--- a/modules/editor/src/main/java/com/jvn/editor/EditorApp.java
+++ b/modules/editor/src/main/java/com/jvn/editor/EditorApp.java
@@ -5254,8 +5254,9 @@ public class EditorApp extends Application {
     fullscreenStage.setOnCloseRequest(e -> cleanup.run());
     fullscreenStage.setOnHidden(e -> cleanup.run());
     
-    timer.start();
     fullscreenStage.show();
+    fullscreenPreview.setPlaybackActive(true);
+    timer.start();
     fullscreenPreview.requestFocus();
   }
 

--- a/modules/editor/src/main/java/com/jvn/editor/ui/FileEditorTab.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/FileEditorTab.java
@@ -458,8 +458,6 @@ public class FileEditorTab extends BorderPane {
     if (isDetachedPreviewVisible()) return;
     if (kind == Kind.JES && viewport != null) {
       viewport.render(dt);
-    } else if (kind == Kind.VNS && vnPreview != null) {
-      vnPreview.render(dt);
     }
   }
 
@@ -1327,6 +1325,9 @@ public class FileEditorTab extends BorderPane {
     stage.setOnHidden(e -> handleDetachedPreviewStageHidden(stage));
     detachedPreviewStage = stage;
     stage.show();
+    if (kind == Kind.VNS && vnPreview != null) {
+      vnPreview.setPlaybackActive(true);
+    }
     if (previewModeBeforeDetach != PreviewLayoutMode.CODE && previewModeCodeButton != null) {
       previewModeCodeButton.setSelected(true);
     }
@@ -1339,6 +1340,9 @@ public class FileEditorTab extends BorderPane {
     Stage stage = detachedPreviewStage;
     detachedPreviewStage = null;
     stopDetachedPreviewTimer();
+    if (kind == Kind.VNS && vnPreview != null) {
+      vnPreview.setPlaybackActive(false);
+    }
     removeDockPreviewFromParent();
     if (stage.isShowing()) stage.hide();
     if (disposing) return;
@@ -1389,7 +1393,11 @@ public class FileEditorTab extends BorderPane {
     if (stage == null || detachedPreviewStage != stage) return;
     detachedPreviewStage = null;
     stopDetachedPreviewTimer();
-    stopPreviewAudio();
+    if (kind == Kind.VNS && vnPreview != null) {
+      vnPreview.setPlaybackActive(false);
+    } else {
+      stopPreviewAudio();
+    }
     removeDockPreviewFromParent();
     if (disposed) return;
 

--- a/modules/editor/src/main/java/com/jvn/editor/ui/VnPreviewView.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/VnPreviewView.java
@@ -36,6 +36,7 @@ import com.jvn.core.phone.VnPhoneStateStore;
 import com.jvn.core.project.StoryMapPaths;
 import com.jvn.core.scene.Scene;
 import com.jvn.core.vn.DefaultVnInterop;
+import com.jvn.core.vn.VnAudioCommand;
 import com.jvn.core.vn.VnErrorOverlay;
 import com.jvn.core.vn.VnExternalCommand;
 import com.jvn.core.vn.VnInteropResult;
@@ -98,6 +99,7 @@ public class VnPreviewView extends StackPane {
   private VnScene scene;
   private double mouseX, mouseY;
   private AudioFacade audio;
+  private boolean playbackActive;
   private File projectRoot;
   private String audioBackend = "auto";
   private String sourceScriptName;
@@ -135,6 +137,11 @@ public class VnPreviewView extends StackPane {
   private int virtualHeight = 0;
 
   public VnPreviewView() {
+    this(null);
+  }
+
+  VnPreviewView(AudioFacade audio) {
+    this.audio = audio;
     configureStoryboardHud();
     getChildren().addAll(canvas, phoneRenderer);
     StackPane.setAlignment(storyboardHud, Pos.TOP_RIGHT);
@@ -294,7 +301,7 @@ public class VnPreviewView extends StackPane {
     this.scene = nextScene;
     this.overlayScene = null;
     phoneRenderer.setSceneModel(null);
-    renderer.setAudioFacade(audio);
+    renderer.setAudioFacade(activeAudioFacade());
     this.scene.onEnter();
     storyboardPreviewLine = resolveCurrentStoryboardLine();
     emitStoryboardPreviewLineChanged();
@@ -327,11 +334,32 @@ public class VnPreviewView extends StackPane {
     applyUiOverrides();
     bindProjectRoot(audio, root);
     if (scene != null) {
-      if (audio == null) {
-        audio = createAudioFacade(root, audioBackend);
-      }
-      scene.setAudioFacade(audio);
+      scene.setAudioFacade(playbackActive ? ensureAudioFacade() : null);
     }
+  }
+
+  /**
+   * Enables runtime audio only while a preview surface is actually visible.
+   * Loading and analysing a VNS document keeps this disabled.
+   */
+  public void setPlaybackActive(boolean active) {
+    if (playbackActive == active) return;
+    playbackActive = active;
+    if (!active) {
+      stopAudio();
+      if (scene != null) scene.setAudioFacade(null);
+      renderer.setAudioFacade(null);
+      return;
+    }
+    if (scene == null) return;
+    AudioFacade activeAudio = ensureAudioFacade();
+    scene.setAudioFacade(activeAudio);
+    renderer.setAudioFacade(activeAudio);
+    restoreAmbientBgm();
+  }
+
+  public boolean isPlaybackActive() {
+    return playbackActive;
   }
 
   private void resolveVirtualViewport(File root) {
@@ -582,7 +610,7 @@ public class VnPreviewView extends StackPane {
     this.scene = nextScene;
     this.overlayScene = null;
     phoneRenderer.setSceneModel(null);
-    renderer.setAudioFacade(audio);
+    renderer.setAudioFacade(activeAudioFacade());
     storyboardPreviewLine = resolveCurrentStoryboardLine();
     emitStoryboardPreviewLineChanged();
     applyStoryboardUiState();
@@ -605,9 +633,9 @@ public class VnPreviewView extends StackPane {
     interop.setSceneAccessor(accessor);
     renderer.setTimelineAccessor(accessor);
     nextScene.setInterop(interop);
-    if (audio == null) audio = createAudioFacade(projectRoot, audioBackend);
-    bindProjectRoot(audio, projectRoot);
-    nextScene.setAudioFacade(audio);
+    if (playbackActive) {
+      nextScene.setAudioFacade(ensureAudioFacade());
+    }
     if (settingsTemplate != null) {
       copySettings(settingsTemplate, nextScene.getState().getSettings());
     }
@@ -867,7 +895,7 @@ public class VnPreviewView extends StackPane {
       VnSettings settings = activeScene == null ? null : activeScene.getState().getSettings();
       this.sourceScriptName = normalizeScriptKey(script);
       this.scene = buildScene(loaded, label, sourceScriptName, settings);
-      renderer.setAudioFacade(audio);
+      renderer.setAudioFacade(activeAudioFacade());
       storyboardPreviewLine = resolveCurrentStoryboardLine();
       emitStoryboardPreviewLineChanged();
       applyStoryboardUiState();
@@ -1755,6 +1783,7 @@ public class VnPreviewView extends StackPane {
   }
 
   public void dispose() {
+    playbackActive = false;
     stopAudio();
     scene = null;
     overlayScene = null;
@@ -1763,6 +1792,47 @@ public class VnPreviewView extends StackPane {
     audio = null;
     renderer.setAudioFacade(null);
     renderer.setProjectRoot(null);
+  }
+
+  private AudioFacade activeAudioFacade() {
+    return playbackActive ? audio : null;
+  }
+
+  private AudioFacade ensureAudioFacade() {
+    if (audio == null) {
+      audio = createAudioFacade(projectRoot, audioBackend);
+    }
+    bindProjectRoot(audio, projectRoot);
+    return audio;
+  }
+
+  private void restoreAmbientBgm() {
+    if (!playbackActive || audio == null || scene == null || scene.getScenario() == null) return;
+    stopAudio();
+
+    VnAudioCommand ambient = null;
+    List<VnNode> nodes = scene.getScenario().getNodes();
+    int limit = Math.min(Math.max(0, scene.getState().getCurrentNodeIndex()), nodes.size());
+    for (int i = 0; i < limit; i++) {
+      VnNode node = nodes.get(i);
+      if (node == null || node.getType() != VnNodeType.AUDIO || node.getAudioCommand() == null) continue;
+      VnAudioCommand command = node.getAudioCommand();
+      switch (command.getType()) {
+        case PLAY_BGM -> ambient = command;
+        case STOP_BGM, FADE_OUT_BGM -> ambient = null;
+        default -> {
+          // Historical voice and SFX commands must not replay when the preview becomes visible.
+        }
+      }
+    }
+
+    VnSettings settings = scene.getState().getSettings();
+    audio.setBgmVolume(settings.getBgmVolume());
+    audio.setSfxVolume(settings.getSfxVolume());
+    audio.setVoiceVolume(settings.getVoiceVolume());
+    if (ambient != null && ambient.getTrackId() != null && !ambient.getTrackId().isBlank()) {
+      audio.playBgm(ambient.getTrackId(), ambient.isLoop());
+    }
   }
 
   static String normalizeAudioBackendValue(String raw) {

--- a/modules/editor/src/test/java/com/jvn/editor/ui/FileEditorTabVnsLaunchTest.java
+++ b/modules/editor/src/test/java/com/jvn/editor/ui/FileEditorTabVnsLaunchTest.java
@@ -1,7 +1,14 @@
 package com.jvn.editor.ui;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.jvn.core.audio.AudioFacade;
+import com.jvn.core.vn.VnAudioCommand;
+import com.jvn.core.vn.VnNode;
+import com.jvn.core.vn.VnNodeType;
+import com.jvn.core.vn.VnScenario;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Set;
@@ -105,6 +112,67 @@ class FileEditorTabVnsLaunchTest {
       }
       return null;
     });
+  }
+
+  @Test
+  void loadingVnsKeepsAudioSilentUntilPreviewIsVisible() throws Exception {
+    Assumptions.assumeTrue(toolkitAvailable, "JavaFX toolkit is unavailable in this environment");
+
+    onFxThread(() -> {
+      RecordingAudio audio = new RecordingAudio();
+      VnPreviewView preview = new VnPreviewView(audio);
+      VnScenario scenario = VnScenario.builder("silent_editor")
+          .addNode(VnNode.builder(VnNodeType.AUDIO)
+              .audioCommand(VnAudioCommand.builder(VnAudioCommand.AudioCommandType.PLAY_BGM)
+                  .trackId("theme.ogg")
+                  .loop(true)
+                  .build())
+              .build())
+          .build();
+
+      try {
+        preview.setScenario(scenario);
+
+        assertFalse(preview.isPlaybackActive());
+        assertEquals(0, audio.bgmPlayCount);
+
+        preview.setPlaybackActive(true);
+
+        assertTrue(preview.isPlaybackActive());
+        assertEquals(1, audio.bgmPlayCount);
+        assertEquals("theme.ogg", audio.lastBgm);
+
+        preview.setPlaybackActive(false);
+
+        assertFalse(preview.isPlaybackActive());
+        assertTrue(audio.stopCount > 0);
+      } finally {
+        preview.dispose();
+      }
+      return null;
+    });
+  }
+
+  private static final class RecordingAudio implements AudioFacade {
+    private int bgmPlayCount;
+    private int stopCount;
+    private String lastBgm = "";
+
+    @Override
+    public void playBgm(String trackId, boolean loop) {
+      bgmPlayCount++;
+      lastBgm = trackId;
+    }
+
+    @Override
+    public void stopBgm() {
+      stopCount++;
+    }
+
+    @Override
+    public void playSfx(String soundId) {
+      // Historical sound effects must not replay when the preview becomes visible.
+    }
   }
 
   private static <T> T onFxThread(java.util.concurrent.Callable<T> work) throws Exception {


### PR DESCRIPTION
## What changed

- Keep VNS audio inactive while a script is only open in the code editor.
- Start playback only after the detached or fullscreen preview becomes visible.
- Stop playback and detach the audio facade when the preview closes.
- Avoid advancing hidden VNS preview frames in the editor render loop.
- Restore only the active ambient BGM when opening a preview, without replaying historical voice or SFX commands.
- Add a regression test for hidden, shown, and closed preview states.

## Root cause

Creating a `VnPreviewView` eagerly attached an audio backend to its runtime scene. Initial VNS audio commands were therefore executed as soon as the editor loaded the script, even though no preview window was visible.

## Impact

Opening or editing a VNS file no longer produces music. Audio begins only when the user opens a preview and stops when that preview is hidden.

## Validation

- `git diff --check`
- `./gradlew :editor:compileJava :editor:test --tests com.jvn.editor.ui.FileEditorTabVnsLaunchTest --tests com.jvn.editor.ui.VnPreviewViewTest`