### PR TITLE
Optimize Puppeteer keyframe and GPU preview paths

### DIFF
--- a/modules/editor/src/main/java/com/jvn/editor/ui/actioneditor/AnimationProject.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/actioneditor/AnimationProject.java
@@ -1050,11 +1050,15 @@ public class AnimationProject {
         double timeMs,
         Map<PropertyType, Double> fallbackLocalValues
     ) {
-        return computeEffectiveEntityTransform(entityName, timeMs, fallbackLocalValues, true, new HashSet<>());
+        Set<String> constraintStack = constraints.containsKey(entityName)
+            ? new HashSet<>()
+            : Collections.emptySet();
+        return computeEffectiveEntityTransform(entityName, timeMs, fallbackLocalValues, true, constraintStack);
     }
 
     EffectiveEntityTransform computeUnconstrainedEntityTransform(String entityName, double timeMs) {
-        return computeEffectiveEntityTransform(entityName, timeMs, Collections.emptyMap(), false, new HashSet<>());
+        return computeEffectiveEntityTransform(
+            entityName, timeMs, Collections.emptyMap(), false, Collections.emptySet());
     }
 
     EffectiveEntityTransform computeUnconstrainedEntityTransform(
@@ -1062,7 +1066,8 @@ public class AnimationProject {
         double timeMs,
         Map<PropertyType, Double> fallbackLocalValues
     ) {
-        return computeEffectiveEntityTransform(entityName, timeMs, fallbackLocalValues, false, new HashSet<>());
+        return computeEffectiveEntityTransform(
+            entityName, timeMs, fallbackLocalValues, false, Collections.emptySet());
     }
 
     private EffectiveEntityTransform computeEffectiveEntityTransform(
@@ -1091,7 +1096,7 @@ public class AnimationProject {
         double visibility = localValueAt(track, PropertyType.VISIBILITY, timeMs, fallbackLocalValues);
 
         String cursor = track.getParentGroupName();
-        Set<String> visited = new HashSet<>();
+        Set<String> visited = cursor != null ? new HashSet<>() : Collections.emptySet();
         while (cursor != null && visited.add(cursor)) {
             EntityGroup group = groups.get(cursor);
             if (group == null) break;

--- a/modules/editor/src/main/java/com/jvn/editor/ui/actioneditor/EntityTrack.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/actioneditor/EntityTrack.java
@@ -57,17 +57,17 @@ public class EntityTrack {
     public Keyframe upsertKeyframe(PropertyType property, Keyframe kf) {
         if (property == null || kf == null) return null;
         List<Keyframe> list = keyframes.computeIfAbsent(property, k -> new ArrayList<>());
-        for (Keyframe existing : list) {
+        int matchingIndex = lowerBound(list, kf.getTimeMs() - KEYFRAME_TIME_EPSILON_MS);
+        if (matchingIndex < list.size()) {
+            Keyframe existing = list.get(matchingIndex);
             if (Math.abs(existing.getTimeMs() - kf.getTimeMs()) <= KEYFRAME_TIME_EPSILON_MS) {
                 // Keep easing shape on existing keyframe; only replace value/time.
                 existing.setTimeMs(kf.getTimeMs());
                 existing.setValue(kf.getValue());
-                sortKeyframes(property);
                 return existing;
             }
         }
-        list.add(kf);
-        sortKeyframes(property);
+        list.add(lowerBound(list, kf.getTimeMs()), kf);
         return kf;
     }
 
@@ -75,16 +75,16 @@ public class EntityTrack {
         if (propertyKey == null || propertyKey.isBlank() || kf == null) return null;
         String normalized = propertyKey.trim();
         List<Keyframe> list = customKeyframes.computeIfAbsent(normalized, k -> new ArrayList<>());
-        for (Keyframe existing : list) {
+        int matchingIndex = lowerBound(list, kf.getTimeMs() - KEYFRAME_TIME_EPSILON_MS);
+        if (matchingIndex < list.size()) {
+            Keyframe existing = list.get(matchingIndex);
             if (Math.abs(existing.getTimeMs() - kf.getTimeMs()) <= KEYFRAME_TIME_EPSILON_MS) {
                 existing.setTimeMs(kf.getTimeMs());
                 existing.setValue(kf.getValue());
-                sortCustomKeyframes(normalized);
                 return existing;
             }
         }
-        list.add(kf);
-        sortCustomKeyframes(normalized);
+        list.add(lowerBound(list, kf.getTimeMs()), kf);
         return kf;
     }
 
@@ -143,11 +143,11 @@ public class EntityTrack {
 
     public Keyframe findKeyframeAt(PropertyType property, double timeMs) {
         List<Keyframe> list = keyframes.get(property);
-        if (list == null) return null;
-        for (Keyframe kf : list) {
-            if (Math.abs(kf.getTimeMs() - timeMs) <= KEYFRAME_TIME_EPSILON_MS) return kf;
-        }
-        return null;
+        if (list == null || list.isEmpty()) return null;
+        int index = lowerBound(list, timeMs - KEYFRAME_TIME_EPSILON_MS);
+        if (index >= list.size()) return null;
+        Keyframe keyframe = list.get(index);
+        return Math.abs(keyframe.getTimeMs() - timeMs) <= KEYFRAME_TIME_EPSILON_MS ? keyframe : null;
     }
 
     public boolean hasKeyframes(PropertyType property) {
@@ -216,21 +216,32 @@ public class EntityTrack {
 
     private static double interpolate(List<Keyframe> list, double timeMs, double defaultValue) {
         if (list == null || list.isEmpty()) return defaultValue;
+        if (Double.isNaN(timeMs)) return defaultValue;
         if (timeMs <= list.get(0).getTimeMs()) return list.get(0).getValue();
         if (timeMs >= list.get(list.size() - 1).getTimeMs()) return list.get(list.size() - 1).getValue();
 
-        for (int i = 0; i < list.size() - 1; i++) {
-            Keyframe k0 = list.get(i);
-            Keyframe k1 = list.get(i + 1);
-            if (timeMs >= k0.getTimeMs() && timeMs <= k1.getTimeMs()) {
-                double span = k1.getTimeMs() - k0.getTimeMs();
-                if (span < 0.001) return k1.getValue();
-                double t = (timeMs - k0.getTimeMs()) / span;
-                double easedT = com.jvn.core.animation.Easing.applyInterpolation(
-                    k1.getEasingSpec(), k1.getInterpolation(), t);
-                return k0.getValue() + (k1.getValue() - k0.getValue()) * easedT;
+        int nextIndex = lowerBound(list, timeMs);
+        Keyframe k0 = list.get(nextIndex - 1);
+        Keyframe k1 = list.get(nextIndex);
+        double span = k1.getTimeMs() - k0.getTimeMs();
+        if (span < 0.001) return k1.getValue();
+        double t = (timeMs - k0.getTimeMs()) / span;
+        double easedT = com.jvn.core.animation.Easing.applyInterpolation(
+            k1.getEasingSpec(), k1.getInterpolation(), t);
+        return k0.getValue() + (k1.getValue() - k0.getValue()) * easedT;
+    }
+
+    private static int lowerBound(List<Keyframe> list, double timeMs) {
+        int low = 0;
+        int high = list.size();
+        while (low < high) {
+            int mid = (low + high) >>> 1;
+            if (list.get(mid).getTimeMs() < timeMs) {
+                low = mid + 1;
+            } else {
+                high = mid;
             }
         }
-        return defaultValue;
+        return low;
     }
 }

--- a/modules/editor/src/main/java/com/jvn/editor/ui/actioneditor/EntityTrack.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/actioneditor/EntityTrack.java
@@ -2,16 +2,18 @@ package com.jvn.editor.ui.actioneditor;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.EnumMap;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 
 public class EntityTrack {
     private static final double KEYFRAME_TIME_EPSILON_MS = 0.001;
+    private static final PropertyType[] PROPERTY_TYPES = PropertyType.values();
 
     private final String entityName;
     private String parentGroupName;
-    private final Map<PropertyType, List<Keyframe>> keyframes;
+    private final List<Keyframe>[] keyframes;
+    private final EnumSet<PropertyType> animatedProperties;
     private final Map<String, List<Keyframe>> customKeyframes;
     private boolean expanded = true;
     private boolean visible = true;
@@ -20,7 +22,8 @@ public class EntityTrack {
 
     public EntityTrack(String entityName) {
         this.entityName = entityName;
-        this.keyframes = new EnumMap<>(PropertyType.class);
+        this.keyframes = newKeyframeTable();
+        this.animatedProperties = EnumSet.noneOf(PropertyType.class);
         this.customKeyframes = new java.util.LinkedHashMap<>();
     }
 
@@ -43,7 +46,8 @@ public class EntityTrack {
     public void setLayerOrder(int layerOrder) { this.layerOrder = layerOrder; }
 
     public List<Keyframe> getKeyframes(PropertyType property) {
-        return keyframes.getOrDefault(property, Collections.emptyList());
+        List<Keyframe> list = keyframesFor(property);
+        return list != null ? list : Collections.emptyList();
     }
 
     public void addKeyframe(PropertyType property, Keyframe kf) {
@@ -56,7 +60,13 @@ public class EntityTrack {
 
     public Keyframe upsertKeyframe(PropertyType property, Keyframe kf) {
         if (property == null || kf == null) return null;
-        List<Keyframe> list = keyframes.computeIfAbsent(property, k -> new ArrayList<>());
+        int propertyIndex = property.ordinal();
+        List<Keyframe> list = keyframes[propertyIndex];
+        if (list == null) {
+            list = new ArrayList<>();
+            keyframes[propertyIndex] = list;
+            animatedProperties.add(property);
+        }
         int matchingIndex = lowerBound(list, kf.getTimeMs() - KEYFRAME_TIME_EPSILON_MS);
         if (matchingIndex < list.size()) {
             Keyframe existing = list.get(matchingIndex);
@@ -89,10 +99,13 @@ public class EntityTrack {
     }
 
     public void removeKeyframe(PropertyType property, Keyframe kf) {
-        List<Keyframe> list = keyframes.get(property);
+        List<Keyframe> list = keyframesFor(property);
         if (list != null) {
             list.remove(kf);
-            if (list.isEmpty()) keyframes.remove(property);
+            if (list.isEmpty()) {
+                keyframes[property.ordinal()] = null;
+                animatedProperties.remove(property);
+            }
         }
     }
 
@@ -106,11 +119,15 @@ public class EntityTrack {
     }
 
     public void setKeyframes(PropertyType property, List<Keyframe> kfs) {
+        if (property == null) return;
         if (kfs == null || kfs.isEmpty()) {
-            keyframes.remove(property);
+            keyframes[property.ordinal()] = null;
+            animatedProperties.remove(property);
         } else {
-            keyframes.put(property, new ArrayList<>(kfs));
-            sortKeyframes(property);
+            List<Keyframe> copy = new ArrayList<>(kfs);
+            Collections.sort(copy);
+            keyframes[property.ordinal()] = copy;
+            animatedProperties.add(property);
         }
     }
 
@@ -131,7 +148,7 @@ public class EntityTrack {
     }
 
     public void sortKeyframes(PropertyType property) {
-        List<Keyframe> list = keyframes.get(property);
+        List<Keyframe> list = keyframesFor(property);
         if (list != null) Collections.sort(list);
     }
 
@@ -142,7 +159,7 @@ public class EntityTrack {
     }
 
     public Keyframe findKeyframeAt(PropertyType property, double timeMs) {
-        List<Keyframe> list = keyframes.get(property);
+        List<Keyframe> list = keyframesFor(property);
         if (list == null || list.isEmpty()) return null;
         int index = lowerBound(list, timeMs - KEYFRAME_TIME_EPSILON_MS);
         if (index >= list.size()) return null;
@@ -151,7 +168,7 @@ public class EntityTrack {
     }
 
     public boolean hasKeyframes(PropertyType property) {
-        List<Keyframe> list = keyframes.get(property);
+        List<Keyframe> list = keyframesFor(property);
         return list != null && !list.isEmpty();
     }
 
@@ -162,7 +179,7 @@ public class EntityTrack {
     }
 
     public Iterable<PropertyType> getAnimatedProperties() {
-        return keyframes.keySet();
+        return animatedProperties;
     }
 
     public Iterable<String> getAnimatedCustomProperties() {
@@ -170,7 +187,8 @@ public class EntityTrack {
     }
 
     public double getValueAt(PropertyType property, double timeMs) {
-        List<Keyframe> list = keyframes.get(property);
+        if (property == null) return 0.0;
+        List<Keyframe> list = keyframes[property.ordinal()];
         return interpolate(list, timeMs, property.getDefaultValue());
     }
 
@@ -181,7 +199,8 @@ public class EntityTrack {
 
     public double getMaxTimeMs() {
         double max = 0;
-        for (List<Keyframe> list : keyframes.values()) {
+        for (PropertyType property : animatedProperties) {
+            List<Keyframe> list = keyframes[property.ordinal()];
             for (Keyframe kf : list) {
                 if (kf.getTimeMs() > max) max = kf.getTimeMs();
             }
@@ -201,10 +220,11 @@ public class EntityTrack {
         copy.visible = visible;
         copy.locked = locked;
         copy.layerOrder = layerOrder;
-        for (Map.Entry<PropertyType, List<Keyframe>> entry : keyframes.entrySet()) {
+        for (PropertyType property : animatedProperties) {
             List<Keyframe> copyList = new ArrayList<>();
-            for (Keyframe kf : entry.getValue()) copyList.add(kf.copy());
-            copy.keyframes.put(entry.getKey(), copyList);
+            for (Keyframe kf : keyframes[property.ordinal()]) copyList.add(kf.copy());
+            copy.keyframes[property.ordinal()] = copyList;
+            copy.animatedProperties.add(property);
         }
         for (Map.Entry<String, List<Keyframe>> entry : customKeyframes.entrySet()) {
             List<Keyframe> copyList = new ArrayList<>();
@@ -212,6 +232,15 @@ public class EntityTrack {
             copy.customKeyframes.put(entry.getKey(), copyList);
         }
         return copy;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<Keyframe>[] newKeyframeTable() {
+        return (List<Keyframe>[]) new List<?>[PROPERTY_TYPES.length];
+    }
+
+    private List<Keyframe> keyframesFor(PropertyType property) {
+        return property != null ? keyframes[property.ordinal()] : null;
     }
 
     private static double interpolate(List<Keyframe> list, double timeMs, double defaultValue) {

--- a/modules/editor/src/test/java/com/jvn/editor/ui/actioneditor/EntityTrackInterpolationTest.java
+++ b/modules/editor/src/test/java/com/jvn/editor/ui/actioneditor/EntityTrackInterpolationTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.jvn.core.animation.Easing;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 class EntityTrackInterpolationTest {
@@ -41,5 +43,28 @@ class EntityTrackInterpolationTest {
 
         double mid = track.getValueAt(PropertyType.X, 50);
         assertTrue(mid > 50.0 && mid < 100.0);
+    }
+
+    @Test
+    void interpolatesLargeSortedTracks() {
+        EntityTrack track = new EntityTrack("hero");
+        List<Keyframe> keyframes = new ArrayList<>();
+        for (int i = 0; i < 4096; i++) {
+            keyframes.add(new Keyframe(i * 10.0, i));
+        }
+        track.setKeyframes(PropertyType.X, keyframes);
+
+        assertEquals(2345.6, track.getValueAt(PropertyType.X, 23456.0), 1e-6);
+        assertEquals(4095.0, track.getValueAt(PropertyType.X, 50000.0), 1e-6);
+    }
+
+    @Test
+    void nanSampleTimeFallsBackToPropertyDefault() {
+        EntityTrack track = new EntityTrack("hero");
+        track.addKeyframe(PropertyType.X, new Keyframe(0.0, 25.0));
+        track.addKeyframe(PropertyType.X, new Keyframe(100.0, 75.0));
+
+        assertEquals(PropertyType.X.getDefaultValue(),
+            track.getValueAt(PropertyType.X, Double.NaN), 1e-6);
     }
 }

--- a/modules/editor/src/test/java/com/jvn/editor/ui/actioneditor/EntityTrackKeyframeUpsertTest.java
+++ b/modules/editor/src/test/java/com/jvn/editor/ui/actioneditor/EntityTrackKeyframeUpsertTest.java
@@ -1,8 +1,11 @@
 package com.jvn.editor.ui.actioneditor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 
@@ -65,5 +68,26 @@ class EntityTrackKeyframeUpsertTest {
 
     assertEquals(3000.0, found.getValue(), 0.0000001);
     assertNull(track.findKeyframeAt(PropertyType.X, 30000.01));
+  }
+
+  @Test
+  void animatedPropertyIndexTracksSetRemoveAndCopy() {
+    EntityTrack track = new EntityTrack("hero");
+    Keyframe x = new Keyframe(100.0, 1.0);
+    track.addKeyframe(PropertyType.X, x);
+    track.setKeyframes(PropertyType.ALPHA, List.of(new Keyframe(200.0, 0.5)));
+
+    assertIterableEquals(List.of(PropertyType.X, PropertyType.ALPHA), track.getAnimatedProperties());
+
+    EntityTrack copy = track.copy();
+    track.removeKeyframe(PropertyType.X, x);
+    track.setKeyframes(PropertyType.ALPHA, List.of());
+
+    assertFalse(track.hasKeyframes(PropertyType.X));
+    assertFalse(track.hasKeyframes(PropertyType.ALPHA));
+    assertIterableEquals(List.of(), track.getAnimatedProperties());
+    assertTrue(copy.hasKeyframes(PropertyType.X));
+    assertTrue(copy.hasKeyframes(PropertyType.ALPHA));
+    assertIterableEquals(List.of(PropertyType.X, PropertyType.ALPHA), copy.getAnimatedProperties());
   }
 }

--- a/modules/editor/src/test/java/com/jvn/editor/ui/actioneditor/EntityTrackKeyframeUpsertTest.java
+++ b/modules/editor/src/test/java/com/jvn/editor/ui/actioneditor/EntityTrackKeyframeUpsertTest.java
@@ -1,6 +1,7 @@
 package com.jvn.editor.ui.actioneditor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.util.List;
@@ -51,5 +52,18 @@ class EntityTrackKeyframeUpsertTest {
     track.upsertKeyframe(PropertyType.X, new Keyframe(101.5, 2.0));
 
     assertEquals(2, track.getKeyframes(PropertyType.X).size());
+  }
+
+  @Test
+  void findsTimestampWithinToleranceOnLargeTrack() {
+    EntityTrack track = new EntityTrack("hero");
+    for (int i = 0; i < 4096; i++) {
+      track.upsertKeyframe(PropertyType.X, new Keyframe(i * 10.0, i));
+    }
+
+    Keyframe found = track.findKeyframeAt(PropertyType.X, 30000.0005);
+
+    assertEquals(3000.0, found.getValue(), 0.0000001);
+    assertNull(track.findKeyframeAt(PropertyType.X, 30000.01));
   }
 }

--- a/modules/fx/src/main/java/com/jvn/fx/scene2d/FxBlitter2D.java
+++ b/modules/fx/src/main/java/com/jvn/fx/scene2d/FxBlitter2D.java
@@ -2,7 +2,6 @@ package com.jvn.fx.scene2d;
 
 import java.net.URL;
 import java.util.ArrayDeque;
-import java.util.Arrays;
 import java.util.Deque;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -24,6 +23,7 @@ import javafx.geometry.VPos;
 import javafx.scene.SnapshotParameters;
 import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.effect.BlendMode;
+import javafx.scene.effect.ColorAdjust;
 import javafx.scene.effect.Effect;
 import javafx.scene.effect.GaussianBlur;
 import javafx.scene.image.Image;
@@ -66,24 +66,36 @@ public class FxBlitter2D implements Blitter2D {
       0.0, 0.0, 1.0, 0.0, 0.0,
       0.0, 0.0, 0.0, 1.0, 0.0
   };
+  private static final double COLOR_MATRIX_EPSILON = 1e-9;
 
   private static final class RenderState {
-    double[] colorMatrix = null;
+    final double[] colorMatrix = new double[IDENTITY_COLOR_MATRIX.length];
+    boolean colorMatrixSet = false;
     double blurRadius = 0.0;
 
-    RenderState copy() {
-      RenderState copy = new RenderState();
-      copy.colorMatrix = colorMatrix != null ? colorMatrix.clone() : null;
-      copy.blurRadius = blurRadius;
-      return copy;
+    void copyFrom(RenderState source) {
+      colorMatrixSet = source.colorMatrixSet;
+      if (colorMatrixSet) {
+        System.arraycopy(source.colorMatrix, 0, colorMatrix, 0, colorMatrix.length);
+      }
+      blurRadius = source.blurRadius;
+    }
+
+    void reset() {
+      colorMatrixSet = false;
+      blurRadius = 0.0;
     }
 
     boolean hasColorMatrix() {
-      if (colorMatrix == null || colorMatrix.length < IDENTITY_COLOR_MATRIX.length) return false;
+      if (!colorMatrixSet) return false;
       for (int i = 0; i < IDENTITY_COLOR_MATRIX.length; i++) {
-        if (Math.abs(colorMatrix[i] - IDENTITY_COLOR_MATRIX[i]) > 1e-9) return true;
+        if (Math.abs(colorMatrix[i] - IDENTITY_COLOR_MATRIX[i]) > COLOR_MATRIX_EPSILON) return true;
       }
       return false;
+    }
+
+    double gpuBrightness() {
+      return colorMatrixSet ? gpuBrightnessFor(colorMatrix) : Double.NaN;
     }
   }
 
@@ -99,6 +111,7 @@ public class FxBlitter2D implements Blitter2D {
   };
   private final Set<String> missing = new HashSet<>();
   private final Deque<RenderState> stateStack = new ArrayDeque<>();
+  private final Deque<RenderState> statePool = new ArrayDeque<>();
   private RenderState state = new RenderState();
   private FxRenderTarget2D ownerTarget;
   
@@ -160,14 +173,28 @@ public class FxBlitter2D implements Blitter2D {
   @Override
   public void push() {
     gc.save();
-    stateStack.push(state.copy());
+    RenderState next = statePool.pollFirst();
+    if (next == null) next = new RenderState();
+    next.copyFrom(state);
+    stateStack.push(state);
+    state = next;
   }
 
   @Override
   public void pop() {
     gc.restore();
-    state = stateStack.isEmpty() ? new RenderState() : stateStack.pop();
-    applyEffectState();
+    RenderState completed = state;
+    RenderState restored = stateStack.pollFirst();
+    if (restored == null) {
+      completed.reset();
+      state = completed;
+    } else {
+      state = restored;
+      completed.reset();
+      statePool.offerFirst(completed);
+    }
+    // GraphicsContext.restore() already restores the saved Effect. Re-applying it
+    // here would allocate another shader/effect chain at every nested entity pop.
   }
 
   @Override
@@ -442,17 +469,28 @@ public class FxBlitter2D implements Blitter2D {
       clearColorMatrix();
       return;
     }
-    state.colorMatrix = Arrays.copyOf(matrix, IDENTITY_COLOR_MATRIX.length);
+    double previousGpuBrightness = state.gpuBrightness();
+    if (state.colorMatrixSet && sameColorMatrix(state.colorMatrix, matrix)) return;
+    System.arraycopy(matrix, 0, state.colorMatrix, 0, state.colorMatrix.length);
+    state.colorMatrixSet = true;
+    if (Double.compare(previousGpuBrightness, state.gpuBrightness()) != 0) {
+      applyEffectState();
+    }
   }
 
   @Override
   public void clearColorMatrix() {
-    state.colorMatrix = null;
+    if (!state.colorMatrixSet) return;
+    double previousGpuBrightness = state.gpuBrightness();
+    state.colorMatrixSet = false;
+    if (!Double.isNaN(previousGpuBrightness)) applyEffectState();
   }
 
   @Override
   public void setBlurRadius(double radius) {
-    state.blurRadius = Math.max(0.0, radius);
+    double nextRadius = Math.max(0.0, radius);
+    if (Math.abs(state.blurRadius - nextRadius) <= COLOR_MATRIX_EPSILON) return;
+    state.blurRadius = nextRadius;
     applyEffectState();
   }
 
@@ -467,7 +505,9 @@ public class FxBlitter2D implements Blitter2D {
       throw new IllegalArgumentException("FxBlitter2D requires a JavaFX render target");
     }
     Image image = fxTarget.snapshot();
-    if (state.hasColorMatrix()) image = applyColorMatrix(image, state.colorMatrix);
+    if (state.hasColorMatrix() && !hasGpuColorMatrix()) {
+      image = applyColorMatrix(image, state.colorMatrix);
+    }
     markOwnerDirty();
     gc.drawImage(image, x, y, width, height);
   }
@@ -569,16 +609,56 @@ public class FxBlitter2D implements Blitter2D {
 
   private void applyEffectState() {
     Effect effect = null;
+    double gpuBrightness = state.gpuBrightness();
+    if (!Double.isNaN(gpuBrightness)) {
+      // For values from 0 through 1 JavaFX's ColorAdjust shader scales HSB value,
+      // which is exactly the uniform RGB multiplication represented by this matrix.
+      // Prism executes the effect on the selected graphics pipeline, avoiding a CPU
+      // pixel pass and a new texture upload for every animated Puppeteer frame.
+      ColorAdjust brightness = new ColorAdjust();
+      brightness.setBrightness(gpuBrightness - 1.0);
+      effect = brightness;
+    }
     if (state.blurRadius > 1e-9) {
-      effect = new GaussianBlur(Math.min(63.0, state.blurRadius));
+      GaussianBlur blur = new GaussianBlur(Math.min(63.0, state.blurRadius));
+      blur.setInput(effect);
+      effect = blur;
     }
     gc.setEffect(effect);
   }
 
   private Image resolveProcessedImage(String path, Image source) {
-    if (source == null || !state.hasColorMatrix()) return source;
+    if (source == null || !state.hasColorMatrix() || hasGpuColorMatrix()) return source;
     String cacheKey = buildProcessedKey(path, state.colorMatrix);
     return processedCache.computeIfAbsent(cacheKey, key -> applyColorMatrix(source, state.colorMatrix));
+  }
+
+  private boolean hasGpuColorMatrix() {
+    return !Double.isNaN(state.gpuBrightness());
+  }
+
+  static double gpuBrightnessFor(double[] matrix) {
+    if (matrix == null || matrix.length < IDENTITY_COLOR_MATRIX.length) return Double.NaN;
+    double brightness = matrix[0];
+    if (!Double.isFinite(brightness) || brightness < 0.0 || brightness >= 1.0) {
+      return Double.NaN;
+    }
+    for (int i = 0; i < IDENTITY_COLOR_MATRIX.length; i++) {
+      double expected = switch (i) {
+        case 0, 6, 12 -> brightness;
+        case 18 -> 1.0;
+        default -> 0.0;
+      };
+      if (Math.abs(matrix[i] - expected) > COLOR_MATRIX_EPSILON) return Double.NaN;
+    }
+    return brightness;
+  }
+
+  private static boolean sameColorMatrix(double[] left, double[] right) {
+    for (int i = 0; i < IDENTITY_COLOR_MATRIX.length; i++) {
+      if (Double.compare(left[i], right[i]) != 0) return false;
+    }
+    return true;
   }
 
   private String buildProcessedKey(String path, double[] matrix) {

--- a/modules/fx/src/test/java/com/jvn/fx/scene2d/FxBlitter2DGpuEffectTest.java
+++ b/modules/fx/src/test/java/com/jvn/fx/scene2d/FxBlitter2DGpuEffectTest.java
@@ -1,0 +1,45 @@
+package com.jvn.fx.scene2d;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class FxBlitter2DGpuEffectTest {
+
+  @Test
+  void recognizesExactDimmingMatrixForGpuShader() {
+    double[] matrix = brightnessMatrix(0.35);
+
+    assertEquals(0.35, FxBlitter2D.gpuBrightnessFor(matrix), 0.0000001);
+  }
+
+  @Test
+  void leavesExposureAndGeneralColorMatricesOnExactCpuFallback() {
+    assertTrue(Double.isNaN(FxBlitter2D.gpuBrightnessFor(brightnessMatrix(1.0))));
+    assertTrue(Double.isNaN(FxBlitter2D.gpuBrightnessFor(brightnessMatrix(1.2))));
+
+    double[] tinted = brightnessMatrix(0.8);
+    tinted[1] = 0.1;
+    assertTrue(Double.isNaN(FxBlitter2D.gpuBrightnessFor(tinted)));
+  }
+
+  @Test
+  void rejectsMissingAndNonFiniteMatrices() {
+    assertTrue(Double.isNaN(FxBlitter2D.gpuBrightnessFor(null)));
+    assertTrue(Double.isNaN(FxBlitter2D.gpuBrightnessFor(new double[4])));
+
+    double[] matrix = brightnessMatrix(0.5);
+    matrix[0] = Double.NaN;
+    assertTrue(Double.isNaN(FxBlitter2D.gpuBrightnessFor(matrix)));
+  }
+
+  private static double[] brightnessMatrix(double brightness) {
+    return new double[] {
+        brightness, 0.0, 0.0, 0.0, 0.0,
+        0.0, brightness, 0.0, 0.0, 0.0,
+        0.0, 0.0, brightness, 0.0, 0.0,
+        0.0, 0.0, 0.0, 1.0, 0.0
+    };
+  }
+}

--- a/modules/testkit/build.gradle.kts
+++ b/modules/testkit/build.gradle.kts
@@ -11,6 +11,7 @@ dependencies {
 
   jmh(project(":core"))
   jmh(project(":editor"))
+  jmh(project(":fx"))
   jmh("org.openjdk.jmh:jmh-core:1.37")
   jmhAnnotationProcessor("org.openjdk.jmh:jmh-generator-annprocess:1.37")
 }

--- a/modules/testkit/build.gradle.kts
+++ b/modules/testkit/build.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
   api("org.junit.jupiter:junit-jupiter-api")
 
   jmh(project(":core"))
+  jmh(project(":editor"))
   jmh("org.openjdk.jmh:jmh-core:1.37")
   jmhAnnotationProcessor("org.openjdk.jmh:jmh-generator-annprocess:1.37")
 }
@@ -18,7 +19,6 @@ jmh {
   warmupIterations.set(3)
   iterations.set(5)
   fork.set(1)
-  timeUnit.set("ms")
   resultFormat.set("JSON")
   resultsFile.set(project.file("build/reports/jmh/results.json"))
 }

--- a/modules/testkit/src/jmh/java/com/jvn/fx/scene2d/PuppeteerRenderEffectBench.java
+++ b/modules/testkit/src/jmh/java/com/jvn/fx/scene2d/PuppeteerRenderEffectBench.java
@@ -1,0 +1,56 @@
+package com.jvn.fx.scene2d;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/** Measures CPU submission work removed by the Puppeteer GPU brightness fast path. */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Fork(1)
+@Warmup(iterations = 3, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+public class PuppeteerRenderEffectBench {
+  @Param({"65536", "2073600"})
+  public int pixelCount;
+
+  private int[] source;
+  private int[] working;
+  private double[] brightnessMatrix;
+
+  @Setup
+  public void setup() {
+    source = new int[pixelCount];
+    working = new int[pixelCount];
+    Arrays.fill(source, 0xffd08040);
+    brightnessMatrix = new double[] {
+        0.65, 0.0, 0.0, 0.0, 0.0,
+        0.0, 0.65, 0.0, 0.0, 0.0,
+        0.0, 0.0, 0.65, 0.0, 0.0,
+        0.0, 0.0, 0.0, 1.0, 0.0
+    };
+  }
+
+  @Benchmark
+  public int cpuBrightnessFrame() {
+    System.arraycopy(source, 0, working, 0, source.length);
+    PixelEffects.applyColorMatrix(working, brightnessMatrix);
+    return working[working.length - 1];
+  }
+
+  @Benchmark
+  public double gpuBrightnessSubmission() {
+    return FxBlitter2D.gpuBrightnessFor(brightnessMatrix);
+  }
+}

--- a/modules/testkit/src/jmh/java/com/jvn/testkit/jmh/PuppeteerTrackBench.java
+++ b/modules/testkit/src/jmh/java/com/jvn/testkit/jmh/PuppeteerTrackBench.java
@@ -1,5 +1,6 @@
 package com.jvn.testkit.jmh;
 
+import com.jvn.editor.ui.actioneditor.AnimationProject;
 import com.jvn.editor.ui.actioneditor.EntityTrack;
 import com.jvn.editor.ui.actioneditor.Keyframe;
 import com.jvn.editor.ui.actioneditor.PropertyType;
@@ -47,6 +48,7 @@ public class PuppeteerTrackBench {
     public int keyframeCount;
 
     private EntityTrack track;
+    private AnimationProject project;
     private double[] sampleTimes;
     private int sampleCursor;
 
@@ -60,6 +62,8 @@ public class PuppeteerTrackBench {
             }
             track.setKeyframes(PREVIEW_PROPERTIES[propertyIndex], keyframes);
         }
+        project = new AnimationProject();
+        project.addTrack(track);
 
         sampleTimes = new double[1024];
         long state = 0x9e3779b97f4a7c15L;
@@ -81,5 +85,11 @@ public class PuppeteerTrackBench {
         for (PropertyType property : PREVIEW_PROPERTIES) {
             blackhole.consume(track.getValueAt(property, time));
         }
+    }
+
+    @Benchmark
+    public AnimationProject.EffectiveEntityTransform sampleEffectiveEntityTransform() {
+        double time = sampleTimes[sampleCursor++ & (sampleTimes.length - 1)];
+        return project.computeEffectiveEntityTransform("bench-sprite", time);
     }
 }

--- a/modules/testkit/src/jmh/java/com/jvn/testkit/jmh/PuppeteerTrackBench.java
+++ b/modules/testkit/src/jmh/java/com/jvn/testkit/jmh/PuppeteerTrackBench.java
@@ -1,0 +1,70 @@
+package com.jvn.testkit.jmh;
+
+import com.jvn.editor.ui.actioneditor.EntityTrack;
+import com.jvn.editor.ui.actioneditor.Keyframe;
+import com.jvn.editor.ui.actioneditor.PropertyType;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/** Measures the keyframe lookup performed for each animated Puppeteer property per preview frame. */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(1)
+@Warmup(iterations = 3, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+public class PuppeteerTrackBench {
+    @Param({"16", "256", "4096"})
+    public int keyframeCount;
+
+    private EntityTrack track;
+    private double[] sampleTimes;
+    private int sampleCursor;
+
+    @Setup
+    public void setup() {
+        track = new EntityTrack("bench-sprite");
+        List<Keyframe> keyframes = new ArrayList<>(keyframeCount);
+        for (int i = 0; i < keyframeCount; i++) {
+            keyframes.add(new Keyframe(i * 10.0, i));
+        }
+        track.setKeyframes(PropertyType.X, keyframes);
+
+        sampleTimes = new double[1024];
+        long state = 0x9e3779b97f4a7c15L;
+        for (int i = 0; i < sampleTimes.length; i++) {
+            state = state * 6364136223846793005L + 1442695040888963407L;
+            sampleTimes[i] = Math.floorMod(state >>> 16, keyframeCount * 1000L) / 100.0;
+        }
+    }
+
+    @Benchmark
+    public double sampleProperty() {
+        double time = sampleTimes[sampleCursor++ & (sampleTimes.length - 1)];
+        return track.getValueAt(PropertyType.X, time);
+    }
+
+    @Benchmark
+    public void samplePreviewFrame(Blackhole blackhole) {
+        int cursor = sampleCursor;
+        for (int property = 0; property < 12; property++) {
+            double time = sampleTimes[cursor++ & (sampleTimes.length - 1)];
+            blackhole.consume(track.getValueAt(PropertyType.X, time));
+        }
+        sampleCursor = cursor;
+    }
+}

--- a/modules/testkit/src/jmh/java/com/jvn/testkit/jmh/PuppeteerTrackBench.java
+++ b/modules/testkit/src/jmh/java/com/jvn/testkit/jmh/PuppeteerTrackBench.java
@@ -28,6 +28,21 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
 public class PuppeteerTrackBench {
+    private static final PropertyType[] PREVIEW_PROPERTIES = {
+        PropertyType.X,
+        PropertyType.Y,
+        PropertyType.Z,
+        PropertyType.PIVOT_X,
+        PropertyType.PIVOT_Y,
+        PropertyType.ROTATION,
+        PropertyType.SCALE_X,
+        PropertyType.SCALE_Y,
+        PropertyType.MIRROR_X,
+        PropertyType.ALPHA,
+        PropertyType.VISIBILITY,
+        PropertyType.BLUR
+    };
+
     @Param({"16", "256", "4096"})
     public int keyframeCount;
 
@@ -38,11 +53,13 @@ public class PuppeteerTrackBench {
     @Setup
     public void setup() {
         track = new EntityTrack("bench-sprite");
-        List<Keyframe> keyframes = new ArrayList<>(keyframeCount);
-        for (int i = 0; i < keyframeCount; i++) {
-            keyframes.add(new Keyframe(i * 10.0, i));
+        for (int propertyIndex = 0; propertyIndex < PREVIEW_PROPERTIES.length; propertyIndex++) {
+            List<Keyframe> keyframes = new ArrayList<>(keyframeCount);
+            for (int i = 0; i < keyframeCount; i++) {
+                keyframes.add(new Keyframe(i * 10.0, propertyIndex * 1000.0 + i));
+            }
+            track.setKeyframes(PREVIEW_PROPERTIES[propertyIndex], keyframes);
         }
-        track.setKeyframes(PropertyType.X, keyframes);
 
         sampleTimes = new double[1024];
         long state = 0x9e3779b97f4a7c15L;
@@ -60,11 +77,9 @@ public class PuppeteerTrackBench {
 
     @Benchmark
     public void samplePreviewFrame(Blackhole blackhole) {
-        int cursor = sampleCursor;
-        for (int property = 0; property < 12; property++) {
-            double time = sampleTimes[cursor++ & (sampleTimes.length - 1)];
-            blackhole.consume(track.getValueAt(PropertyType.X, time));
+        double time = sampleTimes[sampleCursor++ & (sampleTimes.length - 1)];
+        for (PropertyType property : PREVIEW_PROPERTIES) {
+            blackhole.consume(track.getValueAt(property, time));
         }
-        sampleCursor = cursor;
     }
 }


### PR DESCRIPTION
## Summary

- replace linear Puppeteer keyframe lookup and interpolation scans with binary-search lower bounds
- store built-in property lanes in an ordinal-indexed table with an `EnumSet` of active lanes, avoiding repeated enum-map lookup in preview sampling
- preserve sorted order by inserting new keyframes at their resolved position instead of sorting the full list after every insert
- avoid allocating group/constraint traversal sets for the common flat, unconstrained preview entity
- route exact dimming matrices (brightness 0 through 1) through JavaFX `ColorAdjust`, allowing Prism to execute the effect on the active GPU pipeline
- retain the exact CPU color-matrix fallback for exposure above 1 and arbitrary 4×5 matrices
- pool nested `FxBlitter2D` render states and rely on `GraphicsContext.restore()` for effect restoration, removing per-entity state/effect churn
- add regression tests and dedicated JMH coverage for track sampling, effective transforms, and render-effect submission

## Performance

JMH on JDK 21, with the track benchmark corrected to sample 12 distinct property lanes at one playhead time:

| Operation | 16 keyframes | 256 keyframes | 4,096 keyframes |
|---|---:|---:|---:|
| One property sample | 29.8 ns | 58.9 ns | 99.0 ns |
| 12-property preview frame | 285.4 ns | 954.2 ns | 1,443.4 ns |

The flat-entity effective-transform benchmark improved from 473.0 to 355.5 ns at 16 keyframes (about 25%) and from 993.6 to 948.3 ns at 256 keyframes (about 5%). The 4,096-keyframe result remained within run-to-run noise.

The render-effect benchmark quantifies CPU work removed before Prism submission:

| Brightness path | 256×256 sprite | 1920×1080 image |
|---|---:|---:|
| Previous CPU pixel transform | 2.81 ms | 89.79 ms |
| GPU-effect submission check | 0.021 µs | 0.024 µs |

The GPU numbers measure CPU submission overhead, not shader execution time. The important result is that animated dimming no longer performs a CPU pixel pass or creates a newly processed texture for every brightness value.

## Validation

- `./gradlew :core:test :fx:test :editor:compileTestJava :testkit:jmhClasses --no-daemon`
- focused `EntityTrackInterpolationTest`, `EntityTrackKeyframeUpsertTest`, `AnimationProjectGroupHierarchyTest`, `AnimationProjectAnchorTest`, `FxBlitter2DGpuEffectTest`, and `PixelEffectsTest`
- isolated JMH runs for `PuppeteerTrackBench` and `PuppeteerRenderEffectBench`
- `git diff --check`

## Broader suite note

A previous full `:editor:test` attempt reached two unrelated `GameBuildPublisherViewFxTest` timeouts, then the macOS JavaFX Glass runtime crashed natively during teardown. The affected Puppeteer tests were rerun independently afterward and passed cleanly.