### PR TITLE
Improve diagnostics toolbar

### DIFF
--- a/modules/editor/src/main/java/com/jvn/editor/EditorApp.java
+++ b/modules/editor/src/main/java/com/jvn/editor/EditorApp.java
@@ -4330,6 +4330,12 @@ public class EditorApp extends Application {
     if (vnsDiagnosticsView != null) return vnsDiagnosticsView;
     vnsDiagnosticsView = new VnsDiagnosticsView();
     vnsDiagnosticsView.setOnOpenTarget(this::jumpToActiveVnsDiagnostic);
+    vnsDiagnosticsView.setOnRefresh(() -> {
+      FileEditorTab activeTab = getActiveFileTab();
+      refreshVnsToolPanels(
+          activeTab,
+          activeTab == null ? null : activeTab.getCurrentTextSnapshot());
+    });
     FileEditorTab ft = getActiveFileTab();
     refreshVnsToolPanels(ft, ft != null ? ft.getCurrentTextSnapshot() : null);
     return vnsDiagnosticsView;

--- a/modules/editor/src/main/java/com/jvn/editor/ui/VnsDiagnosticsView.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/VnsDiagnosticsView.java
@@ -11,11 +11,14 @@ import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.TextField;
+import javafx.scene.control.ToggleButton;
+import javafx.scene.control.ToggleGroup;
 import javafx.scene.control.Tooltip;
 import javafx.scene.input.Clipboard;
 import javafx.scene.input.ClipboardContent;
 import javafx.scene.input.KeyCode;
 import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
@@ -32,6 +35,12 @@ public class VnsDiagnosticsView extends BorderPane {
   private static final String SEVERITY_ALL = "All";
   private static final String SEVERITY_ERRORS = "Errors";
   private static final String SEVERITY_WARNINGS = "Warnings";
+  private static final String CATEGORY_ALL = "All categories";
+  private static final String CATEGORY_SYNTAX = "Syntax";
+  private static final String CATEGORY_FLOW = "Flow";
+  private static final String CATEGORY_ASSETS = "Assets";
+  private static final String CATEGORY_SCRIPTS = "Scripts";
+  private static final String CATEGORY_CONTENT = "Content";
 
   private enum SortMode { LINE, SEVERITY }
   private SortMode sortMode = SortMode.LINE;
@@ -40,30 +49,37 @@ public class VnsDiagnosticsView extends BorderPane {
   private final Label fileLabel = new Label("No active file");
   private final Label summaryLabel = new Label("Open a script or DSL file to see diagnostics.");
   private final Label statsLabel = new Label("");
-  private final Label errorCountLabel = new Label("0 Errors");
-  private final Label warningCountLabel = new Label("0 Warnings");
+  private final Label healthLabel = new Label("Waiting");
+  private final ToggleButton allCountButton = new ToggleButton("All 0");
+  private final ToggleButton errorCountLabel = new ToggleButton("0 Errors");
+  private final ToggleButton warningCountLabel = new ToggleButton("0 Warnings");
   private final Label filteredCountLabel = new Label("No file");
   private final Label placeholderLabel = new Label("Open a script or DSL file to see diagnostics.");
   private final TextField filterField = new TextField();
-  private final ComboBox<String> severityFilter = new ComboBox<>(
-      FXCollections.observableArrayList(SEVERITY_ALL, SEVERITY_ERRORS, SEVERITY_WARNINGS)
+  private final ComboBox<String> categoryFilter = new ComboBox<>(
+      FXCollections.observableArrayList(
+          CATEGORY_ALL, CATEGORY_SYNTAX, CATEGORY_FLOW, CATEGORY_ASSETS, CATEGORY_SCRIPTS, CATEGORY_CONTENT)
   );
-  private final Button openSelectedButton = actionButton("Open", CssIcon.expand("#7ec8e3"));
-  private final Button copyDiagnosticsButton = actionButton("Copy", CssIcon.copy("#a8d0f0"));
+  private final Button openSelectedButton = actionButton("Open", CssIcon.expand("#477fae"));
+  private final Button copyDiagnosticsButton = actionButton("Copy Report", CssIcon.copy("#4f7fa5"));
   private final Button clearFilterButton = actionButton("Clear Filter", CssIcon.clearX("#f0a080"));
-  private final Button prevButton = actionButton("↑", null);
-  private final Button nextButton = actionButton("↓", null);
-  private final Button sortButton = actionButton("By Line", null);
+  private final Button refreshButton = actionButton("Rescan", CssIcon.refresh("#447ba7"));
+  private final Button prevButton = actionButton("Prev", CssIcon.arrowUp("#536d86"));
+  private final Button nextButton = actionButton("Next", CssIcon.arrowDown("#536d86"));
+  private final Button sortButton = actionButton("By Line", CssIcon.sort("#536d86"));
   private final ListView<DiagnosticRow> listView = new ListView<>();
 
   private final List<DiagnosticRow> allRows = new ArrayList<>();
   private boolean hasActiveFile;
   private Consumer<Integer> onOpenLine;
   private Consumer<OpenTarget> onOpenTarget;
+  private Runnable onRefresh;
 
   public VnsDiagnosticsView() {
     getStyleClass().addAll("vns-diagnostics-root", "sidebar-tool-root");
     titleLabel.getStyleClass().addAll("vns-diagnostics-title", "sidebar-tool-title");
+    titleLabel.setGraphic(CssIcon.warning("#a66c18"));
+    titleLabel.setGraphicTextGap(7);
     fileLabel.getStyleClass().addAll("vns-diagnostics-file", "sidebar-tool-subtitle");
     summaryLabel.getStyleClass().addAll("vns-diagnostics-summary", "sidebar-tool-summary");
     summaryLabel.setWrapText(true);
@@ -77,10 +93,17 @@ public class VnsDiagnosticsView extends BorderPane {
       statsLabel.setManaged(hasText);
     });
     filteredCountLabel.getStyleClass().add("vns-diagnostics-filter-count");
+    healthLabel.getStyleClass().addAll("vns-diagnostics-health", "vns-diagnostics-health-waiting");
+    allCountButton.getStyleClass().addAll("vns-diagnostics-chip", "vns-diagnostics-chip-all");
     errorCountLabel.getStyleClass().addAll("vns-diagnostics-chip", "vns-diagnostics-chip-error");
     warningCountLabel.getStyleClass().addAll("vns-diagnostics-chip", "vns-diagnostics-chip-warning");
+    ToggleGroup severityGroup = new ToggleGroup();
+    configureSeverityButton(allCountButton, severityGroup, SEVERITY_ALL);
+    configureSeverityButton(errorCountLabel, severityGroup, SEVERITY_ERRORS);
+    configureSeverityButton(warningCountLabel, severityGroup, SEVERITY_WARNINGS);
+    allCountButton.setSelected(true);
 
-    filterField.setPromptText("Filter diagnostics...");
+    filterField.setPromptText("Search message, code, source, or line...");
     filterField.getStyleClass().add("vns-diagnostics-filter");
     filterField.textProperty().addListener((obs, oldValue, newValue) -> applyFilter());
     filterField.setOnKeyPressed(e -> {
@@ -90,18 +113,18 @@ public class VnsDiagnosticsView extends BorderPane {
       }
     });
 
-    severityFilter.setValue(SEVERITY_ALL);
-    severityFilter.setFocusTraversable(false);
-    severityFilter.setPrefWidth(96);
-    severityFilter.getStyleClass().add("vns-diagnostics-severity-filter");
-    severityFilter.setButtonCell(new javafx.scene.control.ListCell<>() {
+    categoryFilter.setValue(CATEGORY_ALL);
+    categoryFilter.setFocusTraversable(false);
+    categoryFilter.setPrefWidth(128);
+    categoryFilter.getStyleClass().add("vns-diagnostics-category-filter");
+    categoryFilter.setButtonCell(new javafx.scene.control.ListCell<>() {
       @Override
       protected void updateItem(String item, boolean empty) {
         super.updateItem(item, empty);
         setText(empty ? "" : item);
       }
     });
-    severityFilter.getSelectionModel().selectedItemProperty().addListener((obs, oldValue, newValue) -> applyFilter());
+    categoryFilter.getSelectionModel().selectedItemProperty().addListener((obs, oldValue, newValue) -> applyFilter());
 
     placeholderLabel.getStyleClass().add("vns-diagnostics-placeholder");
     placeholderLabel.setWrapText(true);
@@ -114,13 +137,26 @@ public class VnsDiagnosticsView extends BorderPane {
       openSelectedRow();
     });
     listView.setOnKeyPressed(e -> {
-      if (e.getCode() != KeyCode.ENTER) return;
-      openSelectedRow();
+      if (e.getCode() == KeyCode.ENTER) {
+        openSelectedRow();
+        e.consume();
+      } else if (e.getCode() == KeyCode.F4) {
+        navigateDiagnostic(e.isShiftDown() ? -1 : 1);
+        e.consume();
+      } else if (e.getCode() == KeyCode.C && e.isShortcutDown()) {
+        DiagnosticRow selected = listView.getSelectionModel().getSelectedItem();
+        if (selected != null) copySingleDiagnostic(selected);
+        e.consume();
+      }
     });
 
     openSelectedButton.setOnAction(e -> openSelectedRow());
     copyDiagnosticsButton.setOnAction(e -> copyVisibleDiagnostics());
     clearFilterButton.setOnAction(e -> clearFilters());
+    refreshButton.setTooltip(new Tooltip("Run diagnostics again for the active editor"));
+    refreshButton.setOnAction(e -> {
+      if (onRefresh != null) onRefresh.run();
+    });
 
     prevButton.setTooltip(new Tooltip("Previous diagnostic (wraps around)"));
     prevButton.setOnAction(e -> navigateDiagnostic(-1));
@@ -137,36 +173,48 @@ public class VnsDiagnosticsView extends BorderPane {
       applyFilter();
     });
 
+    javafx.scene.layout.Region titleSpacer = new javafx.scene.layout.Region();
+    HBox.setHgrow(titleSpacer, Priority.ALWAYS);
     HBox titleRow = new HBox(8, titleLabel, SidebarToolHelp.button(this, "VNS Diagnostics", """
-        The Diagnostics panel scans the active .vns script file and reports \
-errors, warnings, and informational messages in real time.
+        The Diagnostics panel scans the active script or DSL file and reports \
+errors and warnings in real time.
 
 Severity levels:
   • Error   — something that will prevent the script from running correctly \
 (e.g. an undefined character ID, a missing @label target)
   • Warning — a potential problem that won't block execution but may produce \
 unexpected results (e.g. unreachable labels, duplicate keys)
-  • Info    — style suggestions and best-practice hints
-
 Clicking a diagnostic entry jumps the editor cursor to the affected line so \
 you can fix it immediately. Use the filter bar to narrow results by keyword \
-or severity, and the copy button to export the full list for sharing."""));
+or category. F4 and Shift+F4 move between findings. Copy Report exports the \
+visible, source-aware result set for sharing."""),
+        titleSpacer, healthLabel);
     titleRow.setAlignment(Pos.CENTER_LEFT);
     titleRow.getStyleClass().add("vns-diagnostics-title-row");
 
-    HBox countsRow = new HBox(8, errorCountLabel, warningCountLabel);
+    HBox countsRow = new HBox(6, allCountButton, errorCountLabel, warningCountLabel);
     countsRow.setAlignment(Pos.CENTER_LEFT);
+    countsRow.getStyleClass().add("vns-diagnostics-severity-row");
 
     VBox header = new VBox(6, titleRow, fileLabel, summaryLabel, statsLabel, countsRow);
     header.setPadding(new Insets(10, 10, 6, 10));
     header.getStyleClass().add("vns-diagnostics-header");
 
-    HBox filterRow = new HBox(8, filterField, severityFilter, sortButton);
+    HBox filterRow = new HBox(8, filterField, categoryFilter, sortButton);
     filterRow.setPadding(new Insets(0, 10, 8, 10));
     HBox.setHgrow(filterField, Priority.ALWAYS);
     filterRow.getStyleClass().add("vns-diagnostics-filter-row");
 
-    HBox actionRow = new HBox(8, openSelectedButton, prevButton, nextButton, copyDiagnosticsButton, clearFilterButton, filteredCountLabel);
+    FlowPane actionRow = new FlowPane(
+        6,
+        6,
+        refreshButton,
+        openSelectedButton,
+        prevButton,
+        nextButton,
+        copyDiagnosticsButton,
+        clearFilterButton,
+        filteredCountLabel);
     actionRow.setAlignment(Pos.CENTER_LEFT);
     actionRow.setPadding(new Insets(0, 10, 8, 10));
     actionRow.getStyleClass().add("vns-diagnostics-action-row");
@@ -185,14 +233,21 @@ or severity, and the copy button to export the full list for sharing."""));
     this.onOpenTarget = onOpenTarget;
   }
 
+  public void setOnRefresh(Runnable onRefresh) {
+    this.onRefresh = onRefresh;
+    updateActionState();
+  }
+
   public void clear() {
     hasActiveFile = false;
     fileLabel.setText("No active file");
     fileLabel.setTooltip(null);
     summaryLabel.setText("Open a script or DSL file to see diagnostics.");
     statsLabel.setText("");
+    allCountButton.setText("All 0");
     errorCountLabel.setText("0 Errors");
     warningCountLabel.setText("0 Warnings");
+    setHealth("Waiting", "waiting");
     allRows.clear();
     listView.getItems().clear();
     updatePlaceholder(0);
@@ -239,15 +294,20 @@ or severity, and the copy button to export the full list for sharing."""));
     }
     errorCountLabel.setText(errors + (errors == 1 ? " Error" : " Errors"));
     warningCountLabel.setText(warnings + (warnings == 1 ? " Warning" : " Warnings"));
+    allCountButton.setText("All " + (errors + warnings));
 
     if (errors == 0 && warnings == 0) {
       summaryLabel.setText(label + ": no issues found.");
+      setHealth("Clean", "clean");
     } else if (errors > 0 && warnings > 0) {
       summaryLabel.setText(label + ": " + errors + " errors, " + warnings + " warnings");
+      setHealth(errors + " blocking", "error");
     } else if (errors > 0) {
       summaryLabel.setText(label + ": " + errors + (errors == 1 ? " error" : " errors"));
+      setHealth(errors + " blocking", "error");
     } else {
       summaryLabel.setText(label + ": " + warnings + (warnings == 1 ? " warning" : " warnings"));
+      setHealth(warnings + " to review", "warning");
     }
 
     applyFilter();
@@ -260,6 +320,7 @@ or severity, and the copy button to export the full list for sharing."""));
     List<DiagnosticRow> filtered = new ArrayList<>();
     for (DiagnosticRow row : allRows) {
       if (!matchesSeverity(row)) continue;
+      if (!matchesCategory(row)) continue;
       if (!normalized.isEmpty() && !row.searchText().contains(normalized)) continue;
       filtered.add(row);
     }
@@ -292,7 +353,8 @@ or severity, and the copy button to export the full list for sharing."""));
   }
 
   private boolean matchesSeverity(DiagnosticRow row) {
-    String selected = severityFilter.getValue();
+    ToggleButton selectedButton = selectedSeverityButton();
+    String selected = selectedButton == null ? SEVERITY_ALL : String.valueOf(selectedButton.getUserData());
     if (SEVERITY_ERRORS.equals(selected)) {
       return !row.issue().warning();
     }
@@ -302,11 +364,21 @@ or severity, and the copy button to export the full list for sharing."""));
     return true;
   }
 
+  private boolean matchesCategory(DiagnosticRow row) {
+    String selected = categoryFilter.getValue();
+    return selected == null
+        || CATEGORY_ALL.equals(selected)
+        || selected.equals(categoryForKind(row.issue().kind()));
+  }
+
   private void clearFilters() {
     boolean changed = filterField.getText() != null && !filterField.getText().isBlank();
-    changed = changed || !SEVERITY_ALL.equals(severityFilter.getValue());
+    ToggleButton selectedButton = selectedSeverityButton();
+    changed = changed || selectedButton != allCountButton;
+    changed = changed || !CATEGORY_ALL.equals(categoryFilter.getValue());
     filterField.clear();
-    severityFilter.setValue(SEVERITY_ALL);
+    allCountButton.setSelected(true);
+    categoryFilter.setValue(CATEGORY_ALL);
     if (!changed) applyFilter();
   }
 
@@ -337,6 +409,14 @@ or severity, and the copy button to export the full list for sharing."""));
     if (rows == null || rows.isEmpty()) return;
 
     StringBuilder out = new StringBuilder();
+    out.append("Diagnostics — ").append(fileLabel.getText()).append(System.lineSeparator());
+    if (!summaryLabel.getText().isBlank()) {
+      out.append(summaryLabel.getText()).append(System.lineSeparator());
+    }
+    if (!statsLabel.getText().isBlank()) {
+      out.append(statsLabel.getText()).append(System.lineSeparator());
+    }
+    out.append(System.lineSeparator());
     for (DiagnosticRow row : rows) {
       out.append(row.level())
           .append(" ")
@@ -382,12 +462,32 @@ or severity, and the copy button to export the full list for sharing."""));
     boolean hasVisibleRows = !listView.getItems().isEmpty();
     boolean hasSelection = listView.getSelectionModel().getSelectedItem() != null;
     boolean hasFilter = (filterField.getText() != null && !filterField.getText().isBlank())
-        || !SEVERITY_ALL.equals(severityFilter.getValue());
+        || selectedSeverityButton() != allCountButton
+        || !CATEGORY_ALL.equals(categoryFilter.getValue());
+    refreshButton.setDisable(!hasActiveFile || onRefresh == null);
     openSelectedButton.setDisable(!hasSelection);
     prevButton.setDisable(!hasVisibleRows);
     nextButton.setDisable(!hasVisibleRows);
     copyDiagnosticsButton.setDisable(!hasVisibleRows);
     clearFilterButton.setDisable(!hasFilter);
+  }
+
+  private ToggleButton selectedSeverityButton() {
+    if (allCountButton.getToggleGroup() == null) return allCountButton;
+    if (allCountButton.getToggleGroup().getSelectedToggle() instanceof ToggleButton button) {
+      return button;
+    }
+    return allCountButton;
+  }
+
+  private void setHealth(String text, String tone) {
+    healthLabel.setText(text == null ? "" : text);
+    healthLabel.getStyleClass().removeAll(
+        "vns-diagnostics-health-waiting",
+        "vns-diagnostics-health-clean",
+        "vns-diagnostics-health-warning",
+        "vns-diagnostics-health-error");
+    healthLabel.getStyleClass().add("vns-diagnostics-health-" + tone);
   }
 
   private static DiagnosticRow buildRow(String source, Diagnostic issue) {
@@ -485,6 +585,40 @@ or severity, and the copy button to export the full list for sharing."""));
     String normalized = kind.replace('_', ' ').trim();
     if (normalized.isEmpty()) return "Issue";
     return Character.toUpperCase(normalized.charAt(0)) + normalized.substring(1);
+  }
+
+  static String categoryForKind(String kind) {
+    String normalized = kind == null ? "" : kind.trim().toLowerCase(Locale.ROOT);
+    if (containsAny(normalized, "asset", "background", "image", "audio", "voice", "sfx", "bgm")) {
+      return CATEGORY_ASSETS;
+    }
+    if (containsAny(normalized, "script", "include", "interop", "provider", "jes")) {
+      return CATEGORY_SCRIPTS;
+    }
+    if (containsAny(normalized, "label", "flow", "jump", "goto", "return", "unreachable", "branch")) {
+      return CATEGORY_FLOW;
+    }
+    if (containsAny(normalized, "parse", "syntax", "invalid", "malformed", "duplicate", "unknown")) {
+      return CATEGORY_SYNTAX;
+    }
+    return CATEGORY_CONTENT;
+  }
+
+  private static boolean containsAny(String value, String... tokens) {
+    if (value == null || value.isBlank() || tokens == null) return false;
+    for (String token : tokens) {
+      if (token != null && !token.isBlank() && value.contains(token)) return true;
+    }
+    return false;
+  }
+
+  private void configureSeverityButton(ToggleButton button, ToggleGroup group, String severity) {
+    button.setToggleGroup(group);
+    button.setUserData(severity);
+    button.setMnemonicParsing(false);
+    button.setFocusTraversable(false);
+    button.setOnAction(e -> applyFilter());
+    button.setTooltip(new Tooltip("Show " + severity.toLowerCase(Locale.ROOT) + " diagnostics"));
   }
 
   private static String buildStatsSummary(VnsScriptAnalyzer.ScriptStats stats) {

--- a/modules/editor/src/main/java/com/jvn/editor/ui/VnsScriptAnalyzer.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/VnsScriptAnalyzer.java
@@ -32,6 +32,10 @@ import com.jvn.core.vn.script.VnScriptParser;
 public final class VnsScriptAnalyzer {
   private static final Pattern LABEL_PATTERN = Pattern.compile("^\\s*(?:@label|label)\\s+(\\S+)\\s*$", Pattern.CASE_INSENSITIVE);
   private static final Pattern BG_DECL_PATTERN = Pattern.compile("^\\s*@background\\s+(\\S+)\\s+(.+)\\s*$", Pattern.CASE_INSENSITIVE);
+  private static final Pattern CHARIMG_PATTERN = Pattern.compile(
+      "^\\s*@charimg\\s+(\\S+)\\s+(\\S+)\\s+(.+)\\s*$", Pattern.CASE_INSENSITIVE);
+  private static final Pattern CHARLAYER_PATTERN = Pattern.compile(
+      "^\\s*@charlayer\\s+(\\S+)\\s+(\\S+)\\s+(.+)\\s*$", Pattern.CASE_INSENSITIVE);
   private static final Pattern COMMAND_PATTERN = Pattern.compile("^\\s*\\[(.+)]\\s*$");
   private static final Pattern CHOICE_IF_SUFFIX_PATTERN = Pattern.compile("^(.*)\\[if\\s+(.+)]\\s*$", Pattern.CASE_INSENSITIVE);
   private static final Pattern IF_GOTO_PATTERN = Pattern.compile("^(.+?)\\s+goto\\s+(\\S+)\\s*$", Pattern.CASE_INSENSITIVE);
@@ -131,6 +135,28 @@ public final class VnsScriptAnalyzer {
         }
       }
 
+      Matcher charImageMatcher = CHARIMG_PATTERN.matcher(line.text);
+      if (charImageMatcher.matches()) {
+        addAssetDiagnostic(
+            projectRoot,
+            diagnostics,
+            line,
+            stripWrappingQuotes(charImageMatcher.group(3)),
+            "character image",
+            "missing_character_asset");
+      }
+
+      Matcher charLayerMatcher = CHARLAYER_PATTERN.matcher(line.text);
+      if (charLayerMatcher.matches()) {
+        addAssetDiagnostic(
+            projectRoot,
+            diagnostics,
+            line,
+            stripWrappingQuotes(charLayerMatcher.group(3)),
+            "character layer",
+            "missing_character_asset");
+      }
+
       if (trimmed.startsWith(">")) {
         addChoiceReference(line, trimmed.substring(1).trim(), refs);
         continue;
@@ -184,6 +210,15 @@ public final class VnsScriptAnalyzer {
               -1
           ));
         }
+      } else if (isAudioAssetCommand(cmd)) {
+        String path = audioAssetPath(cmd, arg);
+        addAssetDiagnostic(
+            projectRoot,
+            diagnostics,
+            line,
+            path,
+            audioAssetKind(cmd),
+            "missing_audio_asset");
       } else if (projectRoot != null) {
         addScriptAssetDiagnostic(projectRoot, diagnostics, line, cmd, arg);
       }
@@ -207,6 +242,7 @@ public final class VnsScriptAnalyzer {
     List<LabelNode> labels = new ArrayList<>(labelsByName.values());
     labels.sort((a, b) -> Integer.compare(a.line(), b.line()));
     List<FlowEdge> edges = computeFlowEdges(source, lines, labelsByName, labels);
+    addUnreachableStatementDiagnostics(lines, diagnostics);
 
     if (!labels.isEmpty()) {
       String startLabel = pickStartLabel(labelsByName, labels);
@@ -228,6 +264,7 @@ public final class VnsScriptAnalyzer {
       }
     }
 
+    diagnostics = deduplicateDiagnostics(diagnostics);
     diagnostics.sort((a, b) -> {
       int sa = a.start();
       int sb = b.start();
@@ -512,6 +549,154 @@ public final class VnsScriptAnalyzer {
     return new LabelRef(target, start, start + target.length(), line.index);
   }
 
+  private static void addUnreachableStatementDiagnostics(List<LineInfo> lines,
+                                                         List<Diagnostic> diagnostics) {
+    boolean flowTerminated = false;
+    boolean reportedInBlock = false;
+    for (LineInfo line : lines) {
+      String trimmed = line.trimmed();
+      if (trimmed.isEmpty() || trimmed.startsWith("#")) continue;
+      if (LABEL_PATTERN.matcher(line.text).matches()) {
+        flowTerminated = false;
+        reportedInBlock = false;
+        continue;
+      }
+
+      if (flowTerminated) {
+        if (!reportedInBlock) {
+          int start = line.start + firstNonWhitespaceIndex(line.text);
+          diagnostics.add(Diagnostic.warning(
+              "unreachable_statement",
+              "This statement cannot run because an earlier command already exits this label.",
+              start,
+              Math.max(start + 1, line.end),
+              line.index,
+              null,
+              null,
+              -1
+          ));
+          reportedInBlock = true;
+        }
+        continue;
+      }
+
+      Matcher commandMatcher = COMMAND_PATTERN.matcher(trimmed);
+      if (!commandMatcher.matches()) continue;
+      String body = commandMatcher.group(1).trim();
+      if (body.isBlank()) continue;
+      String command = body.split("\\s+", 2)[0].toLowerCase(Locale.ROOT);
+      if ("end".equals(command) || "jump".equals(command) || "goto".equals(command)) {
+        flowTerminated = true;
+      }
+    }
+  }
+
+  private static int firstNonWhitespaceIndex(String text) {
+    if (text == null) return 0;
+    for (int i = 0; i < text.length(); i++) {
+      if (!Character.isWhitespace(text.charAt(i))) return i;
+    }
+    return 0;
+  }
+
+  private static boolean isAudioAssetCommand(String command) {
+    if (command == null) return false;
+    return switch (command.toLowerCase(Locale.ROOT)) {
+      case "bgm", "bgm_crossfade", "sfx", "voice" -> true;
+      default -> false;
+    };
+  }
+
+  private static String audioAssetKind(String command) {
+    if (command == null) return "audio";
+    return switch (command.toLowerCase(Locale.ROOT)) {
+      case "bgm", "bgm_crossfade" -> "background music";
+      case "voice" -> "voice";
+      case "sfx" -> "sound effect";
+      default -> "audio";
+    };
+  }
+
+  private static String audioAssetPath(String command, String argument) {
+    String[] tokens = VnArgTokenizer.tokenizeToArray(argument);
+    if (tokens.length == 0) return "";
+    for (String rawToken : tokens) {
+      String token = rawToken == null ? "" : rawToken.trim();
+      if (token.isBlank()) continue;
+      int separator = token.indexOf('=');
+      if (separator <= 0) separator = token.indexOf(':');
+      if (separator > 0 && separator < token.length() - 1) {
+        String key = token.substring(0, separator).trim().toLowerCase(Locale.ROOT);
+        if (Set.of("track", "id", "file", "path").contains(key)) {
+          return stripWrappingQuotes(token.substring(separator + 1));
+        }
+        continue;
+      }
+      return stripWrappingQuotes(token);
+    }
+    return "";
+  }
+
+  private static void addAssetDiagnostic(File projectRoot,
+                                         List<Diagnostic> diagnostics,
+                                         LineInfo line,
+                                         String rawPath,
+                                         String assetKind,
+                                         String missingKind) {
+    String path = rawPath == null ? "" : rawPath.trim();
+    if (projectRoot == null || path.isBlank() || isDynamicAssetPath(path)) return;
+
+    int pathStart = line.start + safeIndexOf(line.text, path, firstNonWhitespaceIndex(line.text));
+    File direct = new File(path);
+    if (direct.isAbsolute()) {
+      diagnostics.add(Diagnostic.warning(
+          "external_asset_path",
+          "Absolute " + assetKind + " path is not portable: " + path,
+          pathStart,
+          pathStart + path.length(),
+          line.index,
+          null,
+          path,
+          -1
+      ));
+    }
+
+    if (assetExists(projectRoot, path)) return;
+    diagnostics.add(Diagnostic.error(
+        missingKind,
+        "Missing " + assetKind + " asset: " + path,
+        pathStart,
+        pathStart + path.length(),
+        line.index,
+        null,
+        path,
+        -1
+    ));
+  }
+
+  private static boolean isDynamicAssetPath(String path) {
+    String normalized = path == null ? "" : path.trim().toLowerCase(Locale.ROOT);
+    return normalized.isBlank()
+        || normalized.contains("${")
+        || normalized.startsWith("$")
+        || normalized.startsWith("http://")
+        || normalized.startsWith("https://")
+        || normalized.startsWith("classpath:")
+        || normalized.startsWith("data:");
+  }
+
+  private static String stripWrappingQuotes(String value) {
+    String trimmed = value == null ? "" : value.trim();
+    if (trimmed.length() >= 2) {
+      char first = trimmed.charAt(0);
+      char last = trimmed.charAt(trimmed.length() - 1);
+      if ((first == '"' && last == '"') || (first == '\'' && last == '\'')) {
+        return trimmed.substring(1, trimmed.length() - 1);
+      }
+    }
+    return trimmed;
+  }
+
   private static boolean assetExists(File projectRoot, String path) {
     if (path == null || path.isBlank()) return false;
     File resolved = resolveAssetPath(projectRoot, path);
@@ -525,18 +710,52 @@ public final class VnsScriptAnalyzer {
                                                String arg) {
     ScriptRef ref = scriptReference(cmd, arg);
     if (ref == null || ref.path() == null || ref.path().isBlank()) return;
-    if (assetExists(projectRoot, ref.path())) return;
-    int pathStart = line.start + safeIndexOf(line.text, ref.path(), 0);
-    diagnostics.add(Diagnostic.error(
-        "missing_script",
-        "Missing " + ref.kind() + " script: " + ref.path(),
-        pathStart,
-        pathStart + ref.path().length(),
-        line.index,
-        null,
-        ref.path(),
-        -1
-    ));
+    String target = ref.label() == null || ref.label().isBlank()
+        ? ref.path()
+        : ref.path() + ":" + ref.label();
+    int pathStart = line.start + safeIndexOf(line.text, target, safeIndexOf(line.text, ref.path(), 0));
+    File scriptFile = resolveAssetPath(projectRoot, ref.path());
+    if (scriptFile == null || !scriptFile.isFile()) {
+      diagnostics.add(Diagnostic.error(
+          "missing_script",
+          "Missing " + ref.kind() + " script: " + ref.path(),
+          pathStart,
+          pathStart + target.length(),
+          line.index,
+          null,
+          ref.path(),
+          -1
+      ));
+      return;
+    }
+    if ("VNS".equals(ref.kind())
+        && ref.label() != null
+        && !ref.label().isBlank()
+        && !scriptDeclaresLabel(scriptFile, ref.label())) {
+      diagnostics.add(Diagnostic.error(
+          "missing_script_label",
+          "VNS script '" + ref.path() + "' has no label named '" + ref.label() + "'.",
+          pathStart,
+          pathStart + target.length(),
+          line.index,
+          ref.label(),
+          ref.path(),
+          -1
+      ));
+    }
+  }
+
+  private static boolean scriptDeclaresLabel(File scriptFile, String targetLabel) {
+    if (scriptFile == null || targetLabel == null || targetLabel.isBlank()) return false;
+    try {
+      for (String line : Files.readAllLines(scriptFile.toPath(), StandardCharsets.UTF_8)) {
+        Matcher matcher = LABEL_PATTERN.matcher(line);
+        if (matcher.matches() && targetLabel.equals(matcher.group(1))) return true;
+      }
+    } catch (Exception ignored) {
+      // A readable target is required for reliable cross-script navigation.
+    }
+    return false;
   }
 
   private static ScriptRef scriptReference(String cmd, String arg) {
@@ -561,7 +780,7 @@ public final class VnsScriptAnalyzer {
     if ("goto".equals(action)) {
       int colon = toks[1].indexOf(':');
       if (colon > 0 && toks[1].substring(0, colon).contains(".")) {
-        return directScriptRef("VNS", toks[1].substring(0, colon));
+        return new ScriptRef("VNS", toks[1].substring(0, colon), toks[1].substring(colon + 1));
       }
     }
     return null;
@@ -573,7 +792,7 @@ public final class VnsScriptAnalyzer {
     if (colon <= 0) return null;
     String script = target.substring(0, colon);
     if (script.indexOf('.') < 0 && !script.contains("/")) return null;
-    return directScriptRef("VNS", script);
+    return new ScriptRef("VNS", script, target.substring(colon + 1));
   }
 
   private static ScriptRef jesPayloadRef(String arg) {
@@ -586,10 +805,10 @@ public final class VnsScriptAnalyzer {
 
   private static ScriptRef directScriptRef(String kind, String path) {
     if (path == null || path.isBlank()) return null;
-    return new ScriptRef(kind, path);
+    return new ScriptRef(kind, path, null);
   }
 
-  private record ScriptRef(String kind, String path) {}
+  private record ScriptRef(String kind, String path, String label) {}
 
   private static File resolveAssetPath(File projectRoot, String rawPath) {
     if (rawPath == null || rawPath.isBlank()) return null;
@@ -625,6 +844,22 @@ public final class VnsScriptAnalyzer {
       if (f.exists()) return f;
     }
     return new File(projectRoot, normalized);
+  }
+
+  private static List<Diagnostic> deduplicateDiagnostics(List<Diagnostic> diagnostics) {
+    if (diagnostics == null || diagnostics.isEmpty()) return new ArrayList<>();
+    List<Diagnostic> unique = new ArrayList<>();
+    Set<String> seen = new LinkedHashSet<>();
+    for (Diagnostic diagnostic : diagnostics) {
+      if (diagnostic == null) continue;
+      String key = diagnostic.kind()
+          + "|" + diagnostic.start()
+          + "|" + diagnostic.end()
+          + "|" + diagnostic.warning()
+          + "|" + diagnostic.message();
+      if (seen.add(key)) unique.add(diagnostic);
+    }
+    return unique;
   }
 
   private static int parseLineFromMessage(String message) {

--- a/modules/editor/src/main/resources/com/jvn/editor/editor-light.css
+++ b/modules/editor/src/main/resources/com/jvn/editor/editor-light.css
@@ -2666,13 +2666,15 @@
 
 .vns-diagnostics-root {
   -fx-background-color:
-      linear-gradient(to bottom, rgba(0, 0, 0, 0.02), rgba(0, 0, 0, 0.0)),
-      linear-gradient(to bottom, #e8e8e8 0%, #efefef 100%);
+      linear-gradient(to bottom, rgba(255, 255, 255, 0.42), rgba(255, 255, 255, 0.0)),
+      linear-gradient(to bottom, #e7eef3 0%, #edf1f4 100%);
 }
 
 .vns-diagnostics-header {
-  -fx-background-color: rgba(239, 239, 239, 0.9);
-  -fx-border-color: #d3d3d3;
+  -fx-background-color:
+      linear-gradient(to bottom, rgba(255, 255, 255, 0.88), rgba(255, 255, 255, 0.18)),
+      linear-gradient(to bottom, #e7f4fc 0%, #cfdfea 100%);
+  -fx-border-color: #9fb7c8;
   -fx-border-width: 0 0 1 0;
 }
 
@@ -2698,35 +2700,86 @@
 }
 
 .vns-diagnostics-stats {
-  -fx-text-fill: #4e5b6c;
+  -fx-text-fill: #344c60;
   -fx-font-size: 11px;
   -fx-font-weight: 700;
   -fx-padding: 5 8 5 8;
-  -fx-background-color: rgba(255, 255, 255, 0.72);
+  -fx-background-color: rgba(255, 255, 255, 0.66);
   -fx-background-radius: 8;
   -fx-border-color: #d1d8e2;
   -fx-border-radius: 8;
+}
+
+.vns-diagnostics-health {
+  -fx-font-size: 10px;
+  -fx-font-weight: 900;
+  -fx-padding: 4 9 4 9;
+  -fx-background-radius: 10;
+  -fx-border-radius: 10;
+  -fx-border-width: 1;
+}
+
+.vns-diagnostics-health-waiting {
+  -fx-text-fill: #4f6170;
+  -fx-background-color: rgba(233, 240, 245, 0.92);
+  -fx-border-color: #b2c2cd;
+}
+
+.vns-diagnostics-health-clean {
+  -fx-text-fill: #285e3c;
+  -fx-background-color: rgba(218, 241, 224, 0.94);
+  -fx-border-color: #8fbd9e;
+}
+
+.vns-diagnostics-health-warning {
+  -fx-text-fill: #76531c;
+  -fx-background-color: rgba(255, 237, 196, 0.95);
+  -fx-border-color: #d0aa59;
+}
+
+.vns-diagnostics-health-error {
+  -fx-text-fill: #7a2d3c;
+  -fx-background-color: rgba(250, 220, 226, 0.95);
+  -fx-border-color: #c78491;
 }
 
 .vns-diagnostics-chip {
   -fx-font-size: 10px;
   -fx-font-weight: 800;
   -fx-padding: 4 9 4 9;
-  -fx-background-radius: 999;
-  -fx-border-radius: 999;
+  -fx-background-radius: 10;
+  -fx-border-radius: 10;
   -fx-border-width: 1;
+  -fx-cursor: hand;
+}
+
+.vns-diagnostics-chip-all {
+  -fx-text-fill: #334957;
+  -fx-background-color: linear-gradient(to bottom, #f8fcff, #dce8ef);
+  -fx-border-color: #a8bcc9;
 }
 
 .vns-diagnostics-chip-error {
-  -fx-text-fill: #ffd8df;
-  -fx-background-color: rgba(109, 42, 57, 0.9);
-  -fx-border-color: #8f5061;
+  -fx-text-fill: #793145;
+  -fx-background-color: linear-gradient(to bottom, #fff6f8, #efd8de);
+  -fx-border-color: #c4939f;
 }
 
 .vns-diagnostics-chip-warning {
-  -fx-text-fill: #ffe5ba;
-  -fx-background-color: rgba(98, 72, 28, 0.9);
-  -fx-border-color: #9b7a3c;
+  -fx-text-fill: #74531e;
+  -fx-background-color: linear-gradient(to bottom, #fffaf0, #eee0bf);
+  -fx-border-color: #c9aa67;
+}
+
+.vns-diagnostics-chip:hover {
+  -fx-effect: dropshadow(gaussian, rgba(63, 106, 137, 0.18), 5, 0.25, 0, 1);
+}
+
+.vns-diagnostics-chip:selected,
+.vns-diagnostics-chip:selected:hover {
+  -fx-text-fill: white;
+  -fx-background-color: linear-gradient(to bottom, #5e9cca, #3676a7);
+  -fx-border-color: #285e87;
 }
 
 .vns-diagnostics-filter-row {
@@ -2787,7 +2840,8 @@
   -fx-effect: none;
 }
 
-.vns-diagnostics-severity-filter {
+.vns-diagnostics-severity-filter,
+.vns-diagnostics-category-filter {
   -fx-font-size: 11px;
   -fx-background-color: #e5e5e5;
   -fx-border-color: #cbcbcb;
@@ -2797,37 +2851,45 @@
   -fx-text-fill: #121212;
 }
 
-.vns-diagnostics-severity-filter:focused {
+.vns-diagnostics-severity-filter:focused,
+.vns-diagnostics-category-filter:focused {
   -fx-border-color: #8e8e8e;
 }
 
-.vns-diagnostics-severity-filter .list-cell {
+.vns-diagnostics-severity-filter .list-cell,
+.vns-diagnostics-category-filter .list-cell {
   -fx-background-color: #e5e5e5;
   -fx-text-fill: #121212;
 }
 
-.vns-diagnostics-severity-filter .arrow-button {
+.vns-diagnostics-severity-filter .arrow-button,
+.vns-diagnostics-category-filter .arrow-button {
   -fx-background-color: #e5e5e5;
   -fx-background-radius: 0 10 10 0;
 }
 
-.vns-diagnostics-severity-filter .arrow {
+.vns-diagnostics-severity-filter .arrow,
+.vns-diagnostics-category-filter .arrow {
   -fx-background-color: #1f1f1f;
 }
 
-.vns-diagnostics-severity-filter .combo-box-popup .list-view {
+.vns-diagnostics-severity-filter .combo-box-popup .list-view,
+.vns-diagnostics-category-filter .combo-box-popup .list-view {
   -fx-background-color: #e7e7e7;
   -fx-control-inner-background: #e7e7e7;
   -fx-border-color: #cbcbcb;
 }
 
-.vns-diagnostics-severity-filter .combo-box-popup .list-cell {
+.vns-diagnostics-severity-filter .combo-box-popup .list-cell,
+.vns-diagnostics-category-filter .combo-box-popup .list-cell {
   -fx-background-color: #e7e7e7;
   -fx-text-fill: #141414;
 }
 
 .vns-diagnostics-severity-filter .combo-box-popup .list-cell:hover,
-.vns-diagnostics-severity-filter .combo-box-popup .list-cell:selected {
+.vns-diagnostics-severity-filter .combo-box-popup .list-cell:selected,
+.vns-diagnostics-category-filter .combo-box-popup .list-cell:hover,
+.vns-diagnostics-category-filter .combo-box-popup .list-cell:selected {
   -fx-background-color: #d9d9d9;
 }
 
@@ -7155,4 +7217,44 @@
   -fx-font-family: "JetBrains Mono", "Consolas", monospace;
   -fx-font-size: 10px;
   -fx-pref-row-count: 8;
+}
+
+/* Diagnostics keeps a compact Windows 7-style glass surface over shared sidebar defaults. */
+.vns-diagnostics-root.sidebar-tool-root {
+  -fx-background-color:
+      linear-gradient(to bottom, rgba(255, 255, 255, 0.42), rgba(255, 255, 255, 0.0)),
+      linear-gradient(to bottom, #e7eef3 0%, #edf1f4 100%);
+}
+
+.vns-diagnostics-root .vns-diagnostics-header {
+  -fx-background-color:
+      linear-gradient(to bottom, rgba(255, 255, 255, 0.88), rgba(255, 255, 255, 0.18)),
+      linear-gradient(to bottom, #e7f4fc 0%, #cfdfea 100%);
+  -fx-border-color: #9fb7c8;
+}
+
+.vns-diagnostics-root .vns-diagnostics-chip.vns-diagnostics-chip-all {
+  -fx-text-fill: #334957;
+  -fx-background-color: linear-gradient(to bottom, #f8fcff, #dce8ef);
+  -fx-border-color: #a8bcc9;
+}
+
+.vns-diagnostics-root .vns-diagnostics-chip.vns-diagnostics-chip-error {
+  -fx-text-fill: #793145;
+  -fx-background-color: linear-gradient(to bottom, #fff6f8, #efd8de);
+  -fx-border-color: #c4939f;
+}
+
+.vns-diagnostics-root .vns-diagnostics-chip.vns-diagnostics-chip-warning {
+  -fx-text-fill: #74531e;
+  -fx-background-color: linear-gradient(to bottom, #fffaf0, #eee0bf);
+  -fx-border-color: #c9aa67;
+}
+
+.vns-diagnostics-root .vns-diagnostics-chip.vns-diagnostics-chip-all:selected,
+.vns-diagnostics-root .vns-diagnostics-chip.vns-diagnostics-chip-error:selected,
+.vns-diagnostics-root .vns-diagnostics-chip.vns-diagnostics-chip-warning:selected {
+  -fx-text-fill: white;
+  -fx-background-color: linear-gradient(to bottom, #64a4d2, #3476a8);
+  -fx-border-color: #285e87;
 }

--- a/modules/editor/src/test/java/com/jvn/editor/ui/VnsDiagnosticsViewFxTest.java
+++ b/modules/editor/src/test/java/com/jvn/editor/ui/VnsDiagnosticsViewFxTest.java
@@ -1,0 +1,97 @@
+package com.jvn.editor.ui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.scene.control.ListView;
+import javafx.scene.control.ToggleButton;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class VnsDiagnosticsViewFxTest {
+  private static boolean toolkitAvailable;
+
+  @BeforeAll
+  static void startToolkit() {
+    if (System.getProperty("os.name", "").toLowerCase().contains("linux")
+        && System.getenv().getOrDefault("DISPLAY", "").isBlank()) {
+      return;
+    }
+    try {
+      CountDownLatch ready = new CountDownLatch(1);
+      Platform.startup(ready::countDown);
+      toolkitAvailable = ready.await(10, TimeUnit.SECONDS);
+    } catch (IllegalStateException alreadyStarted) {
+      toolkitAvailable = true;
+    } catch (Exception unavailable) {
+      toolkitAvailable = false;
+    }
+  }
+
+  @Test
+  void toolbarFiltersFindingsAndRescans(@TempDir Path tempDir) throws Exception {
+    Assumptions.assumeTrue(toolkitAvailable, "JavaFX toolkit is unavailable in this environment");
+    runFx(() -> {
+      VnsDiagnosticsView view = new VnsDiagnosticsView();
+      AtomicBoolean rescanned = new AtomicBoolean();
+      view.setOnRefresh(() -> rescanned.set(true));
+      view.setDiagnostics(
+          tempDir.resolve("demo.vns").toFile(),
+          "VNS",
+          "[jump missing]\n[bgm assets/audio/missing.ogg]",
+          "2 lines",
+          List.of(
+              VnsDiagnosticsView.Diagnostic.error("undefined_label", "Undefined label: missing", 6, 13, 0),
+              VnsDiagnosticsView.Diagnostic.warning("missing_audio_asset", "Missing audio", 20, 30, 1)));
+
+      Scene scene = new Scene(view, 720, 620);
+      var stylesheet = VnsDiagnosticsView.class.getResource("/com/jvn/editor/editor-light.css");
+      if (stylesheet != null) scene.getStylesheets().add(stylesheet.toExternalForm());
+      view.applyCss();
+      view.layout();
+
+      assertTrue(view.lookup(".vns-diagnostics-health") != null);
+      assertTrue(view.lookup(".vns-diagnostics-category-filter") != null);
+      assertTrue(view.lookup(".vns-diagnostics-action-row") != null);
+
+      ToggleButton errors = view.lookupAll(".vns-diagnostics-chip").stream()
+          .filter(ToggleButton.class::isInstance)
+          .map(ToggleButton.class::cast)
+          .filter(button -> button.getText().contains("Error"))
+          .findFirst()
+          .orElseThrow();
+      errors.fire();
+
+      @SuppressWarnings("unchecked")
+      ListView<Object> findings = (ListView<Object>) view.lookup(".vns-diagnostics-list");
+      assertEquals(1, findings.getItems().size());
+
+      view.lookupAll(".button").stream()
+          .filter(javafx.scene.control.Button.class::isInstance)
+          .map(javafx.scene.control.Button.class::cast)
+          .filter(button -> "Rescan".equals(button.getText()))
+          .findFirst()
+          .orElseThrow()
+          .fire();
+      assertTrue(rescanned.get());
+      return null;
+    });
+  }
+
+  private static <T> T runFx(Callable<T> callable) throws Exception {
+    FutureTask<T> task = new FutureTask<>(callable);
+    Platform.runLater(task);
+    return task.get(30, TimeUnit.SECONDS);
+  }
+}

--- a/modules/editor/src/test/java/com/jvn/editor/ui/VnsDiagnosticsViewTest.java
+++ b/modules/editor/src/test/java/com/jvn/editor/ui/VnsDiagnosticsViewTest.java
@@ -92,4 +92,13 @@ class VnsDiagnosticsViewTest {
     assertEquals("jump missing_label", preview.sourceLine());
     assertEquals("     ^", preview.caretLine());
   }
+
+  @Test
+  void categorizesDiagnosticsForToolbarFiltering() {
+    assertEquals("Syntax", VnsDiagnosticsView.categoryForKind("parse_error"));
+    assertEquals("Flow", VnsDiagnosticsView.categoryForKind("unreachable_statement"));
+    assertEquals("Assets", VnsDiagnosticsView.categoryForKind("missing_audio_asset"));
+    assertEquals("Scripts", VnsDiagnosticsView.categoryForKind("missing_script"));
+    assertEquals("Content", VnsDiagnosticsView.categoryForKind("timeline"));
+  }
 }

--- a/modules/editor/src/test/java/com/jvn/editor/ui/VnsScriptAnalyzerExtendedDiagnosticsTest.java
+++ b/modules/editor/src/test/java/com/jvn/editor/ui/VnsScriptAnalyzerExtendedDiagnosticsTest.java
@@ -1,0 +1,123 @@
+package com.jvn.editor.ui;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class VnsScriptAnalyzerExtendedDiagnosticsTest {
+
+  @TempDir
+  Path projectRoot;
+
+  @Test
+  void reportsMissingCharacterAndAudioAssets() {
+    String source = """
+        @scenario asset_check
+        @character hero "Hero"
+        @charimg hero neutral assets/characters/missing_hero.png
+        @charlayer hero eyes assets/characters/missing_eyes.png
+        @label start
+        [bgm "assets/audio/missing_theme.ogg"]
+        [sfx "assets/audio/missing_click.wav"]
+        [voice path="assets/audio/missing_voice.ogg"]
+        Hero: Ready.
+        [end]
+        """;
+
+    VnsScriptAnalyzer.Analysis analysis =
+        VnsScriptAnalyzer.analyze(source, projectRoot.toFile());
+
+    assertTrue(analysis.diagnostics().stream()
+        .anyMatch(d -> "missing_character_asset".equals(d.kind())
+            && d.message().contains("missing_hero.png")));
+    assertTrue(analysis.diagnostics().stream()
+        .anyMatch(d -> "missing_character_asset".equals(d.kind())
+            && d.message().contains("missing_eyes.png")));
+    assertTrue(analysis.diagnostics().stream()
+        .anyMatch(d -> "missing_audio_asset".equals(d.kind())
+            && d.message().contains("missing_theme.ogg")));
+    assertTrue(analysis.diagnostics().stream()
+        .anyMatch(d -> "missing_audio_asset".equals(d.kind())
+            && d.message().contains("missing_click.wav")));
+    assertTrue(analysis.diagnostics().stream()
+        .anyMatch(d -> "missing_audio_asset".equals(d.kind())
+            && d.message().contains("missing_voice.ogg")));
+  }
+
+  @Test
+  void acceptsCharacterAndAudioAssetsThatExist() throws Exception {
+    Files.createDirectories(projectRoot.resolve("assets/characters"));
+    Files.createDirectories(projectRoot.resolve("assets/audio"));
+    Files.writeString(projectRoot.resolve("assets/characters/hero.png"), "image");
+    Files.writeString(projectRoot.resolve("assets/audio/theme.ogg"), "audio");
+
+    String source = """
+        @scenario valid_assets
+        @character hero "Hero"
+        @charimg hero neutral assets/characters/hero.png
+        @label start
+        [bgm assets/audio/theme.ogg]
+        Hero: Ready.
+        [end]
+        """;
+
+    VnsScriptAnalyzer.Analysis analysis =
+        VnsScriptAnalyzer.analyze(source, projectRoot.toFile());
+
+    assertFalse(analysis.diagnostics().stream()
+        .anyMatch(d -> "missing_character_asset".equals(d.kind())
+            || "missing_audio_asset".equals(d.kind())));
+  }
+
+  @Test
+  void reportsMissingLabelInsideExistingCrossScriptTarget() throws Exception {
+    Path story = Files.createDirectories(projectRoot.resolve("scripts/story"));
+    Files.writeString(story.resolve("target.vns"), """
+        @scenario target
+        @label start
+        [end]
+        """);
+
+    String source = """
+        @scenario source
+        @label start
+        [goto story/target.vns:missing_ending]
+        """;
+
+    VnsScriptAnalyzer.Analysis analysis =
+        VnsScriptAnalyzer.analyze(source, projectRoot.toFile());
+
+    assertTrue(analysis.diagnostics().stream()
+        .anyMatch(d -> "missing_script_label".equals(d.kind())
+            && d.message().contains("missing_ending")));
+    assertFalse(analysis.diagnostics().stream()
+        .anyMatch(d -> "missing_script".equals(d.kind())));
+  }
+
+  @Test
+  void reportsOnlyFirstDeadStatementAfterTerminalCommand() {
+    String source = """
+        @scenario dead_code
+        @label start
+        [jump ending]
+        narrator: This cannot run.
+        [sfx assets/audio/also_unreachable.wav]
+
+        @label ending
+        narrator: This can run.
+        [end]
+        """;
+
+    VnsScriptAnalyzer.Analysis analysis =
+        VnsScriptAnalyzer.analyze(source, null);
+
+    long deadStatements = analysis.diagnostics().stream()
+        .filter(d -> "unreachable_statement".equals(d.kind()))
+        .count();
+    assertTrue(deadStatements == 1);
+  }
+}


### PR DESCRIPTION
## What changed

- Redesigned the Diagnostics panel with a compact Windows 7-style glass surface, health state, responsive toolbar, and clearer diagnostic cards.
- Added interactive All, Error, and Warning filters plus category filtering for syntax, flow, assets, scripts, and content.
- Added manual Rescan, F4/Shift+F4 navigation, improved search, and source-aware copied reports.
- Expanded VNS analysis to catch missing character and audio assets, non-portable absolute asset paths, missing labels in existing cross-script targets, and unreachable statements after terminal flow commands.
- Deduplicated identical analyzer findings and kept precise source ranges for navigation.
- Added focused analyzer and JavaFX UI regression coverage.

## Why

The existing utility presented a largely flat list and left several common project errors to runtime. This makes the panel faster to scan, easier to operate in narrow sidebars, and more useful before launching a preview or build.

## Validation

- `git diff --check`
- Focused diagnostics analyzer and JavaFX UI tests passed.
- `GameBuildPublisherViewFxTest` passed in isolation after the combined macOS JavaFX suite encountered an unrelated shutdown timeout/crash.