### PR TITLE
Harden character expression transitions

### DIFF
--- a/modules/core/src/main/java/com/jvn/core/vn/DefaultVnInterop.java
+++ b/modules/core/src/main/java/com/jvn/core/vn/DefaultVnInterop.java
@@ -1923,6 +1923,7 @@ public class DefaultVnInterop implements VnInterop {
         String displaySlot = null;
         Easing.Type easingType = null;
         long durationMs = 0;
+        long expressionDurationMs = -1L;
         for (int ti = startIdx; ti < toks.length; ti++) {
           String tok = toks[ti].trim();
           if (tok.isEmpty()) continue;
@@ -1948,6 +1949,16 @@ public class DefaultVnInterop implements VnInterop {
               case "duration":
               case "ms":
                 durationMs = Math.max(0L, parseLongSafe(value, durationMs));
+                break;
+              case "exprdur":
+              case "exprduration":
+              case "expr_duration":
+              case "expr-duration":
+              case "expressiondur":
+              case "expressionduration":
+              case "expression_duration":
+              case "expression-duration":
+                expressionDurationMs = Math.max(0L, parseLongSafe(value, expressionDurationMs));
                 break;
               case "ease":
               case "easing":
@@ -1975,7 +1986,12 @@ public class DefaultVnInterop implements VnInterop {
           state.setCharacterDefinedPosition(characterId, position);
         }
         state.showCharacterAnimated(position, characterId,
-            expression == null ? "neutral" : expression, null, easingType, durationMs, displaySlot);
+            expression == null ? "neutral" : expression,
+            null,
+            easingType,
+            durationMs,
+            displaySlot,
+            expressionDurationMs);
         break;
       }
       case "show": {

--- a/modules/core/src/main/java/com/jvn/core/vn/VnNode.java
+++ b/modules/core/src/main/java/com/jvn/core/vn/VnNode.java
@@ -25,6 +25,7 @@ public class VnNode {
   private final String displaySlot;
   private final Easing.Type moveEasingType;
   private final long moveDurationMs;
+  private final long expressionDurationMs;
   private final VnExternalCommand externalCommand;
   private final VnParticleCommand particleCommand;
   private final String groupTargetId;
@@ -48,6 +49,7 @@ public class VnNode {
     this.displaySlot = builder.displaySlot;
     this.moveEasingType = builder.moveEasingType;
     this.moveDurationMs = builder.moveDurationMs;
+    this.expressionDurationMs = builder.expressionDurationMs;
     this.externalCommand = builder.externalCommand;
     this.particleCommand = builder.particleCommand;
     this.groupTargetId = builder.groupTargetId;
@@ -71,6 +73,12 @@ public class VnNode {
   public String getDisplaySlot() { return displaySlot; }
   public Easing.Type getMoveEasingType() { return moveEasingType; }
   public long getMoveDurationMs() { return moveDurationMs; }
+  /**
+   * Expression transition duration for move nodes.
+   *
+   * @return milliseconds, or {@code -1} when the runtime default should be used
+   */
+  public long getExpressionDurationMs() { return expressionDurationMs; }
   public VnExternalCommand getExternalCommand() { return externalCommand; }
   public VnParticleCommand getParticleCommand() { return particleCommand; }
   public String getGroupTargetId() { return groupTargetId; }
@@ -96,6 +104,7 @@ public class VnNode {
     private String displaySlot;
     private Easing.Type moveEasingType;
     private long moveDurationMs;
+    private long expressionDurationMs = -1L;
     private VnExternalCommand externalCommand;
     private VnParticleCommand particleCommand;
     private String groupTargetId;
@@ -119,6 +128,7 @@ public class VnNode {
     public Builder displaySlot(String slot) { this.displaySlot = slot; return this; }
     public Builder moveEasingType(Easing.Type easing) { this.moveEasingType = easing; return this; }
     public Builder moveDurationMs(long ms) { this.moveDurationMs = ms; return this; }
+    public Builder expressionDurationMs(long ms) { this.expressionDurationMs = ms; return this; }
     public Builder external(VnExternalCommand cmd) { this.externalCommand = cmd; return this; }
     public Builder particleCommand(VnParticleCommand cmd) { this.particleCommand = cmd; return this; }
     public Builder groupTargetId(String targetId) { this.groupTargetId = targetId; return this; }

--- a/modules/core/src/main/java/com/jvn/core/vn/VnScenarioBuilder.java
+++ b/modules/core/src/main/java/com/jvn/core/vn/VnScenarioBuilder.java
@@ -252,6 +252,16 @@ public class VnScenarioBuilder {
                                  Easing.Type easingType,
                                  long durationMs,
                                  String displaySlot) {
+    return move(characterId, position, expression, easingType, durationMs, displaySlot, -1L);
+  }
+
+  public VnScenarioBuilder move(String characterId,
+                                 CharacterPosition position,
+                                 String expression,
+                                 Easing.Type easingType,
+                                 long durationMs,
+                                 String displaySlot,
+                                 long expressionDurationMs) {
     VnNode.Builder b = VnNode.builder(VnNodeType.MOVE)
         .characterToShow(characterId)
         .showPosition(position)
@@ -259,6 +269,7 @@ public class VnScenarioBuilder {
     if (expression != null) b.showExpression(expression);
     if (easingType != null) b.moveEasingType(easingType);
     if (durationMs > 0) b.moveDurationMs(durationMs);
+    if (expressionDurationMs >= 0L) b.expressionDurationMs(expressionDurationMs);
     scenarioBuilder.addNode(b.build());
     return this;
   }

--- a/modules/core/src/main/java/com/jvn/core/vn/VnScene.java
+++ b/modules/core/src/main/java/com/jvn/core/vn/VnScene.java
@@ -782,13 +782,18 @@ public class VnScene implements Scene {
       }
       String expr = node.getShowExpression() != null ? node.getShowExpression() : null;
       state.showCharacterAnimated(node.getShowPosition(), node.getCharacterToShow(), expr,
-          null, node.getMoveEasingType(), node.getMoveDurationMs(), node.getDisplaySlot());
+          null,
+          node.getMoveEasingType(),
+          node.getMoveDurationMs(),
+          node.getDisplaySlot(),
+          node.getExpressionDurationMs());
     } else if (node.getDisplaySlot() != null && node.getShowPosition() != null) {
       state.moveDisplaySlotAnimated(node.getDisplaySlot(),
           node.getShowPosition(),
           node.getShowExpression(),
           node.getMoveEasingType(),
-          node.getMoveDurationMs());
+          node.getMoveDurationMs(),
+          node.getExpressionDurationMs());
     }
   }
 

--- a/modules/core/src/main/java/com/jvn/core/vn/VnState.java
+++ b/modules/core/src/main/java/com/jvn/core/vn/VnState.java
@@ -249,6 +249,25 @@ public class VnState {
                                     Easing.Type easingType,
                                     long customDurationMs,
                                     String displaySlot) {
+    showCharacterAnimated(
+        position,
+        characterId,
+        expression,
+        layerOrder,
+        easingType,
+        customDurationMs,
+        displaySlot,
+        -1L);
+  }
+
+  public void showCharacterAnimated(CharacterPosition position,
+                                    String characterId,
+                                    String expression,
+                                    Integer layerOrder,
+                                    Easing.Type easingType,
+                                    long customDurationMs,
+                                    String displaySlot,
+                                    long expressionDurationMs) {
     String normalizedSlot = normalizeDisplaySlotId(displaySlot);
     CharacterPosition baseTarget = fallbackPositionFor(characterId, position);
     CharacterPosition target = displayPositionFor(baseTarget, normalizedSlot);
@@ -256,11 +275,14 @@ public class VnState {
     CharacterSlot existingSlot = existingPos == null ? null : visibleCharacters.get(existingPos);
     String fallbackExpression = existingSlot != null ? existingSlot.getExpression() : "neutral";
     String resolvedExpression = normalizeExpression(expression, fallbackExpression);
+    long resolvedExpressionDurationMs = expressionDurationMs >= 0L
+        ? expressionDurationMs
+        : DEFAULT_EXPRESSION_TRANSITION_MS;
     int resolvedLayerOrder = resolveLayerOrder(baseTarget, layerOrder, existingSlot != null ? existingSlot.getLayerOrder() : null);
 
     if (existingPos != null && existingSlot != null && existingPos.equals(target)) {
       updateVisibleSlotExpression(target, existingSlot, resolvedExpression, resolvedLayerOrder,
-          DEFAULT_EXPRESSION_TRANSITION_MS, null);
+          resolvedExpressionDurationMs, null);
       pendingExpressionSwitches.remove(target);
       ensureCharacterVisual(target);
       if (normalizedSlot.isEmpty() && isCharacterGlobalPositionEnabled(characterId)) {
@@ -281,7 +303,12 @@ public class VnState {
       pendingExpressionSwitches.remove(target);
       if (!resolvedExpression.equals(movingExpression)) {
         pendingExpressionSwitches.put(target, new PendingExpressionSwitch(
-            characterId, normalizedSlot, resolvedExpression, moveDur, DEFAULT_EXPRESSION_TRANSITION_MS, null));
+            characterId,
+            normalizedSlot,
+            resolvedExpression,
+            moveDur,
+            resolvedExpressionDurationMs,
+            null));
       }
       if (normalizedSlot.isEmpty()) {
         characterDefinedPositions.put(characterId, baseTarget);
@@ -312,6 +339,15 @@ public class VnState {
                                          String expression,
                                          Easing.Type easingType,
                                          long customDurationMs) {
+    return moveDisplaySlotAnimated(displaySlot, position, expression, easingType, customDurationMs, -1L);
+  }
+
+  public boolean moveDisplaySlotAnimated(String displaySlot,
+                                         CharacterPosition position,
+                                         String expression,
+                                         Easing.Type easingType,
+                                         long customDurationMs,
+                                         long expressionDurationMs) {
     CharacterPosition existingPos = findDisplaySlotPosition(displaySlot);
     CharacterSlot existingSlot = existingPos == null ? null : visibleCharacters.get(existingPos);
     if (existingSlot == null) return false;
@@ -321,7 +357,8 @@ public class VnState {
         null,
         easingType,
         customDurationMs,
-        existingSlot.getDisplaySlot());
+        existingSlot.getDisplaySlot(),
+        expressionDurationMs);
     return true;
   }
 
@@ -404,6 +441,26 @@ public class VnState {
       }
     }
 
+    if (!expressionTransitions.isEmpty()) {
+      var it = expressionTransitions.entrySet().iterator();
+      while (it.hasNext()) {
+        var entry = it.next();
+        String stateKey = entry.getKey();
+        ExpressionTransition transition = entry.getValue();
+        if (findStateKeyPosition(stateKey) == null && !detachedCharacters.containsKey(stateKey)) {
+          it.remove();
+          continue;
+        }
+        transition.update(deltaMs);
+        if (transition.isFinished()) {
+          it.remove();
+        }
+      }
+    }
+
+    // Start delayed expression swaps after advancing transitions that were
+    // already active at the beginning of this frame. A newly-started
+    // crossfade must not consume the movement frame's entire delta.
     if (!pendingExpressionSwitches.isEmpty()) {
       var it = pendingExpressionSwitches.entrySet().iterator();
       while (it.hasNext()) {
@@ -420,23 +477,6 @@ public class VnState {
         updateVisibleSlotExpression(position, slot, pending.expression, slot.getLayerOrder(),
             pending.transitionDurationMs, pending.easingType);
         it.remove();
-      }
-    }
-
-    if (!expressionTransitions.isEmpty()) {
-      var it = expressionTransitions.entrySet().iterator();
-      while (it.hasNext()) {
-        var entry = it.next();
-        String stateKey = entry.getKey();
-        ExpressionTransition transition = entry.getValue();
-        if (findStateKeyPosition(stateKey) == null && !detachedCharacters.containsKey(stateKey)) {
-          it.remove();
-          continue;
-        }
-        transition.update(deltaMs);
-        if (transition.isFinished()) {
-          it.remove();
-        }
       }
     }
   }

--- a/modules/core/src/main/java/com/jvn/core/vn/script/VnScriptParser.java
+++ b/modules/core/src/main/java/com/jvn/core/vn/script/VnScriptParser.java
@@ -1616,6 +1616,7 @@ public class VnScriptParser {
         String moveExpr = null;
         Easing.Type moveEasing = null;
         long moveDur = 0;
+        long moveExprDur = -1L;
 
         // Parse all tokens
         int i = 0;
@@ -1701,6 +1702,19 @@ public class VnScriptParser {
                 moveDur = parseLongValue(option.value(), "[move]", "duration", sourceName, lineNumber, rawLine);
                 if (moveDur < 0) throw parseError(sourceName, lineNumber, "[move] duration must be >= 0", rawLine);
               }
+              case "exprdur", "exprduration", "expr_duration", "expr-duration",
+                   "expressiondur", "expressionduration", "expression_duration", "expression-duration" -> {
+                moveExprDur = parseLongValue(
+                    option.value(),
+                    "[move]",
+                    "expression duration",
+                    sourceName,
+                    lineNumber,
+                    rawLine);
+                if (moveExprDur < 0) {
+                  throw parseError(sourceName, lineNumber, "[move] expression duration must be >= 0", rawLine);
+                }
+              }
               default -> throw parseError(sourceName, lineNumber, "[move] unknown option: " + option.key(), rawLine);
             }
             i++;
@@ -1742,7 +1756,14 @@ public class VnScriptParser {
           throw parseError(sourceName, lineNumber, "[move] expects a character id or slot=...", rawLine);
         }
 
-        state.builder.move(moveCharId, movePos, moveExpr, moveEasing, moveDur, moveDisplaySlot);
+        state.builder.move(
+            moveCharId,
+            movePos,
+            moveExpr,
+            moveEasing,
+            moveDur,
+            moveDisplaySlot,
+            moveExprDur);
         return;
       }
       case "stage": {
@@ -2629,6 +2650,8 @@ public class VnScriptParser {
       case "move" -> switch (key) {
         case "pos", "position", "at", "coord", "coords", "xy",
              "expr", "expression", "preset", "ease", "easing", "dur", "duration", "ms",
+             "exprdur", "exprduration", "expr_duration", "expr-duration",
+             "expressiondur", "expressionduration", "expression_duration", "expression-duration",
              "slot", "as", "instance", "display", "display_slot", "display-slot" -> true;
         default -> false;
       };

--- a/modules/core/src/test/java/com/jvn/core/vn/DefaultVnInteropQuotedArgsTest.java
+++ b/modules/core/src/test/java/com/jvn/core/vn/DefaultVnInteropQuotedArgsTest.java
@@ -96,6 +96,75 @@ class DefaultVnInteropQuotedArgsTest {
   }
 
   @Test
+  void characterExpressionCommandSupportsInstantAndDefaultSwaps() {
+    VnScenario scenario = new VnScenarioBuilder("expression_swap_modes")
+      .addCharacterWithExpressions("lily", "Lily", "neutral.png", "talking.png")
+      .label("start")
+      .end()
+      .build();
+    VnScene scene = new VnScene(scenario);
+    scene.getState().showCharacter(CharacterPosition.CENTER, "lily", "neutral");
+    DefaultVnInterop interop = new DefaultVnInterop();
+
+    interop.handle(new VnExternalCommand("char", "lily expression talking dur=0"), scene);
+    assertEquals("talking", scene.getState().getCharacterExpression("lily"));
+    assertNull(scene.getState().getExpressionTransition("lily"));
+
+    interop.handle(new VnExternalCommand("char", "lily expression neutral"), scene);
+    assertEquals("neutral", scene.getState().getCharacterExpression("lily"));
+    assertNotNull(scene.getState().getExpressionTransition("lily"));
+  }
+
+  @Test
+  void characterMoveAppliesExpressionDurationIndependently() {
+    VnScenario scenario = new VnScenarioBuilder("independent_expression_duration")
+      .addCharacterWithExpressions("john", "John", "neutral.png", "talking.png")
+      .label("start")
+      .end()
+      .build();
+    VnScene scene = new VnScene(scenario);
+    scene.getState().showCharacter(CharacterPosition.CENTER, "john", "neutral");
+    scene.getState().setCharacterGlobalPositionEnabled("john", true);
+    DefaultVnInterop interop = new DefaultVnInterop();
+
+    interop.handle(
+        new VnExternalCommand(
+            "char",
+            "john move right expression=talking dur=400 exprDur=120"),
+        scene);
+
+    assertEquals("neutral", scene.getState().getCharacterExpression("john"));
+    scene.getState().updateCharacterAnimations(400);
+    assertEquals("talking", scene.getState().getCharacterExpression("john"));
+    assertNotNull(scene.getState().getExpressionTransition("john"));
+    scene.getState().updateCharacterAnimations(120);
+    assertNull(scene.getState().getExpressionTransition("john"));
+  }
+
+  @Test
+  void characterMoveAcceptsQuotedExpressionWithInstantDuration() {
+    VnScenario scenario = new VnScenarioBuilder("quoted_expression_duration")
+      .addCharacterWithExpressions("john", "John", "neutral.png")
+      .label("start")
+      .end()
+      .build();
+    VnScene scene = new VnScene(scenario);
+    scene.getState().showCharacter(CharacterPosition.CENTER, "john", "neutral");
+    scene.getState().setCharacterGlobalPositionEnabled("john", true);
+    DefaultVnInterop interop = new DefaultVnInterop();
+
+    interop.handle(
+        new VnExternalCommand(
+            "char",
+            "john move right expression=\"soft smile\" dur=400 exprDur=0"),
+        scene);
+
+    scene.getState().updateCharacterAnimations(400);
+    assertEquals("soft smile", scene.getState().getCharacterExpression("john"));
+    assertNull(scene.getState().getExpressionTransition("john"));
+  }
+
+  @Test
   void laterInlineTimelineMoveReplacesEarlierCharacterDisplacement() {
     VnScenario scenario = new VnScenarioBuilder("timeline_displacement_latest")
       .addCharacterWithExpressions("john", "John", "body.png")

--- a/modules/core/src/test/java/com/jvn/core/vn/VnRollbackEntryTest.java
+++ b/modules/core/src/test/java/com/jvn/core/vn/VnRollbackEntryTest.java
@@ -4,6 +4,7 @@ import com.jvn.core.vn.rollback.VnRollbackEntry;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class VnRollbackEntryTest {
@@ -84,5 +85,21 @@ class VnRollbackEntryTest {
     assertEquals("body", state.getVisibleCharacters().get(bodySlot).getCharacterId());
     assertEquals("head", state.getVisibleCharacters().get(headSlot).getCharacterId());
     assertEquals(10, state.getVisibleCharacters().get(headSlot).getLayerOrder());
+  }
+
+  @Test
+  void rollbackDuringExpressionTransitionRestoresTargetExpressionDeterministically() {
+    VnState state = new VnState();
+    state.showCharacter(CharacterPosition.CENTER, "lily", "neutral");
+    assertTrue(state.setCharacterExpression("lily", "talking", 240));
+    assertTrue(state.getExpressionTransition("lily") != null);
+
+    VnRollbackEntry entry = VnRollbackEntry.capture(state, "Lily", "Line");
+    state.setCharacterExpression("lily", "neutral", 0);
+
+    entry.applyTo(state);
+
+    assertEquals("talking", state.getCharacterExpression("lily"));
+    assertNull(state.getExpressionTransition("lily"));
   }
 }

--- a/modules/core/src/test/java/com/jvn/core/vn/VnSavePersistenceTest.java
+++ b/modules/core/src/test/java/com/jvn/core/vn/VnSavePersistenceTest.java
@@ -145,4 +145,28 @@ public class VnSavePersistenceTest {
     assertEquals("head", loaded.getVisibleCharacters().get(headSlot).getCharacterId());
     assertEquals(10, loaded.getVisibleCharacters().get(headSlot).getLayerOrder());
   }
+
+  @Test
+  public void saveDuringExpressionTransitionClampsToTargetExpression() throws Exception {
+    VnScenario scenario = new VnScenarioBuilder("transition_save")
+        .addCharacterWithExpressions("lily", "Lily", "neutral.png", "talking.png")
+        .end()
+        .build();
+    VnState state = new VnState();
+    state.setScenario(scenario);
+    state.showCharacter(CharacterPosition.CENTER, "lily", "neutral");
+    assertTrue(state.setCharacterExpression("lily", "talking", 240));
+    assertTrue(state.getExpressionTransition("lily") != null);
+
+    Path tmp = Files.createTempDirectory("vn_transition_save_test");
+    VnSaveManager manager = new VnSaveManager(tmp.toString());
+    manager.save(state, "during_transition");
+
+    VnState loaded = new VnState();
+    loaded.setScenario(scenario);
+    manager.applyToState(manager.load("during_transition"), loaded);
+
+    assertEquals("talking", loaded.getCharacterExpression("lily"));
+    assertTrue(loaded.getExpressionTransition("lily") == null);
+  }
 }

--- a/modules/core/src/test/java/com/jvn/core/vn/VnScriptParserTest.java
+++ b/modules/core/src/test/java/com/jvn/core/vn/VnScriptParserTest.java
@@ -1061,6 +1061,63 @@ public class VnScriptParserTest {
   }
 
   @Test
+  public void moveCommandSupportsIndependentExpressionDuration() throws Exception {
+    String script = """
+      @label start
+      [move john pos=right expression=talking dur=400 exprDur=120]
+      [end]
+    """;
+
+    VnScenario scenario = new VnScriptParser().parseFromString(script);
+    VnNode move = scenario.getNodes().stream()
+        .filter(n -> n.getType() == VnNodeType.MOVE)
+        .findFirst()
+        .orElseThrow();
+
+    assertEquals(400, move.getMoveDurationMs());
+    assertEquals(120, move.getExpressionDurationMs());
+  }
+
+  @Test
+  public void characterExpressionCommandAcceptsInstantAndDefaultDurations() throws Exception {
+    String instantScript = """
+      @scenario expression_instant
+      @character lily "Lily"
+      @charimg lily neutral neutral.png
+      @charimg lily talking talking.png
+      @label start
+      [show lily center neutral]
+      [character lily expression talking dur=0]
+      [end]
+    """;
+
+    VnScene instantScene = new VnScene(new VnScriptParser().parseFromString(instantScript));
+    instantScene.setInterop(new DefaultVnInterop());
+    instantScene.onEnter();
+
+    assertEquals("talking", instantScene.getState().getCharacterExpression("lily"));
+    assertNull(instantScene.getState().getExpressionTransition("lily"));
+
+    String defaultScript = """
+      @scenario expression_default
+      @character lily "Lily"
+      @charimg lily neutral neutral.png
+      @charimg lily talking talking.png
+      @label start
+      [show lily center talking]
+      [character lily expression neutral]
+      [end]
+    """;
+
+    VnScene defaultScene = new VnScene(new VnScriptParser().parseFromString(defaultScript));
+    defaultScene.setInterop(new DefaultVnInterop());
+    defaultScene.onEnter();
+
+    assertEquals("neutral", defaultScene.getState().getCharacterExpression("lily"));
+    assertNotNull(defaultScene.getState().getExpressionTransition("lily"));
+  }
+
+  @Test
   public void transitionCommandSupportsNamedOptions() throws Exception {
     String script = """
       @label start


### PR DESCRIPTION
## What changed

- add independent `exprDur` / `expressionDuration` support to `[move]` and `[character … move …]`
- carry expression timing through parsed move nodes, scenario execution, direct interop, and display-slot movement
- preserve existing behavior with a `-1` sentinel: omitted expression duration still uses the documented 180 ms default, while `exprDur=0` swaps instantly
- prevent a newly started post-move crossfade from consuming the movement frame’s entire delta
- add parser/runtime coverage for instant and default expression swaps, quoted/unquoted move forms, deterministic save/load, and rollback during an active crossfade

## Root cause and impact

Movement and expression changes previously shared only the movement command’s timing path, while the expression crossfade duration was hard-coded in state. Save/load and rollback already captured the target expression deterministically, but that contract was not protected by tests.

Authors can now tune movement and expression timing independently without changing existing scripts. Saves and rollback made during a crossfade restore a complete target expression with no renderer-specific half-state.

## Validation

- `./gradlew :core:test --no-daemon`
- focused parser, interop, save/load, and rollback test run
- `git diff --check`

Closes #14
Closes #15
Closes #19