### PR TITLE
Release JVN 0.4.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <div align="left">
   <img src="docs/assets/images/jvn_logo.svg" width="460" alt="Java Vector Nexus logo">
   <br>
-  <strong>Current version:</strong> v0.4.2 <em></em>
+  <strong>Current version:</strong> v0.4.3 <em></em>
 </div>
 
 JVN is a young, modular cross-platform Visual Novel engine and 2D animation toolkit written in Java.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,7 @@ interface JvnInjectedExecOperations {
 }
 
 val jvnGroup = (findProperty("jvnGroup") as String?) ?: "com.jvn"
-val jvnVersion = (findProperty("jvnVersion") as String?) ?: "0.4.2"
+val jvnVersion = (findProperty("jvnVersion") as String?) ?: "0.4.3"
 val jvnBuildDirOverride = (findProperty("jvnBuildDir") as String?)
   ?.trim()
   ?.takeIf { it.isNotBlank() }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
 org.gradle.caching=true
 org.gradle.parallel=true
-jvnVersion=0.4.2
+jvnVersion=0.4.3
 # Optional: set jvnBuildDir in this file or pass -PjvnBuildDir=<dir> to relocate workspace build outputs.
 # Default Java version used by toolchains (can be overridden per module)
 javaVersion=21

--- a/modules/editor/src/main/java/com/jvn/editor/AppBuildInfo.java
+++ b/modules/editor/src/main/java/com/jvn/editor/AppBuildInfo.java
@@ -8,7 +8,7 @@ import java.util.logging.Logger;
 
 public final class AppBuildInfo {
   private static final Logger log = Logger.getLogger(AppBuildInfo.class.getName());
-  private static final String FALLBACK_VERSION = "0.4.2";
+  private static final String FALLBACK_VERSION = "0.4.3";
 
   private AppBuildInfo() {
   }

--- a/modules/editor/src/main/java/com/jvn/editor/ui/WhatsNewCatalog.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/WhatsNewCatalog.java
@@ -49,6 +49,39 @@ public final class WhatsNewCatalog {
   private static Map<String, Release> createReleases() {
     Map<String, Release> releases = new LinkedHashMap<>();
     add(releases, new Release(
+        "v0.4.3",
+        "Broader runtime reach, stronger VNS authoring, and a more dependable play loop.",
+        List.of(
+            new Section(
+                "Web and release workflows",
+                "JVN projects are easier to launch and package beyond the desktop editor.",
+                List.of(
+                    "The web runtime now includes an executable browser bootstrap, application configuration parsing, and a complete runtime session.",
+                    "Runtime packaging, project storage, and accessibility behavior are more resilient.",
+                    "Console launches now provide a clearer, more consistent path from project actions into a running game.")),
+            new Section(
+                "VNS authoring tools",
+                "The visual-novel workflow has gained faster controls and clearer feedback.",
+                List.of(
+                    "The VNS tool strip now uses distinct controls for preview, validation, formatting, navigation, and related actions.",
+                    "the diagnostics utilities handle timeline issues more safely and offer clearer refresh and toolbar actions.",
+                    "Preview launches keep their visible game window and no longer leave hidden preview audio playing.")),
+            new Section(
+                "Characters and dialogue",
+                "Authors have more control over how speakers look and behave.",
+                List.of(
+                    "Dialogue speakers can define their own persistent colors.",
+                    "Characters can keep an authored scale across VNS scenes, with matching editor preview support.",
+                    "Expression transitions have been hardened so rapid changes settle on the intended pose.")),
+            new Section(
+                "Runtime stability and polish",
+                "Core playback paths now behave more predictably under real project load.",
+                List.of(
+                    "Update loops, renderer primitives, audio ownership, and title-menu music startup are more robust.",
+                    "The gameplay menu and dialogue presentation have moved closer to full runtime parity.",
+                    "Performance HUD metrics now report frame timing and activity more accurately."))),
+        true));
+    add(releases, new Release(
         "v0.4.2",
         "A more immediate authoring loop, calmer runtime feedback, and sharper editor tools.",
         List.of(

--- a/modules/editor/src/test/java/com/jvn/editor/AppBuildInfoTest.java
+++ b/modules/editor/src/test/java/com/jvn/editor/AppBuildInfoTest.java
@@ -11,14 +11,14 @@ class AppBuildInfoTest {
 
   @Test
   void displayVersionLabelUsesFallbackForDev() {
-    assertEquals("v0.4.2", AppBuildInfo.displayVersionLabel("dev"));
-    assertEquals("v0.4.2", AppBuildInfo.displayVersionLabel("vdev"));
-    assertEquals("v0.4.2", AppBuildInfo.displayVersionLabel(""));
+    assertEquals("v0.4.3", AppBuildInfo.displayVersionLabel("dev"));
+    assertEquals("v0.4.3", AppBuildInfo.displayVersionLabel("vdev"));
+    assertEquals("v0.4.3", AppBuildInfo.displayVersionLabel(""));
   }
 
   @Test
   void displayVersionLabelMapsSnapshotToAlpha() {
-    assertEquals("v0.4.2 Alpha", AppBuildInfo.displayVersionLabel("0.4.2-SNAPSHOT"));
+    assertEquals("v0.4.3 Alpha", AppBuildInfo.displayVersionLabel("0.4.3-SNAPSHOT"));
   }
 
   @Test

--- a/modules/editor/src/test/java/com/jvn/editor/ui/WhatsNewCatalogTest.java
+++ b/modules/editor/src/test/java/com/jvn/editor/ui/WhatsNewCatalogTest.java
@@ -10,19 +10,19 @@ class WhatsNewCatalogTest {
 
   @Test
   void requestsPopupOnlyWhenVersionChanges() {
-    assertTrue(WhatsNewCatalog.shouldShow("v0.4.2", ""));
-    assertTrue(WhatsNewCatalog.shouldShow("v0.4.2", "v0.4.1"));
-    assertTrue(WhatsNewCatalog.shouldShow("v0.4.2", "v0.4.2 Beta"));
-    assertFalse(WhatsNewCatalog.shouldShow("v0.4.2", " v0.4.2 "));
+    assertTrue(WhatsNewCatalog.shouldShow("v0.4.3", ""));
+    assertTrue(WhatsNewCatalog.shouldShow("v0.4.3", "v0.4.2"));
+    assertTrue(WhatsNewCatalog.shouldShow("v0.4.3", "v0.4.3 Beta"));
+    assertFalse(WhatsNewCatalog.shouldShow("v0.4.3", " v0.4.3 "));
     assertFalse(WhatsNewCatalog.shouldShow("", "v0.4.1"));
   }
 
   @Test
   void currentReleaseContainsCuratedDetailedNotes() {
-    WhatsNewCatalog.Release release = WhatsNewCatalog.forVersion("v0.4.2");
+    WhatsNewCatalog.Release release = WhatsNewCatalog.forVersion("v0.4.3");
 
     assertTrue(release.curated());
-    assertEquals("v0.4.2", release.versionLabel());
+    assertEquals("v0.4.3", release.versionLabel());
     assertEquals(4, release.sections().size());
     assertTrue(release.sections().stream().allMatch(section -> !section.title().isBlank()));
     assertTrue(release.sections().stream().allMatch(section -> section.changes().size() >= 2));
@@ -30,10 +30,10 @@ class WhatsNewCatalogTest {
 
   @Test
   void maturityBuildUsesNumericReleaseNotesButKeepsFullLabel() {
-    WhatsNewCatalog.Release release = WhatsNewCatalog.forVersion("v0.4.2 Beta");
+    WhatsNewCatalog.Release release = WhatsNewCatalog.forVersion("v0.4.3 Beta");
 
     assertTrue(release.curated());
-    assertEquals("v0.4.2 Beta", release.versionLabel());
+    assertEquals("v0.4.3 Beta", release.versionLabel());
   }
 
   @Test

--- a/modules/hub/src/main/java/com/jvn/hub/JvnHub.java
+++ b/modules/hub/src/main/java/com/jvn/hub/JvnHub.java
@@ -3776,7 +3776,7 @@ public final class JvnHub {
   private static String displayVersionLabel(String rawVersion) {
     String raw = rawVersion == null ? "" : rawVersion.trim();
     if (raw.isBlank() || raw.equalsIgnoreCase("dev") || raw.equalsIgnoreCase("vdev")) {
-      return "v0.4.2";
+      return "v0.4.3";
     }
 
     String version = raw.startsWith("v") || raw.startsWith("V") ? raw.substring(1) : raw;
@@ -3795,7 +3795,7 @@ public final class JvnHub {
     int plus = version.indexOf('+');
     if (plus >= 0) version = version.substring(0, plus);
     version = version.trim();
-    if (version.isBlank()) version = "0.4.2";
+    if (version.isBlank()) version = "0.4.3";
     return "v" + version + (maturity == null ? "" : " " + maturity);
   }
 

--- a/modules/hub/src/test/java/com/jvn/hub/JvnHubDisplayScaleTest.java
+++ b/modules/hub/src/test/java/com/jvn/hub/JvnHubDisplayScaleTest.java
@@ -37,7 +37,7 @@ class JvnHubDisplayScaleTest {
 
   @Test
   void sourceBuildIndicatorUsesTheHubOrangeAccent() {
-    String label = JvnHub.formatVersionLabel("0.4.2");
+    String label = JvnHub.formatVersionLabel("0.4.3");
     if (label.startsWith("<html>")) {
       org.junit.jupiter.api.Assertions.assertTrue(label.contains("color:#ff9933"));
       org.junit.jupiter.api.Assertions.assertTrue(label.contains("Running from source"));


### PR DESCRIPTION
## What changed

- Bumped JVN from 0.4.2 to 0.4.3 across Gradle, editor, Hub, and README version sources.
- Added curated 0.4.3 notes to the custom version-aware What’s New popup.
- Updated focused version and release-note tests.

## Why

This publishes the accumulated runtime, VNS authoring, character/dialogue, and stability work as JVN 0.4.3 and ensures upgraded users see the project’s custom announcement.

## Validation

- `./gradlew :editor:test --tests com.jvn.editor.AppBuildInfoTest --tests com.jvn.editor.ui.WhatsNewCatalogTest :hub:test --tests com.jvn.hub.JvnHubDisplayScaleTest`
- `git diff --check`
