### PR TITLE
Harden timeline diagnostics and refresh icons

### DIFF
--- a/modules/core/src/main/java/com/jvn/core/vn/script/VnScriptParser.java
+++ b/modules/core/src/main/java/com/jvn/core/vn/script/VnScriptParser.java
@@ -927,24 +927,24 @@ public class VnScriptParser {
         continue;
       }
 
-      // Inline timeline { ... } block
-      if (trimmed.startsWith("timeline") && (trimmed.endsWith("{") || trimmed.equals("timeline"))) {
+      // Inline timeline { ... } block. Scan braces lexically so values such as
+      // text: "use {braces}" and commented-out braces do not corrupt block depth.
+      String timelineHeader = timelineHeaderCode(trimmed);
+      if (isTimelineHeader(timelineHeader)) {
         state.contentEmitted = true;
         flushChoices(state.builder, state.pendingChoices);
         flushPendingVoice(state);
         ensureBuilder(state);
         StringBuilder block = new StringBuilder();
-        String timelineModifiers = timelineHeaderModifiers(trimmed);
-        int braceDepth = 0;
-        // Count opening braces on the first line
-        for (char c : trimmed.toCharArray()) { if (c == '{') braceDepth++; }
+        String timelineModifiers = timelineHeaderModifiers(timelineHeader);
+        int braceDepth = scanTimelineBraces(timelineHeader, 0).depth();
         if (braceDepth == 0) {
           // Opening brace on next line
           String nextLine;
           boolean foundOpeningBrace = false;
           while ((nextLine = reader.readLine()) != null) {
             lineNumber++;
-            String nt = nextLine.trim();
+            String nt = timelineHeaderCode(nextLine);
             if (nt.isEmpty() || nt.startsWith("#")) continue;
             if (nt.equals("{")) {
               braceDepth = 1;
@@ -959,15 +959,23 @@ public class VnScriptParser {
         }
         while (braceDepth > 0 && (line = reader.readLine()) != null) {
           lineNumber++;
-          for (char c : line.toCharArray()) {
-            if (c == '{') braceDepth++;
-            else if (c == '}') braceDepth--;
-          }
+          TimelineBraceScan scan = scanTimelineBraces(line, braceDepth);
+          braceDepth = scan.depth();
+          int closingBrace = scan.closingBrace();
           if (braceDepth > 0) block.append(line).append('\n');
           else {
-            // Remove trailing } from the line content if there's anything before it
-            int lastBrace = line.lastIndexOf('}');
-            if (lastBrace > 0) block.append(line, 0, lastBrace).append('\n');
+            if (closingBrace > 0) block.append(line, 0, closingBrace).append('\n');
+            String trailing = closingBrace >= 0
+                ? line.substring(closingBrace + 1).trim()
+                : "";
+            String trailingCode = timelineHeaderCode(trailing);
+            if (!trailingCode.isEmpty()) {
+              throw parseError(
+                  sourceName,
+                  lineNumber,
+                  "Unexpected content after timeline block: " + trailingCode,
+                  line);
+            }
           }
         }
         if (braceDepth != 0) {
@@ -3398,12 +3406,134 @@ public class VnScriptParser {
   private String timelineHeaderModifiers(String header) {
     if (header == null) return "";
     String trimmed = header.trim();
-    if (!trimmed.startsWith("timeline")) return "";
+    if (!hasTimelineKeyword(trimmed)) return "";
     String tail = trimmed.substring("timeline".length()).trim();
-    int brace = tail.indexOf('{');
+    int brace = timelineOpeningBrace(tail);
     if (brace >= 0) tail = tail.substring(0, brace).trim();
     return tail;
   }
+
+  private boolean isTimelineHeader(String header) {
+    if (!hasTimelineKeyword(header)) return false;
+    String code = header.trim();
+    return code.equals("timeline") || code.endsWith("{");
+  }
+
+  private boolean hasTimelineKeyword(String value) {
+    if (value == null) return false;
+    String trimmed = value.trim();
+    if (!trimmed.startsWith("timeline")) return false;
+    return trimmed.length() == "timeline".length()
+        || Character.isWhitespace(trimmed.charAt("timeline".length()))
+        || trimmed.charAt("timeline".length()) == '{';
+  }
+
+  /**
+   * Removes a VNS-style trailing comment while respecting quoted values.
+   * A hash begins a comment at the start of a line or after whitespace.
+   */
+  private String timelineHeaderCode(String value) {
+    if (value == null || value.isEmpty()) return "";
+    char quote = 0;
+    boolean escaped = false;
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      if (quote != 0) {
+        if (escaped) {
+          escaped = false;
+        } else if (c == '\\') {
+          escaped = true;
+        } else if (c == quote) {
+          quote = 0;
+        }
+        continue;
+      }
+      if (c == '"' || c == '\'') {
+        quote = c;
+      } else if (isTimelineCommentStart(value, i)) {
+        return value.substring(0, i).trim();
+      }
+    }
+    return value.trim();
+  }
+
+  private TimelineBraceScan scanTimelineBraces(String value, int initialDepth) {
+    int depth = initialDepth;
+    char quote = 0;
+    boolean escaped = false;
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      if (quote != 0) {
+        if (escaped) {
+          escaped = false;
+        } else if (c == '\\') {
+          escaped = true;
+        } else if (c == quote) {
+          quote = 0;
+        }
+        continue;
+      }
+      if (c == '"' || c == '\'') {
+        quote = c;
+        continue;
+      }
+      if (isTimelineCommentStart(value, i)) {
+        break;
+      }
+      if (c == '{') {
+        depth++;
+      } else if (c == '}') {
+        depth--;
+        if (depth == 0) return new TimelineBraceScan(depth, i);
+      }
+    }
+    return new TimelineBraceScan(depth, -1);
+  }
+
+  private int timelineOpeningBrace(String value) {
+    if (value == null || value.isEmpty()) return -1;
+    char quote = 0;
+    boolean escaped = false;
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      if (quote != 0) {
+        if (escaped) escaped = false;
+        else if (c == '\\') escaped = true;
+        else if (c == quote) quote = 0;
+      } else if (c == '"' || c == '\'') {
+        quote = c;
+      } else if (isTimelineCommentStart(value, i)) {
+        return -1;
+      } else if (c == '{') {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  private boolean isTimelineCommentStart(String value, int index) {
+    if (value == null || index < 0 || index >= value.length() || value.charAt(index) != '#') {
+      return false;
+    }
+    if (isTimelineHexColor(value, index)) return false;
+    if (index == 0 || Character.isWhitespace(value.charAt(index - 1))) return true;
+    char previous = value.charAt(index - 1);
+    return previous == '{' || previous == '}';
+  }
+
+  private boolean isTimelineHexColor(String value, int hashIndex) {
+    int end = hashIndex + 1;
+    while (end < value.length() && Character.digit(value.charAt(end), 16) >= 0) end++;
+    int digits = end - hashIndex - 1;
+    if (digits != 3 && digits != 4 && digits != 6 && digits != 8) return false;
+    return end == value.length()
+        || Character.isWhitespace(value.charAt(end))
+        || value.charAt(end) == '}'
+        || value.charAt(end) == ','
+        || value.charAt(end) == ';';
+  }
+
+  private record TimelineBraceScan(int depth, int closingBrace) {}
 
   private void validateJavaImport(String imp, String sourceName, int lineNumber, String rawLine) throws IOException {
     if (!JAVA_IMPORT_PATTERN.matcher(imp).matches()) {

--- a/modules/core/src/test/java/com/jvn/core/vn/VnScriptParserTest.java
+++ b/modules/core/src/test/java/com/jvn/core/vn/VnScriptParserTest.java
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.Test;
 
 import com.jvn.core.vn.script.InMemoryJavaCompiler;
+import com.jvn.core.vn.script.MultipleParseErrorsException;
 import com.jvn.core.vn.script.VnScriptParser;
 
 public class VnScriptParserTest {
@@ -837,6 +838,91 @@ public class VnScriptParserTest {
         .orElseThrow();
     assertTrue(timeline.getExternalCommand().getPayload().startsWith("timeline {"));
     assertTrue(timeline.getExternalCommand().getPayload().contains("move \"hero\""));
+  }
+
+  @Test
+  public void rejectsTrailingContentAfterInlineTimelineBlock() {
+    String script = """
+      @scenario malformed_timeline
+      @label start
+      timeline {
+        entity "heart_effect" {
+          0ms { alpha: 0.3 }
+        }
+      }a
+      [end]
+      """;
+
+    MultipleParseErrorsException error = assertThrows(
+        MultipleParseErrorsException.class,
+        () -> new VnScriptParser().parseFromString(script));
+
+    assertTrue(error.getMessage().contains("Unexpected content after timeline block: a"));
+    assertEquals(7, error.getErrors().getFirst().getLineNumber());
+  }
+
+  @Test
+  public void allowsCommentAfterInlineTimelineBlock() throws Exception {
+    String script = """
+      @scenario commented_timeline
+      @label start
+      timeline {
+        entity "heart_effect" {
+          0ms { alpha: 0.3 }
+        }
+      } # pulse complete
+      [end]
+      """;
+
+    VnScenario scenario = new VnScriptParser().parseFromString(script);
+
+    assertTrue(scenario.getNodes().stream().anyMatch(node ->
+        node.getType() == VnNodeType.EXTERNAL
+            && "jes_timeline_inline".equals(node.getExternalCommand().getProvider())));
+  }
+
+  @Test
+  public void ignoresQuotedAndCommentedBracesInsideInlineTimeline() throws Exception {
+    String script = """
+      @scenario quoted_timeline
+      @label start
+      timeline { # opening comment with }
+        entity "brace_{_name" {
+          0ms { text: "escaped \\"}\\" and {", tint: #7de2ff } # ignored }
+        }
+      } # closing comment
+      [end]
+      """;
+
+    VnScenario scenario = new VnScriptParser().parseFromString(script);
+
+    VnNode timeline = scenario.getNodes().stream()
+        .filter(node -> node.getType() == VnNodeType.EXTERNAL
+            && "jes_timeline_inline".equals(node.getExternalCommand().getProvider()))
+        .findFirst()
+        .orElseThrow();
+    assertTrue(timeline.getExternalCommand().getPayload().contains("escaped"));
+    assertTrue(timeline.getExternalCommand().getPayload().contains("#7de2ff"));
+  }
+
+  @Test
+  public void rejectsCommandsAndExtraBracesAfterInlineTimelineBlock() {
+    for (String suffix : List.of("[wait 100]", "}")) {
+      String script = """
+        @scenario malformed_timeline
+        @label start
+        timeline {
+          0ms { alpha: 0.3 }
+        } %s
+        [end]
+        """.formatted(suffix);
+
+      MultipleParseErrorsException error = assertThrows(
+          MultipleParseErrorsException.class,
+          () -> new VnScriptParser().parseFromString(script));
+
+      assertTrue(error.getMessage().contains("Unexpected content after timeline block: " + suffix));
+    }
   }
 
   @Test

--- a/modules/editor/src/main/java/com/jvn/editor/ui/DiagnosticsToolbarIcon.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/DiagnosticsToolbarIcon.java
@@ -1,0 +1,212 @@
+package com.jvn.editor.ui;
+
+import javafx.scene.CacheHint;
+import javafx.scene.Group;
+import javafx.scene.effect.DropShadow;
+import javafx.scene.effect.InnerShadow;
+import javafx.scene.layout.Pane;
+import javafx.scene.paint.Color;
+import javafx.scene.paint.CycleMethod;
+import javafx.scene.paint.LinearGradient;
+import javafx.scene.paint.Stop;
+import javafx.scene.shape.Circle;
+import javafx.scene.shape.Line;
+import javafx.scene.shape.Rectangle;
+import javafx.scene.shape.SVGPath;
+import javafx.scene.shape.StrokeLineCap;
+import javafx.scene.shape.StrokeLineJoin;
+
+/** Compact Aero-style vector artwork for the diagnostics command buttons. */
+public final class DiagnosticsToolbarIcon extends Pane {
+  public enum Kind {
+    RESCAN,
+    OPEN,
+    PREVIOUS,
+    NEXT,
+    COPY_REPORT,
+    CLEAR_FILTER,
+    SORT_LINE,
+    SORT_SEVERITY
+  }
+
+  private static final double SIZE = 20.0;
+  private static final Color WHITE = Color.web("#f7fcff");
+  private final Kind kind;
+
+  private DiagnosticsToolbarIcon(Kind requestedKind) {
+    kind = requestedKind == null ? Kind.RESCAN : requestedKind;
+    setMinSize(SIZE, SIZE);
+    setPrefSize(SIZE, SIZE);
+    setMaxSize(SIZE, SIZE);
+    setMouseTransparent(true);
+    setCache(true);
+    setCacheHint(CacheHint.SPEED);
+    getStyleClass().add("vns-diagnostics-command-icon");
+
+    Group artwork = switch (kind) {
+      case RESCAN -> rescan();
+      case OPEN -> open();
+      case PREVIOUS -> navigation(true);
+      case NEXT -> navigation(false);
+      case COPY_REPORT -> copyReport();
+      case CLEAR_FILTER -> clearFilter();
+      case SORT_LINE -> sortLine();
+      case SORT_SEVERITY -> sortSeverity();
+    };
+    artwork.setEffect(new DropShadow(2.2, 0, 1.0, Color.rgb(0, 0, 0, 0.52)));
+    getChildren().setAll(artwork);
+  }
+
+  public static DiagnosticsToolbarIcon of(Kind kind) {
+    return new DiagnosticsToolbarIcon(kind);
+  }
+
+  public Kind kind() {
+    return kind;
+  }
+
+  private static Group rescan() {
+    Circle bezel = jewel(10, 10, 8.2, "#225877", "#88d3f1");
+    SVGPath arrow = stroked(
+        "M14.9 7.2 A5.6 5.6 0 1 0 15 13.1 M14.9 7.2 L14.7 3.7 M14.9 7.2 L11.5 7.1",
+        WHITE,
+        1.65);
+    Circle status = new Circle(15.9, 15.5, 2.25, gradient("#b9f7bd", "#3f9d4a"));
+    status.setStroke(Color.web("#e8ffe9"));
+    status.setStrokeWidth(0.7);
+    return new Group(bezel, arrow, status);
+  }
+
+  private static Group open() {
+    Rectangle window = roundedRect(
+        2.1, 3.0, 14.8, 13.8, 2.0, gradient("#eaf8ff", "#5da8d2"), Color.web("#2f6c91"), 1.0);
+    Rectangle title = roundedRect(
+        3.3, 4.1, 12.3, 2.4, 0.8, gradient("#ffffff", "#a8d7ed"), Color.TRANSPARENT, 0);
+    Rectangle pane = roundedRect(
+        3.8, 7.4, 9.1, 7.3, 0.8, gradient("#d7f0fb", "#73b3d4"), Color.web("#dff7ff"), 0.55);
+    SVGPath arrow = stroked("M10.8 10.7 L17.5 4 M13.3 4 H17.5 V8.2", WHITE, 1.7);
+    arrow.setEffect(new DropShadow(2.2, Color.web("#214d69")));
+    return new Group(window, title, pane, arrow);
+  }
+
+  private static Group navigation(boolean previous) {
+    Circle bezel = jewel(10, 10, 8.0, "#334e67", "#9bc7e7");
+    String path = previous
+        ? "M5.8 11.4 L10 7.2 L14.2 11.4 M10 7.6 V14.7"
+        : "M5.8 8.6 L10 12.8 L14.2 8.6 M10 5.3 V12.4";
+    SVGPath arrow = stroked(path, WHITE, 1.7);
+    return new Group(bezel, arrow);
+  }
+
+  private static Group copyReport() {
+    Rectangle rear = roundedRect(
+        3.0, 2.1, 11.5, 14.2, 1.7, gradient("#dcebf3", "#7794a8"), Color.web("#435e70"), 0.9);
+    Rectangle page = roundedRect(
+        6.0, 4.7, 11.1, 13.1, 1.7, gradient("#ffffff", "#c6dfec"), Color.web("#4f84a2"), 1.0);
+    Circle tickOne = new Circle(8.5, 8.4, 1.15, gradient("#baf1bd", "#40924a"));
+    Circle tickTwo = new Circle(8.5, 12.4, 1.15, gradient("#baf1bd", "#40924a"));
+    Line lineOne = line(11, 8.4, 15.0, 8.4, Color.web("#4d7890"), 1.0);
+    Line lineTwo = line(11, 12.4, 15.0, 12.4, Color.web("#4d7890"), 1.0);
+    Line shine = line(7.2, 6.0, 15.8, 6.0, Color.rgb(255, 255, 255, 0.72), 0.7);
+    return new Group(rear, page, tickOne, tickTwo, lineOne, lineTwo, shine);
+  }
+
+  private static Group clearFilter() {
+    SVGPath funnel = filled(
+        "M2.4 3.2 H17.1 L12.3 8.7 V14.2 L8.3 16.8 V8.7 Z",
+        gradient("#dff4ff", "#5b9dc2"));
+    funnel.setStroke(Color.web("#356b89"));
+    funnel.setStrokeWidth(1.0);
+    funnel.setStrokeLineJoin(StrokeLineJoin.ROUND);
+    Line shine = line(4.3, 4.7, 14.7, 4.7, Color.rgb(255, 255, 255, 0.72), 0.8);
+    Circle badge = new Circle(15.5, 14.8, 3.6, gradient("#ffb0ad", "#b83c42"));
+    badge.setStroke(Color.web("#ffe7e6"));
+    badge.setStrokeWidth(0.8);
+    SVGPath x = stroked("M13.7 13 L17.3 16.6 M17.3 13 L13.7 16.6", WHITE, 1.35);
+    return new Group(funnel, shine, badge, x);
+  }
+
+  private static Group sortLine() {
+    Rectangle plate = roundedRect(
+        2.2, 2.1, 15.6, 15.8, 2.1, gradient("#f3fbff", "#9bc5dc"), Color.web("#527b93"), 1.0);
+    Line one = line(8.2, 6.1, 15.1, 6.1, Color.web("#416a82"), 1.15);
+    Line two = line(8.2, 10.0, 13.6, 10.0, Color.web("#416a82"), 1.15);
+    Line three = line(8.2, 13.9, 12.2, 13.9, Color.web("#416a82"), 1.15);
+    Circle dotOne = new Circle(5.2, 6.1, 1.25, gradient("#9ad8f2", "#2b789e"));
+    Circle dotTwo = new Circle(5.2, 10.0, 1.25, gradient("#9ad8f2", "#2b789e"));
+    Circle dotThree = new Circle(5.2, 13.9, 1.25, gradient("#9ad8f2", "#2b789e"));
+    return new Group(plate, one, two, three, dotOne, dotTwo, dotThree);
+  }
+
+  private static Group sortSeverity() {
+    Rectangle plate = roundedRect(
+        2.2, 2.1, 15.6, 15.8, 2.1, gradient("#f3fbff", "#9bc5dc"), Color.web("#527b93"), 1.0);
+    Circle error = new Circle(5.3, 6.0, 1.7, gradient("#ffaca9", "#b8373f"));
+    Circle warning = new Circle(5.3, 10.1, 1.7, gradient("#ffe39a", "#bd8420"));
+    Circle info = new Circle(5.3, 14.2, 1.7, gradient("#9cdbf4", "#367ca2"));
+    Line one = line(8.5, 6.0, 15.0, 6.0, Color.web("#557a8e"), 1.1);
+    Line two = line(8.5, 10.1, 13.6, 10.1, Color.web("#557a8e"), 1.1);
+    Line three = line(8.5, 14.2, 12.3, 14.2, Color.web("#557a8e"), 1.1);
+    return new Group(plate, error, warning, info, one, two, three);
+  }
+
+  private static Circle jewel(double x, double y, double radius, String dark, String bright) {
+    Circle circle = new Circle(x, y, radius, gradient(bright, dark));
+    circle.setStroke(Color.web(bright).deriveColor(0, 0.72, 1.08, 0.9));
+    circle.setStrokeWidth(1.0);
+    circle.setEffect(new InnerShadow(2.0, Color.rgb(255, 255, 255, 0.2)));
+    return circle;
+  }
+
+  private static Rectangle roundedRect(
+      double x,
+      double y,
+      double width,
+      double height,
+      double radius,
+      javafx.scene.paint.Paint fill,
+      Color stroke,
+      double strokeWidth) {
+    Rectangle rectangle = new Rectangle(x, y, width, height);
+    rectangle.setArcWidth(radius * 2);
+    rectangle.setArcHeight(radius * 2);
+    rectangle.setFill(fill);
+    rectangle.setStroke(stroke);
+    rectangle.setStrokeWidth(strokeWidth);
+    return rectangle;
+  }
+
+  private static Line line(double x1, double y1, double x2, double y2, Color color, double width) {
+    Line line = new Line(x1, y1, x2, y2);
+    line.setStroke(color);
+    line.setStrokeWidth(width);
+    line.setStrokeLineCap(StrokeLineCap.ROUND);
+    return line;
+  }
+
+  private static SVGPath filled(String path, javafx.scene.paint.Paint fill) {
+    SVGPath shape = new SVGPath();
+    shape.setContent(path);
+    shape.setFill(fill);
+    return shape;
+  }
+
+  private static SVGPath stroked(String path, Color color, double width) {
+    SVGPath shape = new SVGPath();
+    shape.setContent(path);
+    shape.setFill(Color.TRANSPARENT);
+    shape.setStroke(color);
+    shape.setStrokeWidth(width);
+    shape.setStrokeLineCap(StrokeLineCap.ROUND);
+    shape.setStrokeLineJoin(StrokeLineJoin.ROUND);
+    return shape;
+  }
+
+  private static LinearGradient gradient(String top, String bottom) {
+    return new LinearGradient(
+        0, 0, 0, 1, true, CycleMethod.NO_CYCLE,
+        new Stop(0, Color.web(top)),
+        new Stop(0.46, Color.web(top).deriveColor(0, 0.9, 1.08, 1)),
+        new Stop(1, Color.web(bottom)));
+  }
+}

--- a/modules/editor/src/main/java/com/jvn/editor/ui/VnsDiagnosticsView.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/VnsDiagnosticsView.java
@@ -60,13 +60,20 @@ public class VnsDiagnosticsView extends BorderPane {
       FXCollections.observableArrayList(
           CATEGORY_ALL, CATEGORY_SYNTAX, CATEGORY_FLOW, CATEGORY_ASSETS, CATEGORY_SCRIPTS, CATEGORY_CONTENT)
   );
-  private final Button openSelectedButton = actionButton("Open", CssIcon.expand("#477fae"));
-  private final Button copyDiagnosticsButton = actionButton("Copy Report", CssIcon.copy("#4f7fa5"));
-  private final Button clearFilterButton = actionButton("Clear Filter", CssIcon.clearX("#f0a080"));
-  private final Button refreshButton = actionButton("Rescan", CssIcon.refresh("#447ba7"));
-  private final Button prevButton = actionButton("Prev", CssIcon.arrowUp("#536d86"));
-  private final Button nextButton = actionButton("Next", CssIcon.arrowDown("#536d86"));
-  private final Button sortButton = actionButton("By Line", CssIcon.sort("#536d86"));
+  private final Button openSelectedButton =
+      actionButton("Open", DiagnosticsToolbarIcon.Kind.OPEN);
+  private final Button copyDiagnosticsButton =
+      actionButton("Copy Report", DiagnosticsToolbarIcon.Kind.COPY_REPORT);
+  private final Button clearFilterButton =
+      actionButton("Clear Filter", DiagnosticsToolbarIcon.Kind.CLEAR_FILTER);
+  private final Button refreshButton =
+      actionButton("Rescan", DiagnosticsToolbarIcon.Kind.RESCAN);
+  private final Button prevButton =
+      actionButton("Prev", DiagnosticsToolbarIcon.Kind.PREVIOUS);
+  private final Button nextButton =
+      actionButton("Next", DiagnosticsToolbarIcon.Kind.NEXT);
+  private final Button sortButton =
+      actionButton("By Line", DiagnosticsToolbarIcon.Kind.SORT_LINE);
   private final ListView<DiagnosticRow> listView = new ListView<>();
 
   private final List<DiagnosticRow> allRows = new ArrayList<>();
@@ -78,7 +85,7 @@ public class VnsDiagnosticsView extends BorderPane {
   public VnsDiagnosticsView() {
     getStyleClass().addAll("vns-diagnostics-root", "sidebar-tool-root");
     titleLabel.getStyleClass().addAll("vns-diagnostics-title", "sidebar-tool-title");
-    titleLabel.setGraphic(CssIcon.warning("#a66c18"));
+    titleLabel.setGraphic(AeroIcon.of(AeroIcon.Kind.VNS_DIAGNOSTICS, 20));
     titleLabel.setGraphicTextGap(7);
     fileLabel.getStyleClass().addAll("vns-diagnostics-file", "sidebar-tool-subtitle");
     summaryLabel.getStyleClass().addAll("vns-diagnostics-summary", "sidebar-tool-summary");
@@ -167,6 +174,9 @@ public class VnsDiagnosticsView extends BorderPane {
       sortMode = sortMode == SortMode.LINE ? SortMode.SEVERITY : SortMode.LINE;
       boolean bySeverity = sortMode == SortMode.SEVERITY;
       sortButton.setText(bySeverity ? "By Severity" : "By Line");
+      sortButton.setGraphic(DiagnosticsToolbarIcon.of(bySeverity
+          ? DiagnosticsToolbarIcon.Kind.SORT_SEVERITY
+          : DiagnosticsToolbarIcon.Kind.SORT_LINE));
       sortButton.setTooltip(new Tooltip(bySeverity
           ? "Errors shown first — click to sort by line number"
           : "Sorted by line number — click to sort errors first"));
@@ -633,12 +643,13 @@ visible, source-aware result set for sharing."""),
         + " | ~" + minutes;
   }
 
-  private static Button actionButton(String text, javafx.scene.layout.Region icon) {
+  private static Button actionButton(String text, DiagnosticsToolbarIcon.Kind iconKind) {
     Button button = new Button(text);
-    button.getStyleClass().add("sidebar-tool-btn");
-    button.setGraphic(icon);
+    button.getStyleClass().addAll("sidebar-tool-btn", "vns-diagnostics-action-button");
+    button.setGraphic(DiagnosticsToolbarIcon.of(iconKind));
     button.setGraphicTextGap(6);
     button.setMnemonicParsing(false);
+    button.setFocusTraversable(false);
     return button;
   }
 

--- a/modules/editor/src/main/java/com/jvn/editor/ui/VnsScriptAnalyzer.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/VnsScriptAnalyzer.java
@@ -61,7 +61,7 @@ public final class VnsScriptAnalyzer {
         int start = 0;
         int end = Math.max(0, source.length());
         if (line >= 0) {
-          int[] bounds = lineBounds(source, line);
+          int[] bounds = parseDiagnosticBounds(source, line, ex);
           start = bounds[0];
           end = bounds[1];
         }
@@ -279,6 +279,26 @@ public final class VnsScriptAnalyzer {
     ScriptStats stats = computeStats(lines, labels, edges);
 
     return new Analysis(source, diagnostics, labels, edges, startLabel, backgrounds, stats);
+  }
+
+  private static int[] parseDiagnosticBounds(String source, int line, VnParseException error) {
+    int[] lineRange = lineBounds(source, line);
+    if (error == null
+        || error.getDetailMessage() == null
+        || !error.getDetailMessage().startsWith("Unexpected content after timeline block:")) {
+      return lineRange;
+    }
+
+    String rawLine = error.getRawLine();
+    int colon = error.getDetailMessage().indexOf(':');
+    String trailing = colon < 0 ? "" : error.getDetailMessage().substring(colon + 1).trim();
+    if (rawLine == null || trailing.isEmpty()) return lineRange;
+
+    int relativeStart = rawLine.lastIndexOf(trailing);
+    if (relativeStart < 0) return lineRange;
+    int absoluteStart = Math.min(lineRange[1], lineRange[0] + relativeStart);
+    int absoluteEnd = Math.min(lineRange[1], absoluteStart + trailing.length());
+    return new int[] {absoluteStart, Math.max(absoluteStart + 1, absoluteEnd)};
   }
 
   private static void parseWithIncludeResolver(String source, File projectRoot, File sourceFile) throws Exception {

--- a/modules/editor/src/main/resources/com/jvn/editor/editor-light.css
+++ b/modules/editor/src/main/resources/com/jvn/editor/editor-light.css
@@ -7258,3 +7258,33 @@
   -fx-background-color: linear-gradient(to bottom, #64a4d2, #3476a8);
   -fx-border-color: #285e87;
 }
+
+.vns-diagnostics-root .vns-diagnostics-action-button {
+  -fx-padding: 4 9 4 7;
+  -fx-graphic-text-gap: 6;
+  -fx-text-fill: #263b49;
+  -fx-background-color:
+      linear-gradient(to bottom, rgba(255, 255, 255, 0.92), rgba(255, 255, 255, 0.18)),
+      linear-gradient(to bottom, #eaf5fb 0%, #c9dce7 52%, #b7cdd9 100%);
+  -fx-border-color: #87a5b8;
+  -fx-border-radius: 5;
+  -fx-background-radius: 5;
+  -fx-effect: dropshadow(gaussian, rgba(26, 63, 84, 0.18), 2, 0.15, 0, 1);
+}
+
+.vns-diagnostics-root .vns-diagnostics-action-button:hover {
+  -fx-text-fill: #16364b;
+  -fx-background-color:
+      linear-gradient(to bottom, rgba(255, 255, 255, 0.98), rgba(255, 255, 255, 0.24)),
+      linear-gradient(to bottom, #f3fbff 0%, #d5eaf5 52%, #bfdcea 100%);
+  -fx-border-color: #5f91af;
+  -fx-effect: dropshadow(gaussian, rgba(54, 132, 177, 0.30), 5, 0.2, 0, 1);
+}
+
+.vns-diagnostics-root .vns-diagnostics-action-button:pressed {
+  -fx-background-color:
+      linear-gradient(to bottom, rgba(255, 255, 255, 0.14), rgba(255, 255, 255, 0.42)),
+      linear-gradient(to bottom, #adc9d8, #d6e8f1);
+  -fx-border-color: #4b7d99;
+  -fx-effect: innershadow(gaussian, rgba(30, 65, 84, 0.24), 3, 0.2, 0, 1);
+}

--- a/modules/editor/src/main/resources/com/jvn/editor/editor.css
+++ b/modules/editor/src/main/resources/com/jvn/editor/editor.css
@@ -7126,6 +7126,36 @@ The editor.css file defines the visual styling for the editor module, including 
   -fx-font-size: 11px;
 }
 
+.vns-diagnostics-root .vns-diagnostics-action-button {
+  -fx-padding: 4 9 4 7;
+  -fx-graphic-text-gap: 6;
+  -fx-text-fill: #dcebf4;
+  -fx-background-color:
+      linear-gradient(to bottom, rgba(255, 255, 255, 0.16), rgba(255, 255, 255, 0.01)),
+      linear-gradient(to bottom, #344957 0%, #253641 52%, #1d2a32 100%);
+  -fx-border-color: #4d6d80;
+  -fx-border-radius: 5;
+  -fx-background-radius: 5;
+  -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.36), 3, 0.15, 0, 1);
+}
+
+.vns-diagnostics-root .vns-diagnostics-action-button:hover {
+  -fx-text-fill: #f0faff;
+  -fx-background-color:
+      linear-gradient(to bottom, rgba(255, 255, 255, 0.21), rgba(255, 255, 255, 0.03)),
+      linear-gradient(to bottom, #406178 0%, #2e495b 52%, #243845 100%);
+  -fx-border-color: #6594af;
+  -fx-effect: dropshadow(gaussian, rgba(72, 157, 207, 0.30), 6, 0.2, 0, 1);
+}
+
+.vns-diagnostics-root .vns-diagnostics-action-button:pressed {
+  -fx-background-color:
+      linear-gradient(to bottom, rgba(0, 0, 0, 0.12), rgba(255, 255, 255, 0.08)),
+      linear-gradient(to bottom, #1c2b34, #334b5a);
+  -fx-border-color: #75a7c3;
+  -fx-effect: innershadow(gaussian, rgba(0, 0, 0, 0.50), 4, 0.25, 0, 1);
+}
+
 .sidebar-tool-root .check-box .box {
   -fx-background-color: #1c1c1c;
   -fx-border-color: #404040;

--- a/modules/editor/src/test/java/com/jvn/editor/ui/VnsDiagnosticsViewFxTest.java
+++ b/modules/editor/src/test/java/com/jvn/editor/ui/VnsDiagnosticsViewFxTest.java
@@ -4,7 +4,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Path;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.FutureTask;
@@ -12,6 +14,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javafx.application.Platform;
 import javafx.scene.Scene;
+import javafx.scene.control.Button;
 import javafx.scene.control.ListView;
 import javafx.scene.control.ToggleButton;
 import org.junit.jupiter.api.Assumptions;
@@ -64,6 +67,34 @@ class VnsDiagnosticsViewFxTest {
       assertTrue(view.lookup(".vns-diagnostics-health") != null);
       assertTrue(view.lookup(".vns-diagnostics-category-filter") != null);
       assertTrue(view.lookup(".vns-diagnostics-action-row") != null);
+
+      Set<DiagnosticsToolbarIcon.Kind> toolbarKinds = new HashSet<>();
+      view.lookupAll(".vns-diagnostics-action-button").stream()
+          .filter(Button.class::isInstance)
+          .map(Button.class::cast)
+          .forEach(button -> {
+            assertTrue(button.getGraphic() instanceof DiagnosticsToolbarIcon);
+            toolbarKinds.add(((DiagnosticsToolbarIcon) button.getGraphic()).kind());
+          });
+      assertEquals(Set.of(
+          DiagnosticsToolbarIcon.Kind.RESCAN,
+          DiagnosticsToolbarIcon.Kind.OPEN,
+          DiagnosticsToolbarIcon.Kind.PREVIOUS,
+          DiagnosticsToolbarIcon.Kind.NEXT,
+          DiagnosticsToolbarIcon.Kind.COPY_REPORT,
+          DiagnosticsToolbarIcon.Kind.CLEAR_FILTER,
+          DiagnosticsToolbarIcon.Kind.SORT_LINE), toolbarKinds);
+
+      Button sort = view.lookupAll(".vns-diagnostics-action-button").stream()
+          .filter(Button.class::isInstance)
+          .map(Button.class::cast)
+          .filter(button -> "By Line".equals(button.getText()))
+          .findFirst()
+          .orElseThrow();
+      sort.fire();
+      assertEquals(
+          DiagnosticsToolbarIcon.Kind.SORT_SEVERITY,
+          ((DiagnosticsToolbarIcon) sort.getGraphic()).kind());
 
       ToggleButton errors = view.lookupAll(".vns-diagnostics-chip").stream()
           .filter(ToggleButton.class::isInstance)

--- a/modules/editor/src/test/java/com/jvn/editor/ui/VnsScriptAnalyzerExtendedDiagnosticsTest.java
+++ b/modules/editor/src/test/java/com/jvn/editor/ui/VnsScriptAnalyzerExtendedDiagnosticsTest.java
@@ -1,5 +1,6 @@
 package com.jvn.editor.ui;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -119,5 +120,31 @@ class VnsScriptAnalyzerExtendedDiagnosticsTest {
         .filter(d -> "unreachable_statement".equals(d.kind()))
         .count();
     assertTrue(deadStatements == 1);
+  }
+
+  @Test
+  void reportsTrailingCharactersAfterTimelineClosingBrace() {
+    String source = """
+        @scenario malformed_timeline
+        @label heart_slow
+        timeline {
+          entity "heart_effect" {
+            0ms { alpha: 0.3 }
+          }
+        }a
+        [return]
+        """;
+
+    VnsScriptAnalyzer.Analysis analysis =
+        VnsScriptAnalyzer.analyze(source, null);
+
+    VnsScriptAnalyzer.Diagnostic diagnostic = analysis.diagnostics().stream().filter(d ->
+        "parse_error".equals(d.kind())
+            && d.line() == 6
+            && d.message().contains("Unexpected content after timeline block: a"))
+        .findFirst()
+        .orElseThrow();
+
+    assertEquals("a", source.substring(diagnostic.start(), diagnostic.end()));
   }
 }


### PR DESCRIPTION
## What changed

- Harden inline VNS timeline block scanning around quoted and escaped braces, inline comments, nested blocks, and hex color literals.
- Report unexpected content after a closing timeline brace, including cases such as `}a`, trailing commands, and extra braces.
- Narrow the editor diagnostic range to the offending suffix.
- Replace the diagnostics toolbar glyphs with purpose-built Aero-style vector icons and add matching light/dark glass button styling.
- Make the sort icon reflect line-order versus severity-order mode.

## Why

The previous parser stopped at the closing timeline brace and silently discarded trailing content, so malformed scripts could evade diagnostics. The toolbar also used generic flat glyphs that did not match the rest of the Windows 7-inspired interface.

## Validation

- `./gradlew :core:test --tests com.jvn.core.vn.VnScriptParserTest :editor:test --tests com.jvn.editor.ui.VnsScriptAnalyzerExtendedDiagnosticsTest --tests com.jvn.editor.ui.VnsDiagnosticsViewFxTest`
- `git diff --check`