### PR TITLE
Unify sidebar Aero button styling

### DIFF
--- a/modules/editor/src/main/java/com/jvn/editor/EditorApp.java
+++ b/modules/editor/src/main/java/com/jvn/editor/EditorApp.java
@@ -6493,6 +6493,7 @@ public class EditorApp extends Application {
     javafx.scene.layout.VBox root = new javafx.scene.layout.VBox(10);
     root.setPadding(new javafx.geometry.Insets(12));
     root.setFillWidth(true);
+    root.getStyleClass().addAll("panel-chooser-root", "sidebar-tool-root");
     Label heading = new Label(title);
     heading.getStyleClass().add("panel-chooser-heading");
     Label info = new Label(details);

--- a/modules/editor/src/main/java/com/jvn/editor/ui/EditorSettingsView.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/EditorSettingsView.java
@@ -76,7 +76,7 @@ public class EditorSettingsView extends BorderPane {
   public EditorSettingsView(EditorPreferencesStore store) {
     this.store = store == null ? new EditorPreferencesStore() : store;
     setPadding(Insets.EMPTY);
-    getStyleClass().add("editor-settings-view");
+    getStyleClass().addAll("editor-settings-view", "sidebar-tool-root");
 
     ToolBar toolbar = new ToolBar();
     toolbar.getStyleClass().add("editor-settings-toolbar");

--- a/modules/editor/src/main/resources/com/jvn/editor/editor-light.css
+++ b/modules/editor/src/main/resources/com/jvn/editor/editor-light.css
@@ -7288,3 +7288,82 @@
   -fx-border-color: #4b7d99;
   -fx-effect: innershadow(gaussian, rgba(30, 65, 84, 0.24), 3, 0.2, 0, 1);
 }
+
+/*
+ * One command language for every sidebar tool: the same quiet-at-rest,
+ * glass-on-interaction treatment used by the VNS strip and Aero welcome
+ * actions. This final shared block intentionally wins over legacy
+ * tool-specific button capsules without forcing each tool to opt in.
+ */
+.sidebar-tool-root .button,
+.sidebar-tool-root .toggle-button,
+.sidebar-tool-root .menu-button,
+.sidebar-tool-root .split-menu-button {
+  -fx-background-color: transparent;
+  -fx-text-fill: #263b49;
+  -fx-border-color: transparent;
+  -fx-border-width: 1;
+  -fx-background-insets: 0;
+  -fx-border-insets: 0;
+  -fx-background-radius: 5;
+  -fx-border-radius: 5;
+  -fx-font-size: 11px;
+  -fx-font-weight: 700;
+  -fx-cursor: hand;
+  -fx-effect: none;
+}
+
+.sidebar-tool-root .button:hover,
+.sidebar-tool-root .toggle-button:hover,
+.sidebar-tool-root .menu-button:hover,
+.sidebar-tool-root .split-menu-button:hover {
+  -fx-background-color:
+      linear-gradient(to bottom, rgba(255, 255, 255, 0.86), rgba(141, 201, 234, 0.32));
+  -fx-border-color: rgba(74, 137, 174, 0.38);
+  -fx-text-fill: #16364b;
+  -fx-effect: dropshadow(gaussian, rgba(54, 132, 177, 0.22), 5, 0.18, 0, 1);
+}
+
+.sidebar-tool-root .button:pressed,
+.sidebar-tool-root .toggle-button:pressed,
+.sidebar-tool-root .menu-button:pressed,
+.sidebar-tool-root .split-menu-button:pressed {
+  -fx-background-color:
+      linear-gradient(to bottom, rgba(102, 167, 204, 0.34), rgba(230, 247, 255, 0.66));
+  -fx-border-color: rgba(48, 119, 160, 0.48);
+  -fx-text-fill: #122f42;
+  -fx-effect: innershadow(gaussian, rgba(35, 83, 109, 0.24), 3, 0.2, 0, 1);
+}
+
+.sidebar-tool-root .toggle-button:selected,
+.sidebar-tool-root .toggle-button:selected:hover,
+.sidebar-tool-root .menu-button:showing,
+.sidebar-tool-root .split-menu-button:showing {
+  -fx-background-color:
+      linear-gradient(to bottom, rgba(255, 255, 255, 0.92), rgba(98, 177, 219, 0.46));
+  -fx-border-color: rgba(42, 118, 161, 0.58);
+  -fx-text-fill: #12364d;
+  -fx-effect: innershadow(gaussian, rgba(47, 111, 147, 0.16), 3, 0.18, 0, 1);
+}
+
+.sidebar-tool-root .button:focused,
+.sidebar-tool-root .toggle-button:focused,
+.sidebar-tool-root .menu-button:focused,
+.sidebar-tool-root .split-menu-button:focused {
+  -fx-border-color: rgba(45, 123, 167, 0.58);
+}
+
+.sidebar-tool-root .button:disabled,
+.sidebar-tool-root .toggle-button:disabled,
+.sidebar-tool-root .menu-button:disabled,
+.sidebar-tool-root .split-menu-button:disabled {
+  -fx-opacity: 0.42;
+  -fx-cursor: default;
+  -fx-effect: none;
+}
+
+.sidebar-tool-root .split-menu-button > .label,
+.sidebar-tool-root .split-menu-button > .arrow-button {
+  -fx-background-color: transparent;
+  -fx-border-color: transparent;
+}

--- a/modules/editor/src/main/resources/com/jvn/editor/editor.css
+++ b/modules/editor/src/main/resources/com/jvn/editor/editor.css
@@ -7423,3 +7423,82 @@ The editor.css file defines the visual styling for the editor module, including 
   -fx-padding: 3;
   -fx-effect: none;
 }
+
+/*
+ * One command language for every sidebar tool: the same quiet-at-rest,
+ * glass-on-interaction treatment used by the VNS strip and Aero welcome
+ * actions. This final shared block intentionally wins over legacy
+ * tool-specific button capsules without forcing each tool to opt in.
+ */
+.sidebar-tool-root .button,
+.sidebar-tool-root .toggle-button,
+.sidebar-tool-root .menu-button,
+.sidebar-tool-root .split-menu-button {
+  -fx-background-color: transparent;
+  -fx-text-fill: #dcebf4;
+  -fx-border-color: transparent;
+  -fx-border-width: 1;
+  -fx-background-insets: 0;
+  -fx-border-insets: 0;
+  -fx-background-radius: 5;
+  -fx-border-radius: 5;
+  -fx-font-size: 11px;
+  -fx-font-weight: 700;
+  -fx-cursor: hand;
+  -fx-effect: none;
+}
+
+.sidebar-tool-root .button:hover,
+.sidebar-tool-root .toggle-button:hover,
+.sidebar-tool-root .menu-button:hover,
+.sidebar-tool-root .split-menu-button:hover {
+  -fx-background-color:
+      linear-gradient(to bottom, rgba(166, 224, 255, 0.16), rgba(72, 143, 184, 0.08));
+  -fx-border-color: rgba(185, 229, 255, 0.20);
+  -fx-text-fill: #f0faff;
+  -fx-effect: dropshadow(gaussian, rgba(72, 157, 207, 0.24), 6, 0.18, 0, 1);
+}
+
+.sidebar-tool-root .button:pressed,
+.sidebar-tool-root .toggle-button:pressed,
+.sidebar-tool-root .menu-button:pressed,
+.sidebar-tool-root .split-menu-button:pressed {
+  -fx-background-color:
+      linear-gradient(to bottom, rgba(45, 96, 126, 0.22), rgba(140, 210, 246, 0.10));
+  -fx-border-color: rgba(145, 208, 241, 0.26);
+  -fx-text-fill: #f2fbff;
+  -fx-effect: innershadow(gaussian, rgba(0, 0, 0, 0.46), 4, 0.22, 0, 1);
+}
+
+.sidebar-tool-root .toggle-button:selected,
+.sidebar-tool-root .toggle-button:selected:hover,
+.sidebar-tool-root .menu-button:showing,
+.sidebar-tool-root .split-menu-button:showing {
+  -fx-background-color:
+      linear-gradient(to bottom, rgba(156, 220, 255, 0.24), rgba(43, 112, 151, 0.16));
+  -fx-border-color: rgba(167, 222, 252, 0.44);
+  -fx-text-fill: #f2fbff;
+  -fx-effect: innershadow(gaussian, rgba(0, 0, 0, 0.34), 4, 0.2, 0, 1);
+}
+
+.sidebar-tool-root .button:focused,
+.sidebar-tool-root .toggle-button:focused,
+.sidebar-tool-root .menu-button:focused,
+.sidebar-tool-root .split-menu-button:focused {
+  -fx-border-color: rgba(149, 210, 242, 0.48);
+}
+
+.sidebar-tool-root .button:disabled,
+.sidebar-tool-root .toggle-button:disabled,
+.sidebar-tool-root .menu-button:disabled,
+.sidebar-tool-root .split-menu-button:disabled {
+  -fx-opacity: 0.42;
+  -fx-cursor: default;
+  -fx-effect: none;
+}
+
+.sidebar-tool-root .split-menu-button > .label,
+.sidebar-tool-root .split-menu-button > .arrow-button {
+  -fx-background-color: transparent;
+  -fx-border-color: transparent;
+}

--- a/modules/editor/src/test/java/com/jvn/editor/ui/SidebarToolButtonStyleFxTest.java
+++ b/modules/editor/src/test/java/com/jvn/editor/ui/SidebarToolButtonStyleFxTest.java
@@ -1,0 +1,106 @@
+package com.jvn.editor.ui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URL;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+import javafx.application.Platform;
+import javafx.css.PseudoClass;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.control.ButtonBase;
+import javafx.scene.control.MenuButton;
+import javafx.scene.control.SplitMenuButton;
+import javafx.scene.control.ToggleButton;
+import javafx.scene.layout.VBox;
+import javafx.scene.paint.Color;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class SidebarToolButtonStyleFxTest {
+  private static final PseudoClass HOVER = PseudoClass.getPseudoClass("hover");
+  private static boolean toolkitAvailable;
+
+  @BeforeAll
+  static void startToolkit() {
+    if (System.getProperty("os.name", "").toLowerCase().contains("linux")
+        && System.getenv().getOrDefault("DISPLAY", "").isBlank()) {
+      return;
+    }
+    try {
+      CountDownLatch ready = new CountDownLatch(1);
+      Platform.startup(ready::countDown);
+      toolkitAvailable = ready.await(10, TimeUnit.SECONDS);
+    } catch (IllegalStateException alreadyStarted) {
+      toolkitAvailable = true;
+    } catch (Exception unavailable) {
+      toolkitAvailable = false;
+    }
+  }
+
+  @Test
+  void everySidebarButtonFamilyUsesTheSharedAeroStatesInBothThemes() throws Exception {
+    Assumptions.assumeTrue(toolkitAvailable, "JavaFX toolkit is unavailable in this environment");
+
+    for (String stylesheet : List.of("editor-light.css", "editor.css")) {
+      runFx(() -> {
+        Button button = new Button("Run");
+        ToggleButton toggle = new ToggleButton("Selected");
+        MenuButton menu = new MenuButton("Options");
+        SplitMenuButton split = new SplitMenuButton();
+        split.setText("More");
+
+        VBox root = new VBox(button, toggle, menu, split);
+        root.getStyleClass().add("sidebar-tool-root");
+        Scene scene = new Scene(root, 420, 180);
+        URL css = SidebarToolButtonStyleFxTest.class.getResource("/com/jvn/editor/" + stylesheet);
+        assertTrue(css != null, stylesheet + " should be available");
+        scene.getStylesheets().add(css.toExternalForm());
+        root.applyCss();
+        root.layout();
+
+        for (ButtonBase control : List.of(button, toggle, menu, split)) {
+          assertTrue(hasTransparentRestingSurface(control), control.getClass().getSimpleName());
+          control.pseudoClassStateChanged(HOVER, true);
+          root.applyCss();
+          assertTrue(hasVisibleGlassSurface(control), control.getClass().getSimpleName());
+          control.pseudoClassStateChanged(HOVER, false);
+        }
+
+        toggle.setSelected(true);
+        root.applyCss();
+        assertTrue(hasVisibleGlassSurface(toggle), "selected toggles should stay illuminated");
+
+        button.setDisable(true);
+        root.applyCss();
+        assertEquals(0.42, button.getOpacity(), 0.001);
+        return null;
+      });
+    }
+  }
+
+  private static boolean hasTransparentRestingSurface(ButtonBase button) {
+    if (button.getBackground() == null || button.getBackground().getFills().isEmpty()) return true;
+    return button.getBackground().getFills().stream().allMatch(fill ->
+        fill.getFill() instanceof Color color && color.getOpacity() == 0.0);
+  }
+
+  private static boolean hasVisibleGlassSurface(ButtonBase button) {
+    assertFalse(button.getBackground() == null || button.getBackground().getFills().isEmpty());
+    return button.getBackground().getFills().stream().anyMatch(fill ->
+        !(fill.getFill() instanceof Color color) || color.getOpacity() > 0.0);
+  }
+
+  private static <T> T runFx(Callable<T> callable) throws Exception {
+    FutureTask<T> task = new FutureTask<>(callable);
+    Platform.runLater(task);
+    return task.get(30, TimeUnit.SECONDS);
+  }
+}


### PR DESCRIPTION
## What changed

- Apply the VNS/Aero quiet-at-rest and blue-glass interaction treatment to every sidebar `Button`, `ToggleButton`, `MenuButton`, and `SplitMenuButton`.
- Unify hover, pressed, selected/open, focused, and disabled states in both light and dark themes.
- Bring Editor Settings and the New Panel chooser into the shared sidebar styling scope.
- Add JavaFX regression coverage for all supported button families and interaction states in both themes.

## Why

Sidebar tools had accumulated separate capsules and per-tool color treatments, while the VNS strip and welcome actions used the newer Aero interaction language. A final shared sidebar theme layer now makes the behavior consistent without requiring each tool to opt in individually.

## Validation

- `./gradlew :editor:test --tests com.jvn.editor.ui.SidebarToolButtonStyleFxTest --tests com.jvn.editor.ui.VnsDiagnosticsViewFxTest --tests com.jvn.editor.ui.EditorSidebarPanelTest`
- `./gradlew :editor:test --tests com.jvn.editor.ui.GameBuildPublisherViewFxTest`
- `git diff --check`

A full `:editor:test` attempt reached 82 tests before an unrelated macOS JavaFX `libglass` crash following two publisher-test timeouts; that publisher test passed when rerun independently.