### PR TITLE
Fix runtime performance HUD metrics

### DIFF
--- a/modules/editor/src/main/java/com/jvn/editor/ui/RunConsoleView.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/RunConsoleView.java
@@ -111,15 +111,15 @@ public class RunConsoleView extends BorderPane {
     private final Label errorCountLabel = new Label("0 errors");
     private final Label warnCountLabel = new Label("0 warnings");
     private final PerfGraph perfGraph = new PerfGraph();
-    private final Tooltip perfGraphTooltip = new Tooltip("CPU -- | JVN -- MB | FPS --");
+    private final Tooltip perfGraphTooltip = new Tooltip("CPU -- | JVM -- MB | FPS --");
     private final Label perfCpuValue = new Label("CPU --");
-    private final Label perfJvmValue = new Label("JVN -- MB");
+    private final Label perfJvmValue = new Label("JVM -- MB");
     private final Label perfFpsValue = new Label("FPS --");
 
     // Raw line buffer for search/filter replay
     private final List<String> rawLineBuffer = new ArrayList<>();
 
-    private EngineState engineState = EngineState.BUILDING;
+    private volatile EngineState engineState = EngineState.BUILDING;
     private @Nullable Process runningProcess;
     private @Nullable ProcessStarter processStarter;
     private final RuntimeGradleOptionsStore gradleOptionsStore;
@@ -469,7 +469,7 @@ public class RunConsoleView extends BorderPane {
         if (size > 0) outputList.scrollTo(size - 1);
     }
 
-    private static String classifyLine(String line) {
+    static String classifyLine(String line) {
         if (line.startsWith("\u200B")) return "run-console-line-milestone";
         java.util.regex.Matcher rtm = RUNTIME_LOG_LINE.matcher(line);
         if (rtm.find()) {
@@ -689,7 +689,7 @@ public class RunConsoleView extends BorderPane {
         return Math.min(0.76, Math.max(0.0, progress));
     }
 
-    private static boolean isEngineOutputLine(String rawLine) {
+    static boolean isEngineOutputLine(String rawLine) {
         if (rawLine == null || rawLine.isBlank()) return false;
         return ENGINE_MSG.matcher(rawLine).find() || RUNTIME_LOG_LINE.matcher(rawLine).find();
     }
@@ -1292,8 +1292,8 @@ public class RunConsoleView extends BorderPane {
             nonHeapCeilingBytes = nonHeap.getUsed();
         }
         double nonHeapCeilingMb = Math.max(nonHeapMb, bytesToMb(nonHeapCeilingBytes));
-        double jvnUsedMb = Math.max(0.0, heapUsedMb + nonHeapMb);
-        double jvnCeilingMb = Math.max(1.0, heapMaxMb + nonHeapCeilingMb);
+        double jvmUsedMb = Math.max(0.0, heapUsedMb + nonHeapMb);
+        double jvmCeilingMb = Math.max(1.0, heapMaxMb + nonHeapCeilingMb);
         double cpuRatio = isRatioValid(smoothedProcessCpu) ? clamp01(smoothedProcessCpu) : 0.0;
         double cpuPercent = cpuRatio * 100.0;
         double fpsValue = Math.max(0.0, smoothedFps);
@@ -1310,14 +1310,14 @@ public class RunConsoleView extends BorderPane {
 
         perfGraphTooltip.setText(String.format(
             Locale.ROOT,
-            "CPU %.0f%% | JVN %.0f MB | %s",
+            "CPU %.0f%% | JVM %.0f MB | %s",
             cpuPercent,
-            jvnUsedMb,
+            jvmUsedMb,
             fpsText));
         perfCpuValue.setText(String.format(Locale.ROOT, "CPU %.0f%%", cpuPercent));
-        perfJvmValue.setText(String.format(Locale.ROOT, "JVN %.0f MB", jvnUsedMb));
+        perfJvmValue.setText(String.format(Locale.ROOT, "JVM %.0f MB", jvmUsedMb));
         perfFpsValue.setText(fpsText);
-        perfGraph.pushSample(cpuPercent, jvnUsedMb, fpsSampleValue, jvnCeilingMb);
+        perfGraph.pushSample(cpuPercent, jvmUsedMb, fpsSampleValue, jvmCeilingMb);
     }
 
     private static final class PerfGraph {

--- a/modules/editor/src/test/java/com/jvn/editor/ui/RunConsoleViewLogFormatTest.java
+++ b/modules/editor/src/test/java/com/jvn/editor/ui/RunConsoleViewLogFormatTest.java
@@ -1,0 +1,30 @@
+package com.jvn.editor.ui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class RunConsoleViewLogFormatTest {
+
+  @Test
+  void recognizesRuntimeLogbackOutputAsEngineOutput() {
+    String line =
+        "12:34:56.789 INFO  [JavaFX Application Thread] com.jvn.fx.FxLauncher"
+            + " - Runtime viewport -> window=1280x720, logical=1920x1080";
+
+    assertTrue(RunConsoleView.isEngineOutputLine(line));
+    assertEquals("run-console-line-info", RunConsoleView.classifyLine(line));
+  }
+
+  @Test
+  void recognizesLegacyBracketedEngineOutput() {
+    assertTrue(RunConsoleView.isEngineOutputLine("[Engine] Scene ready"));
+  }
+
+  @Test
+  void doesNotTreatGradleTaskOutputAsRuntimeOutput() {
+    assertFalse(RunConsoleView.isEngineOutputLine("> Task :runtime:run"));
+  }
+}

--- a/modules/fx/src/main/java/com/jvn/fx/FxLauncher.java
+++ b/modules/fx/src/main/java/com/jvn/fx/FxLauncher.java
@@ -489,6 +489,10 @@ public class FxLauncher extends Application {
         }
         syncPhoneOverlay(currentScene);
         pollProjectHotReload();
+        // Use the AnimationTimer's nanosecond clock for the HUD. Engine frame
+        // statistics intentionally store millisecond deltas and can therefore
+        // lose precision for fast frames.
+        hudData.tick(now);
         updatePerfHud(now);
 
         // Render
@@ -518,7 +522,6 @@ public class FxLauncher extends Application {
           } else {
             drawDefaultScene(w, h);
           }
-          hudData.tick(now);
           hudOverlay.render(gc, w, h);
           hideRuntimeLoadingOverlayAfterFirstFrame();
         }
@@ -558,7 +561,7 @@ public class FxLauncher extends Application {
 
   private HBox createPerfHud() {
     perfCpuLabel = createPerfHudLabel("CPU --", "#f27333");
-    perfJvmLabel = createPerfHudLabel("JVN -- MB", "#49a5ff");
+    perfJvmLabel = createPerfHudLabel("JVM -- MB", "#49a5ff");
     perfFpsLabel = createPerfHudLabel("FPS --", "#f4f4f4");
 
     HBox box = new HBox(6, perfCpuLabel, perfJvmLabel, perfFpsLabel);
@@ -599,19 +602,19 @@ public class FxLauncher extends Application {
       processCpu = osBean.getProcessCpuLoad();
     }
     smoothedProcessCpu = smoothRatio(smoothedProcessCpu, processCpu, PERF_CPU_SMOOTH_ALPHA);
-    smoothedFps = smoothRatio(smoothedFps, engine.frameStats().getFps(), PERF_FPS_SMOOTH_ALPHA);
+    smoothedFps = smoothRatio(smoothedFps, hudData.getFps(), PERF_FPS_SMOOTH_ALPHA);
 
     MemoryUsage heap = memoryBean.getHeapMemoryUsage();
     MemoryUsage nonHeap = memoryBean.getNonHeapMemoryUsage();
     double heapUsedMb = Math.max(0.0, bytesToMb(heap == null ? -1L : heap.getUsed()));
     double nonHeapMb = Math.max(0.0, bytesToMb(nonHeap == null ? -1L : nonHeap.getUsed()));
-    double jvnUsedMb = Math.max(0.0, heapUsedMb + nonHeapMb);
+    double jvmUsedMb = Math.max(0.0, heapUsedMb + nonHeapMb);
 
     String cpuText = isRatioValid(smoothedProcessCpu)
         ? String.format(Locale.ROOT, "CPU %.0f%%", smoothedProcessCpu * 100.0)
         : "CPU --";
-    String jvmText = String.format(Locale.ROOT, "JVN %.0f MB", jvnUsedMb);
-    String fpsText = String.format(Locale.ROOT, "FPS %.0f", Math.max(0.0, smoothedFps));
+    String jvmText = jvmMemoryText(jvmUsedMb);
+    String fpsText = fpsText(smoothedFps);
 
     perfCpuLabel.setText(cpuText);
     perfJvmLabel.setText(jvmText);
@@ -1976,6 +1979,16 @@ public class FxLauncher extends Application {
   private static double bytesToMb(long bytes) {
     if (bytes <= 0L) return 0.0;
     return bytes / (1024.0 * 1024.0);
+  }
+
+  static String jvmMemoryText(double usedMb) {
+    return String.format(Locale.ROOT, "JVM %.0f MB", Math.max(0.0, usedMb));
+  }
+
+  static String fpsText(double fps) {
+    return isRatioValid(fps)
+        ? String.format(Locale.ROOT, "FPS %.0f", fps)
+        : "FPS --";
   }
 
   private static boolean isRatioValid(double value) {

--- a/modules/fx/src/test/java/com/jvn/fx/FxLauncherPerfHudTest.java
+++ b/modules/fx/src/test/java/com/jvn/fx/FxLauncherPerfHudTest.java
@@ -1,0 +1,23 @@
+package com.jvn.fx;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class FxLauncherPerfHudTest {
+
+  @Test
+  void runtimeMemoryUsesJvmLabel() {
+    assertEquals("JVM 128 MB", FxLauncher.jvmMemoryText(127.6));
+  }
+
+  @Test
+  void runtimeFpsFormatsAvailableSample() {
+    assertEquals("FPS 60", FxLauncher.fpsText(59.7));
+  }
+
+  @Test
+  void runtimeFpsKeepsPlaceholderUntilSampleExists() {
+    assertEquals("FPS --", FxLauncher.fpsText(Double.NaN));
+  }
+}


### PR DESCRIPTION
## What changed

- label JVM memory consistently as `JVM` in both runtime performance surfaces
- drive the in-game FPS chip from the existing nanosecond JavaFX pulse sampler instead of integer-millisecond engine deltas
- make the runtime-console lifecycle state safely visible between its process reader and JavaFX animation thread
- add regressions for runtime metric formatting and actual Logback runtime output recognition

## Root cause and impact

The runtime HUD used an imprecise millisecond timing source, while the runtime console only renders FPS after its cross-thread lifecycle state becomes `RUNNING`. This could leave the runtime view showing `FPS --` even though the editor had a valid FPS sample. Memory values also described the JVM but were labelled `JVN`.

The runtime surfaces now report the same terminology and obtain a stable FPS sample while the game is running.

## Validation

- `./gradlew :core:test :fx:test --no-daemon`
- `./gradlew :core:test --tests com.jvn.core.diagnostics.PerformanceHudTest :fx:test --tests com.jvn.fx.FxLauncherPerfHudTest :editor:test --tests com.jvn.editor.ui.RunConsoleViewLogFormatTest --no-daemon`
- `git diff --check`

Closes #40
Closes #41