### PR TITLE
Improve GPU launches and VNS preview performance

### DIFF
--- a/docs/architecture/quality/performance.md
+++ b/docs/architecture/quality/performance.md
@@ -26,6 +26,42 @@ Lock-heavy environments (especially Linux) should:
 
 ## Runtime Performance
 
+### Verify and profile the desktop GPU path
+
+The Engine Hub's **Render Pipeline → GPU Preferred** profile selects JavaFX's native
+hardware backend while retaining a software fallback. On Linux hybrid-GPU systems,
+Hub-managed launches also ask `switcheroo-control` for the discrete adapter. Existing
+`DRI_PRIME` or NVIDIA PRIME variables are preserved so Steam, gamescope, and desktop
+GPU preferences remain authoritative.
+
+Use **Render Pipeline → Inspect Render Stack** before a test. On Linux the report runs
+the same adapter probe used by the managed launcher. Every hardware launch also writes
+the resolved OpenGL vendor and renderer to the Hub log when `glxinfo` is available.
+For a platform-independent recording, choose **Render Diagnostics → Launch Editor with
+Java Flight Recorder**. The launch enables JavaFX's startup diagnostics (including the
+actual Prism pipeline and renderer) and writes a `.jfr` recording under the platform's
+JVN Engine Hub state directory:
+
+- Linux: `$XDG_STATE_HOME/jvn-engine-hub/profiles` or `~/.local/state/jvn-engine-hub/profiles`
+- macOS: `~/Library/Application Support/JVN Engine Hub/profiles`
+- Windows: `%LOCALAPPDATA%\JVN Engine Hub\profiles`
+
+Open the recording in JDK Mission Control. JFR measures Java frame submission, CPU,
+allocation, locks, and GC; use a vendor GPU tool alongside it when shader or GPU-core
+timings are required. The runtime's F3 HUD provides FPS, heap, cache-hit, and timeline
+signals during an interactive test.
+
+The `:testkit:jmh` suite is useful for deterministic CPU-side microbenchmarks, but it
+does not prove which GPU rendered a JavaFX window. In particular, do not use the
+placeholder `RenderFrameBench` as an adapter-usage test.
+
+Editor VNS preview windows use bounded frame pacing: 60 FPS on a hardware-capable
+pipeline and 30 FPS when JavaFX reports the software path. This keeps CPU rendering
+responsive instead of letting preview work monopolize every JavaFX pulse. For a
+controlled comparison, override the cap with
+`-Djvn.editor.previewMaxFps=15..240`. UI layout/style overrides are applied when they
+change rather than reparsed and reloaded on every preview frame.
+
 ### VNS rendering and flow
 
 - Keep dialogue effects focused; animated per-character spans cost more than plain text.

--- a/modules/core/src/main/java/com/jvn/core/vn/VnNode.java
+++ b/modules/core/src/main/java/com/jvn/core/vn/VnNode.java
@@ -85,6 +85,32 @@ public class VnNode {
   public String getGroupParentId() { return groupParentId; }
   public int getSourceLine() { return sourceLine; }
 
+  VnNode withSourceLine(int line) {
+    return builder(type)
+        .dialogue(dialogue)
+        .choices(choices)
+        .backgroundId(backgroundId)
+        .jumpLabel(jumpLabel)
+        .audioCommand(audioCommand)
+        .transition(transition)
+        .waitMs(waitMs)
+        .characterToShow(characterToShow)
+        .characterToHide(characterToHide)
+        .showPosition(showPosition)
+        .showExpression(showExpression)
+        .showLayerOrder(showLayerOrder)
+        .displaySlot(displaySlot)
+        .moveEasingType(moveEasingType)
+        .moveDurationMs(moveDurationMs)
+        .expressionDurationMs(expressionDurationMs)
+        .external(externalCommand)
+        .particleCommand(particleCommand)
+        .groupTargetId(groupTargetId)
+        .groupParentId(groupParentId)
+        .sourceLine(line)
+        .build();
+  }
+
   public static Builder builder(VnNodeType type) { return new Builder(type); }
 
   public static class Builder {

--- a/modules/core/src/main/java/com/jvn/core/vn/VnScenario.java
+++ b/modules/core/src/main/java/com/jvn/core/vn/VnScenario.java
@@ -63,11 +63,20 @@ public class VnScenario {
     private final Map<String, VnBackground> backgrounds = new HashMap<>();
     private final Map<String, VnStagePreset> stagePresets = new HashMap<>();
     private final Map<String, VnGroup> groups = new HashMap<>();
+    private int sourceLine;
 
     private Builder(String id) { this.id = id; }
 
     public Builder addNode(VnNode node) {
+      if (node != null && node.getSourceLine() <= 0 && sourceLine > 0) {
+        node = node.withSourceLine(sourceLine);
+      }
       nodes.add(node);
+      return this;
+    }
+
+    public Builder sourceLine(int line) {
+      sourceLine = Math.max(0, line);
       return this;
     }
 

--- a/modules/core/src/main/java/com/jvn/core/vn/VnScenarioBuilder.java
+++ b/modules/core/src/main/java/com/jvn/core/vn/VnScenarioBuilder.java
@@ -17,6 +17,12 @@ public class VnScenarioBuilder {
     this.scenarioBuilder = VnScenario.builder(scenarioId);
   }
 
+  /** Sets the source line stamped onto subsequently emitted nodes. */
+  public VnScenarioBuilder sourceLine(int line) {
+    scenarioBuilder.sourceLine(line);
+    return this;
+  }
+
   public VnScenarioBuilder addCharacter(String id, String displayName) {
     VnCharacter character = VnCharacter.builder(id)
       .displayName(displayName)

--- a/modules/core/src/main/java/com/jvn/core/vn/script/VnScriptParser.java
+++ b/modules/core/src/main/java/com/jvn/core/vn/script/VnScriptParser.java
@@ -195,6 +195,7 @@ public class VnScriptParser {
     String activeDisplayPresetId;
     String pendingVoiceTrackId;
     List<VnParseException> errors = new ArrayList<>();
+    int currentSourceLine;
 
     boolean insideMenu = false;
     List<BufferedLine> menuBuffer = new ArrayList<>();
@@ -485,6 +486,8 @@ public class VnScriptParser {
 
     while ((line = reader.readLine()) != null) {
       lineNumber++;
+      state.currentSourceLine = lineNumber;
+      if (state.builder != null) state.builder.sourceLine(lineNumber);
       String rawLine = line;
       String trimmed = rawLine.trim();
 
@@ -3401,7 +3404,8 @@ public class VnScriptParser {
 
   private void ensureBuilder(ParseState state) {
     if (state.builder == null) {
-      state.builder = new VnScenarioBuilder(state.scenarioId);
+      state.builder = new VnScenarioBuilder(state.scenarioId)
+          .sourceLine(state.currentSourceLine);
     }
   }
 

--- a/modules/core/src/test/java/com/jvn/core/vn/VnScriptParserTest.java
+++ b/modules/core/src/test/java/com/jvn/core/vn/VnScriptParserTest.java
@@ -49,6 +49,34 @@ public class VnScriptParserTest {
   }
 
   @Test
+  public void parsedNodesRetainTheirExactSourceLines() throws Exception {
+    VnScenario scenario = new VnScriptParser().parseFromString("""
+        @scenario cursor_lines
+        @character narrator ""
+        @label start
+
+        [bg bg_mags]
+
+        [show panel_01 center neutral]
+        [show panel_mags center neutral]
+        narrator:1714
+        [show panel_01 center neutral]
+        [show panel_mags center neutral]
+        narrator:1716
+        [end]
+        """);
+
+    List<VnNode> nodes = scenario.getNodes();
+    assertEquals(5, nodes.get(0).getSourceLine());
+    assertEquals(9, nodes.stream()
+        .filter(node -> node.getType() == VnNodeType.DIALOGUE)
+        .findFirst().orElseThrow().getSourceLine());
+    assertEquals(12, nodes.stream()
+        .filter(node -> node.getType() == VnNodeType.DIALOGUE)
+        .skip(1).findFirst().orElseThrow().getSourceLine());
+  }
+
+  @Test
   public void parsesCharacterSpeakerColorAndCarriesItToDialogue() throws Exception {
     String script = """
       @scenario color_demo

--- a/modules/editor/build.gradle.kts
+++ b/modules/editor/build.gradle.kts
@@ -1,4 +1,6 @@
 import java.io.File
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 import java.util.Properties
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.model.ObjectFactory
@@ -118,10 +120,11 @@ fun JavaExec.configureGraphicsPipelineAtProcessStart() {
   when (requestedGraphicsModeForLaunch().lowercase()) {
     "gpu", "hardware", "accelerated", "prefer-gpu" -> {
       systemProperty("jvn.graphics.mode", "hardware")
-      val prismOrder = if (System.getProperty("os.name", "").lowercase().contains("win")) {
-        "d3d,es2,sw"
-      } else {
-        "es2,sw"
+      val os = System.getProperty("os.name", "").lowercase()
+      val prismOrder = when {
+        os.contains("win") -> "d3d,es2,sw"
+        os.contains("mac") -> "metal,es2,sw"
+        else -> "es2,sw"
       }
       systemProperty("prism.order", prismOrder)
       systemProperty("prism.forceGPU", "true")
@@ -132,6 +135,25 @@ fun JavaExec.configureGraphicsPipelineAtProcessStart() {
     }
     else -> systemProperty("jvn.graphics.mode", "auto")
   }
+}
+
+fun JavaExec.configureFlightRecordingForLaunch() {
+  val requested = System.getenv("JVN_PROFILE_JFR")?.trim()?.lowercase()
+  if (requested !in setOf("1", "true", "yes", "on")) return
+  val os = System.getProperty("os.name", "").lowercase()
+  val userHome = File(System.getProperty("user.home", "."))
+  val profileDir = when {
+    os.contains("win") -> File(System.getenv("LOCALAPPDATA") ?: userHome.path, "JVN Engine Hub/profiles")
+    os.contains("mac") -> File(userHome, "Library/Application Support/JVN Engine Hub/profiles")
+    else -> File(System.getenv("XDG_STATE_HOME") ?: File(userHome, ".local/state").path,
+      "jvn-engine-hub/profiles")
+  }
+  profileDir.mkdirs()
+  val timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss"))
+  val recording = File(profileDir, "editor-$timestamp.jfr")
+  jvmArgs("-XX:StartFlightRecording=filename=${recording.absolutePath},settings=profile,dumponexit=true")
+  systemProperty("prism.verbose", "true")
+  logger.lifecycle("JVN Java Flight Recorder: ${recording.absolutePath}")
 }
 
 fun JavaExec.forwardHubLaunchSystemProps() {
@@ -156,6 +178,7 @@ fun JavaExec.forwardHubLaunchSystemProps() {
 // This avoids the "JavaFX runtime components are missing" error.
 tasks.named<JavaExec>("run") {
   configureJavaFxRuntime()
+  configureFlightRecordingForLaunch()
   systemProperty("jvn.version", rootProject.version.toString())
   forwardHubLaunchSystemProps()
 }
@@ -167,6 +190,7 @@ tasks.register<JavaExec>("runLauncher") {
   mainClass.set("com.jvn.editor.JvnLauncherApp")
   workingDir = rootProject.projectDir
   systemProperty("jvn.version", rootProject.version.toString())
+  configureFlightRecordingForLaunch()
   forwardHubLaunchSystemProps()
   configureJavaFxRuntime()
 }

--- a/modules/editor/src/main/java/com/jvn/editor/EditorApp.java
+++ b/modules/editor/src/main/java/com/jvn/editor/EditorApp.java
@@ -5278,14 +5278,14 @@ public class EditorApp extends Application {
     
     // Animation timer for rendering
     javafx.animation.AnimationTimer timer = new javafx.animation.AnimationTimer() {
-      long last = -1;
+      final com.jvn.editor.ui.PreviewFramePacer pacer =
+          com.jvn.editor.ui.PreviewFramePacer.forCurrentPipeline();
       @Override
       public void handle(long now) {
-        if (last < 0) { last = now; return; }
-        long dt = (now - last) / 1_000_000L;
-        last = now;
+        com.jvn.editor.ui.PreviewFramePacer.Frame frame = pacer.next(now);
+        if (!frame.render()) return;
         fullscreenPreview.setSize(scene.getWidth(), scene.getHeight());
-        fullscreenPreview.render(dt);
+        fullscreenPreview.render(frame.deltaMs());
       }
     };
     

--- a/modules/editor/src/main/java/com/jvn/editor/EditorApp.java
+++ b/modules/editor/src/main/java/com/jvn/editor/EditorApp.java
@@ -1853,13 +1853,13 @@ public class EditorApp extends Application {
 	    miVnsOpen.setOnAction(e -> doOpenVns(primaryStage));
 	    MenuItem miVnsApplyPreview = new MenuItem("Apply to Preview");
 	    miVnsApplyPreview.setOnAction(e -> applyCodeFromEditor());
-	    MenuItem miVnsLaunchHere = new MenuItem("Launch from Here");
+	    MenuItem miVnsLaunchHere = new MenuItem("Run from Cursor");
 	    miVnsLaunchHere.setOnAction(e -> {
 	      FileEditorTab ft = getActiveFileTab();
 	      if (ft != null && ft.getKind() == FileEditorTab.Kind.VNS) {
-	        ft.launchFromHere();
+	        ft.launchFromCursor();
 	      } else {
-	        status.setText("Launch from Here is only available for VNS files");
+	        status.setText("Run from Cursor is only available for VNS files");
 	      }
 	    });
 	    MenuItem miVnsLaunchStart = new MenuItem("Launch from Start");
@@ -1871,14 +1871,14 @@ public class EditorApp extends Application {
 	        status.setText("Launch from Start is only available for VNS files");
 	      }
 	    });
-	    MenuItem miVnsApplyAndLaunchHere = new MenuItem("Apply Preview and Launch Here");
+	    MenuItem miVnsApplyAndLaunchHere = new MenuItem("Apply Preview and Run from Cursor");
 	    miVnsApplyAndLaunchHere.setOnAction(e -> {
 	      applyCodeFromEditor();
 	      FileEditorTab ft = getActiveFileTab();
 	      if (ft != null && ft.getKind() == FileEditorTab.Kind.VNS) {
-	        ft.launchFromHere();
+	        ft.launchFromCursor();
 	      } else {
-	        status.setText("Apply + Launch Here is only available for VNS files");
+	        status.setText("Apply + Run from Cursor is only available for VNS files");
 	      }
 	    });
 	    MenuItem miVnsApplyAndLaunchStart = new MenuItem("Apply Preview and Launch From Start");
@@ -1964,14 +1964,14 @@ public class EditorApp extends Application {
     miRunProject.setOnAction(e -> doRunProject(primaryStage));
     MenuItem miBuildPublishProject = new MenuItem("Build & Publish...");
     miBuildPublishProject.setOnAction(e -> showGameBuildPublisherWindow(primaryStage));
-    MenuItem miLaunchHere = new MenuItem("Launch VNS from Here");
+    MenuItem miLaunchHere = new MenuItem("Run VNS from Cursor");
     miLaunchHere.setAccelerator(new KeyCodeCombination(KeyCode.F5));
     miLaunchHere.setOnAction(e -> {
       FileEditorTab ft = getActiveFileTab();
       if (ft != null && ft.getKind() == FileEditorTab.Kind.VNS) {
-        ft.launchFromHere();
+        ft.launchFromCursor();
       } else {
-        status.setText("Launch from Here is only available for VNS files");
+        status.setText("Run from Cursor is only available for VNS files");
       }
     });
     MenuItem miLaunchStart = new MenuItem("Launch VNS from Start");
@@ -1984,14 +1984,14 @@ public class EditorApp extends Application {
         status.setText("Launch from Start is only available for VNS files");
       }
     });
-    MenuItem miApplyAndLaunchHere = new MenuItem("Apply Preview and Launch Here");
+    MenuItem miApplyAndLaunchHere = new MenuItem("Apply Preview and Run from Cursor");
     miApplyAndLaunchHere.setOnAction(e -> {
       applyCodeFromEditor();
       FileEditorTab ft = getActiveFileTab();
       if (ft != null && ft.getKind() == FileEditorTab.Kind.VNS) {
-        ft.launchFromHere();
+        ft.launchFromCursor();
       } else {
-        status.setText("Apply + Launch Here is only available for VNS files");
+        status.setText("Apply + Run from Cursor is only available for VNS files");
       }
     });
     MenuItem miApplyAndLaunchStart = new MenuItem("Apply Preview and Launch From Start");

--- a/modules/editor/src/main/java/com/jvn/editor/ui/AeroIcon.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/AeroIcon.java
@@ -38,7 +38,7 @@ public final class AeroIcon extends StackPane {
     PUPPETEER, SCRIPT_EDITOR, SETTINGS,
     NEW_PROJECT, OPEN_PROJECT, RUN, BUILD, REFRESH, ENTRY_SCRIPT, MANIFEST,
     README, DOCUMENTATION, REVEAL, ARROW_BACK, HELP, WHATS_NEW, NO_PROJECT,
-    VNS_RUN_LABEL, VNS_RUN_ENTRY, VNS_SYMBOLS, VNS_SNIPPET, VNS_FIND,
+    VNS_RUN_LABEL, VNS_RUN_CURSOR, VNS_RUN_ENTRY, VNS_SYMBOLS, VNS_SNIPPET, VNS_FIND,
     VNS_COMMANDS, VNS_WORD_WRAP, VNS_DIFF, VNS_DIAGNOSTICS, VNS_PREVIEW
   }
 
@@ -137,7 +137,7 @@ public final class AeroIcon extends StackPane {
       case BUILD -> sized(CssIcon.download(color), size);
       case REFRESH -> sized(CssIcon.refresh(color), size);
       case ENTRY_SCRIPT -> sized(CssIcon.speech(color), size);
-      case VNS_RUN_LABEL, VNS_RUN_ENTRY, VNS_SYMBOLS, VNS_SNIPPET, VNS_FIND,
+      case VNS_RUN_LABEL, VNS_RUN_CURSOR, VNS_RUN_ENTRY, VNS_SYMBOLS, VNS_SNIPPET, VNS_FIND,
           VNS_COMMANDS, VNS_WORD_WRAP, VNS_DIFF, VNS_DIAGNOSTICS, VNS_PREVIEW ->
           vnsCommandGlyph(kind, size, palette);
       case MANIFEST, README -> sized(CssIcon.document(color), size);
@@ -160,6 +160,7 @@ public final class AeroIcon extends StackPane {
 
   private static boolean isVnsCommand(Kind kind) {
     return kind == Kind.VNS_RUN_LABEL
+        || kind == Kind.VNS_RUN_CURSOR
         || kind == Kind.VNS_RUN_ENTRY
         || kind == Kind.VNS_SYMBOLS
         || kind == Kind.VNS_SNIPPET
@@ -174,6 +175,7 @@ public final class AeroIcon extends StackPane {
   private static Region vnsCommandGlyph(Kind kind, double size, Palette palette) {
     return switch (kind) {
       case VNS_RUN_LABEL -> vnsRunLabelGlyph(size, palette);
+      case VNS_RUN_CURSOR -> vnsRunCursorGlyph(size, palette);
       case VNS_RUN_ENTRY -> vnsRunEntryGlyph(size, palette);
       case VNS_SYMBOLS -> vnsSymbolsGlyph(size, palette);
       case VNS_SNIPPET -> vnsSnippetGlyph(size, palette);
@@ -217,6 +219,27 @@ public final class AeroIcon extends StackPane {
     Polygon play = playTriangle(size * 0.16, Color.WHITE);
     playOrb.getChildren().add(play);
     art.getChildren().addAll(page, fold, ruleTop, ruleBottom, label, pin, playOrb);
+    return art;
+  }
+
+  private static Region vnsRunCursorGlyph(double size, Palette palette) {
+    Pane art = vnsCanvas(size);
+    Rectangle page = vnsDocument(size, palette, 0.05, 0.08, 0.66, 0.82);
+    Polygon fold = vnsPageFold(size, palette, 0.49, 0.08, 0.22);
+    for (int i = 0; i < 3; i++) {
+      art.getChildren().add(styledLine(
+          size * 0.16, size * (0.30 + i * 0.17),
+          size * 0.54, size * (0.30 + i * 0.17),
+          Color.rgb(224, 247, 255, 0.66), Math.max(0.65, size * 0.032)));
+    }
+    Line caret = styledLine(
+        size * 0.39, size * 0.36, size * 0.39, size * 0.69,
+        Color.web("#fff3a6"), Math.max(1.35, size * 0.07));
+    caret.setEffect(new DropShadow(Math.max(1, size * 0.06), Color.web("#b46a25")));
+    StackPane playOrb = vnsOrb(size, "#f2fbff", "#35a9dd", "#155a82");
+    playOrb.resizeRelocate(size * 0.58, size * 0.53, size * 0.39, size * 0.39);
+    playOrb.getChildren().add(playTriangle(size * 0.16, Color.WHITE));
+    art.getChildren().addAll(page, fold, caret, playOrb);
     return art;
   }
 
@@ -706,6 +729,8 @@ public final class AeroIcon extends StackPane {
       case ENTRY_SCRIPT -> new Badge(sized(CssIcon.play("#ffffff"), glyphSize), Color.web("#2fa35a"));
       case VNS_RUN_LABEL ->
           new Badge(sized(CssIcon.play("#ffffff"), glyphSize), Color.web("#2fa35a"));
+      case VNS_RUN_CURSOR ->
+          new Badge(sized(CssIcon.play("#ffffff"), glyphSize), Color.web("#2689d8"));
       case VNS_RUN_ENTRY ->
           new Badge(sized(CssIcon.rocket("#ffffff"), glyphSize), Color.web("#cf6927"));
       case VNS_SYMBOLS ->
@@ -921,6 +946,8 @@ public final class AeroIcon extends StackPane {
           palette("#8de8aa", "#26824e", "#d8ffe4");
       case VNS_RUN_LABEL ->
           palette("#75e8d6", "#1d8074", "#d4fff8");
+      case VNS_RUN_CURSOR ->
+          palette("#8bdfff", "#26689f", "#dff7ff");
       case VNS_RUN_ENTRY ->
           palette("#8de8aa", "#26824e", "#d8ffe4");
       case VNS_SYMBOLS ->

--- a/modules/editor/src/main/java/com/jvn/editor/ui/FileEditorTab.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/FileEditorTab.java
@@ -284,6 +284,10 @@ public class FileEditorTab extends BorderPane {
     }
   }
 
+  int getVnsPreviewSourceLine() {
+    return vnPreview == null ? -1 : vnPreview.getCurrentSourceLine();
+  }
+
   public void runFromLabel(String label) {
     try {
       if (kind != Kind.VNS || vnsEditor == null || vnPreview == null) return;

--- a/modules/editor/src/main/java/com/jvn/editor/ui/FileEditorTab.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/FileEditorTab.java
@@ -116,7 +116,7 @@ public class FileEditorTab extends BorderPane {
   private PreviewDockPosition lastEmbeddedPreviewDock = PreviewDockPosition.TOP;
   private Stage detachedPreviewStage;
   private AnimationTimer detachedPreviewTimer;
-  private long detachedPreviewLastNs = -1L;
+  private PreviewFramePacer detachedPreviewPacer;
   private double verticalDockDivider = 0.6;
   private double horizontalDockDivider = 0.5;
   private PreviewLayoutMode previewModeBeforeDetach = PreviewLayoutMode.SPLIT;
@@ -1372,22 +1372,18 @@ public class FileEditorTab extends BorderPane {
 
   private void startDetachedPreviewTimer() {
     if (detachedPreviewTimer != null) return;
-    detachedPreviewLastNs = -1L;
+    detachedPreviewPacer = PreviewFramePacer.forCurrentPipeline();
     detachedPreviewTimer = new AnimationTimer() {
       @Override
       public void handle(long now) {
         if (!isDetachedPreviewVisible()) return;
-        if (detachedPreviewLastNs < 0L) {
-          detachedPreviewLastNs = now;
-          return;
-        }
-        long dt = (now - detachedPreviewLastNs) / 1_000_000L;
-        detachedPreviewLastNs = now;
+        PreviewFramePacer.Frame frame = detachedPreviewPacer.next(now);
+        if (!frame.render()) return;
         try {
           if (kind == Kind.JES && viewport != null) {
-            viewport.render(dt);
+            viewport.render(frame.deltaMs());
           } else if (kind == Kind.VNS && vnPreview != null) {
-            vnPreview.render(dt);
+            vnPreview.render(frame.deltaMs());
           }
         } catch (Exception ex) {
           stopDetachedPreviewTimer();
@@ -1430,7 +1426,6 @@ public class FileEditorTab extends BorderPane {
     if (detachedPreviewTimer == null) return;
     detachedPreviewTimer.stop();
     detachedPreviewTimer = null;
-    detachedPreviewLastNs = -1L;
   }
 
   private void updatePreviewDockMenuText() {

--- a/modules/editor/src/main/java/com/jvn/editor/ui/FileEditorTab.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/FileEditorTab.java
@@ -154,6 +154,7 @@ public class FileEditorTab extends BorderPane {
     
     if (vnsEditor != null) {
       vnsEditor.setOnLaunchFromHere(this::runFromLabel);
+      vnsEditor.setOnLaunchFromCursor(this::runFromSourceLine);
       vnsEditor.setOnStoryboardLineRequested(this::syncStoryboardPreviewToLine);
     }
     if (vnPreview != null) {
@@ -255,12 +256,32 @@ public class FileEditorTab extends BorderPane {
 
   public void launchFromHere() {
     if (kind != Kind.VNS || vnsEditor == null) return;
-    vnsEditor.setOnLaunchFromHere(this::runFromLabel);
-    // Trigger the VNS editor's built-in launch-from-here logic
-    javafx.scene.input.KeyEvent fakeF5 = new javafx.scene.input.KeyEvent(
-        javafx.scene.input.KeyEvent.KEY_PRESSED, "", "", javafx.scene.input.KeyCode.F5,
-        false, false, false, false);
-    vnsEditor.fireEvent(fakeF5);
+    vnsEditor.launchFromCurrentLabel();
+  }
+
+  public void launchFromCursor() {
+    if (kind != Kind.VNS || vnsEditor == null) return;
+    vnsEditor.launchFromCursor();
+  }
+
+  public void runFromSourceLine(int oneBasedLine) {
+    try {
+      if (kind != Kind.VNS || vnsEditor == null || vnPreview == null) return;
+      String code = vnsEditor.getText();
+      if (code == null || code.isBlank()) {
+        if (onStatus != null) onStatus.accept("Cannot run an empty VNS script");
+        return;
+      }
+      VnScenario scenario = parseVnsScenarioFromText(code);
+      vnPreview.setSourceScriptName(resolveVnsScriptKey());
+      vnPreview.runScenarioFromSourceLine(scenario, Math.max(1, oneBasedLine));
+      setPreviewDockPosition(PreviewDockPosition.WINDOW);
+      if (onStatus != null) onStatus.accept("Run from cursor: line " + Math.max(1, oneBasedLine));
+    } catch (Exception ex) {
+      showVnsParseOverlay(ex);
+      setPreviewDockPosition(PreviewDockPosition.WINDOW);
+      if (onStatus != null) onStatus.accept("VNS launch failed: " + ex.getMessage());
+    }
   }
 
   public void runFromLabel(String label) {
@@ -1068,8 +1089,16 @@ public class FileEditorTab extends BorderPane {
           runLabel,
           AeroIcon.of(AeroIcon.Kind.VNS_RUN_LABEL, 32),
           "Run from current label",
-          "Start at the nearest @label above the caret and open the runtime preview (F5)");
+          "Start at the nearest @label at or above the caret");
       runLabel.setOnAction(e -> vnsEditor.launchFromCurrentLabel());
+
+      Button runCursor = new Button();
+      configureVnsAeroButton(
+          runCursor,
+          AeroIcon.of(AeroIcon.Kind.VNS_RUN_CURSOR, 32),
+          "Run from cursor",
+          "Start at the first executable VNS line at or after the blinking caret (F5)");
+      runCursor.setOnAction(e -> vnsEditor.launchFromCursor());
 
       Button runStart = new Button();
       configureVnsAeroButton(
@@ -1151,7 +1180,10 @@ public class FileEditorTab extends BorderPane {
           "VNS editor tools",
           """
           Run from current label
-          Starts the runtime at the nearest @label above the caret. Shortcut: F5.
+          Starts at the nearest @label at or above the blinking caret.
+
+          Run from cursor
+          Starts at the first executable VNS line at or after the blinking caret. Shortcut: F5.
 
           Run from script entry
           Starts the runtime from the project entry point. Shortcut: Shift+F5.
@@ -1181,13 +1213,13 @@ public class FileEditorTab extends BorderPane {
           Opens the live game preview in its own resizable window.
           """);
       help.setGraphic(AeroIcon.of(AeroIcon.Kind.HELP, 30));
-      help.setMinSize(44, 42);
-      help.setPrefSize(44, 42);
-      help.setMaxSize(44, 42);
+      help.setMinSize(38, 36);
+      help.setPrefSize(38, 36);
+      help.setMaxSize(38, 36);
       help.getStyleClass().add("vns-tools-help-button");
 
       toolbarActions = new Node[] {
-          runLabel, runStart, vnsToolSeparator(),
+          runLabel, runCursor, runStart, vnsToolSeparator(),
           symbols, snippets, find, commands, vnsToolSeparator(),
           wordWrap, diff, diagnostics, vnsToolSeparator(),
           openPreview, vnsToolSeparator(), help
@@ -1198,12 +1230,13 @@ public class FileEditorTab extends BorderPane {
       };
     }
 
-    HBox toolbar = buildWorkspaceToolbar(
-        vnsDetachedOnly ? "VNS Tools" : (title == null ? "Preview" : title),
-        previewWorkspaceSubtitle(vnsDetachedOnly),
-        previewWorkspaceTitleIcon(),
-        toolbarActions);
-    if (vnsDetachedOnly) toolbar.getStyleClass().add("vns-tools-strip");
+    HBox toolbar = vnsDetachedOnly
+        ? buildVnsToolsStrip(toolbarActions)
+        : buildWorkspaceToolbar(
+            title == null ? "Preview" : title,
+            previewWorkspaceSubtitle(false),
+            previewWorkspaceTitleIcon(),
+            toolbarActions);
 
     root.setTop(toolbar);
     root.setCenter(previewWorkspaceContent);
@@ -1624,6 +1657,18 @@ public class FileEditorTab extends BorderPane {
     return toolbar;
   }
 
+  private static HBox buildVnsToolsStrip(Node... actions) {
+    HBox toolbar = new HBox(5);
+    toolbar.getStyleClass().addAll("script-editor-workspace-toolbar", "vns-tools-strip");
+    toolbar.setAlignment(Pos.CENTER_LEFT);
+    if (actions != null) {
+      for (Node action : actions) {
+        if (action != null) toolbar.getChildren().add(action);
+      }
+    }
+    return toolbar;
+  }
+
   private static void configureIconToggle(ToggleButton button, Node icon, String tooltipText) {
     if (button == null) return;
     button.setText("");
@@ -1664,9 +1709,9 @@ public class FileEditorTab extends BorderPane {
     button.setTooltip(new Tooltip(tooltipText));
     button.setContentDisplay(ContentDisplay.GRAPHIC_ONLY);
     button.setAccessibleText(accessibleText);
-    button.setMinSize(44, 42);
-    button.setPrefSize(44, 42);
-    button.setMaxSize(44, 42);
+    button.setMinSize(38, 36);
+    button.setPrefSize(38, 36);
+    button.setMaxSize(38, 36);
     button.setFocusTraversable(false);
     button.getStyleClass().add("vns-tools-aero-button");
   }
@@ -1678,9 +1723,9 @@ public class FileEditorTab extends BorderPane {
     button.setTooltip(new Tooltip(tooltipText));
     button.setContentDisplay(ContentDisplay.GRAPHIC_ONLY);
     button.setAccessibleText(accessibleText);
-    button.setMinSize(44, 42);
-    button.setPrefSize(44, 42);
-    button.setMaxSize(44, 42);
+    button.setMinSize(38, 36);
+    button.setPrefSize(38, 36);
+    button.setMaxSize(38, 36);
     button.setFocusTraversable(false);
     button.getStyleClass().add("vns-tools-aero-button");
   }

--- a/modules/editor/src/main/java/com/jvn/editor/ui/PreviewFramePacer.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/PreviewFramePacer.java
@@ -1,0 +1,53 @@
+package com.jvn.editor.ui;
+
+import com.jvn.core.diagnostics.GraphicsPipeline;
+import javafx.application.ConditionalFeature;
+import javafx.application.Platform;
+
+/** Stable frame pacing for editor previews, especially JavaFX's CPU renderer. */
+public final class PreviewFramePacer {
+  private static final int HARDWARE_DEFAULT_FPS = 60;
+  private static final int SOFTWARE_DEFAULT_FPS = 30;
+  private static final long PULSE_JITTER_TOLERANCE_NS = 500_000L;
+  private final long minimumFrameIntervalNs;
+  private long lastRenderNs = -1L;
+
+  public record Frame(boolean render, long deltaMs) {
+    private static final Frame SKIP = new Frame(false, 0L);
+  }
+
+  public PreviewFramePacer(int targetFps) {
+    int boundedFps = Math.max(1, Math.min(240, targetFps));
+    minimumFrameIntervalNs = 1_000_000_000L / boundedFps;
+  }
+
+  public static PreviewFramePacer forCurrentPipeline() {
+    return new PreviewFramePacer(targetFpsForCurrentPipeline());
+  }
+
+  static int targetFpsForCurrentPipeline() {
+    int override = Integer.getInteger("jvn.editor.previewMaxFps", 0);
+    if (override > 0) return Math.min(240, override);
+    if (GraphicsPipeline.requestedMode() == GraphicsPipeline.Mode.SOFTWARE) {
+      return SOFTWARE_DEFAULT_FPS;
+    }
+    try {
+      if (!Platform.isSupported(ConditionalFeature.SCENE3D)) return SOFTWARE_DEFAULT_FPS;
+    } catch (IllegalStateException ignored) {
+      // A unit test or early startup call has no JavaFX toolkit yet.
+    }
+    return HARDWARE_DEFAULT_FPS;
+  }
+
+  public Frame next(long nowNs) {
+    if (lastRenderNs < 0L) {
+      lastRenderNs = nowNs;
+      return Frame.SKIP;
+    }
+    long elapsedNs = nowNs - lastRenderNs;
+    if (elapsedNs + PULSE_JITTER_TOLERANCE_NS < minimumFrameIntervalNs) return Frame.SKIP;
+    lastRenderNs = nowNs;
+    long deltaMs = Math.max(1L, Math.min(100L, elapsedNs / 1_000_000L));
+    return new Frame(true, deltaMs);
+  }
+}

--- a/modules/editor/src/main/java/com/jvn/editor/ui/VnPreviewView.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/VnPreviewView.java
@@ -434,7 +434,6 @@ public class VnPreviewView extends StackPane {
     scene.update(deltaMs);
     renderer.updateAnimation(deltaMs);
     renderer.setAudioFacade(scene.getAudioFacade());
-    applyUiOverrides();
     syncRequestedOverlayScene();
     if (overlayScene instanceof PhoneScene phone && phone.consumeCloseRequested()) {
       closeOverlayScene();

--- a/modules/editor/src/main/java/com/jvn/editor/ui/VnPreviewView.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/VnPreviewView.java
@@ -281,6 +281,10 @@ public class VnPreviewView extends StackPane {
     requestFocus();
   }
 
+  int getCurrentSourceLine() {
+    return resolveCurrentStoryboardLine();
+  }
+
   public void reloadScenarioPreservingPosition(VnScenario scenario) {
     if (scenario == null) {
       initializeScenario(null, null);

--- a/modules/editor/src/main/java/com/jvn/editor/ui/VnPreviewView.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/VnPreviewView.java
@@ -255,6 +255,32 @@ public class VnPreviewView extends StackPane {
     initializeScenario(scenario, label);
   }
 
+  /** Starts preview at the first parsed node on or after the requested source line. */
+  public void runScenarioFromSourceLine(VnScenario scenario, int oneBasedLine) {
+    renderer.resetParticleState();
+    activeError = null;
+    stopAudio();
+    if (scenario == null) {
+      initializeScenario(null, null);
+      return;
+    }
+
+    VnSettings existingSettings = scene == null ? null : scene.getState().getSettings();
+    VnScene nextScene = buildScene(scenario, null, sourceScriptName, existingSettings, false);
+    int targetIndex = findLaunchNodeIndexForSourceLine(scenario, Math.max(1, oneBasedLine));
+    nextScene.preflightState(targetIndex);
+    nextScene.getState().setCurrentNodeIndex(targetIndex);
+    this.scene = nextScene;
+    this.overlayScene = null;
+    phoneRenderer.setSceneModel(null);
+    renderer.setAudioFacade(activeAudioFacade());
+    nextScene.onEnter();
+    storyboardPreviewLine = resolveCurrentStoryboardLine();
+    emitStoryboardPreviewLineChanged();
+    applyStoryboardUiState();
+    requestFocus();
+  }
+
   public void reloadScenarioPreservingPosition(VnScenario scenario) {
     if (scenario == null) {
       initializeScenario(null, null);
@@ -523,6 +549,29 @@ public class VnPreviewView extends StackPane {
       }
     }
     return bestIndex;
+  }
+
+  static int findLaunchNodeIndexForSourceLine(VnScenario scenario, int sourceLine) {
+    if (scenario == null || scenario.getNodes().isEmpty()) return 0;
+    List<VnNode> nodes = scenario.getNodes();
+    int firstAfterIndex = -1;
+    int firstAfterLine = Integer.MAX_VALUE;
+    int lastBeforeIndex = 0;
+    int lastBeforeLine = Integer.MIN_VALUE;
+    for (int i = 0; i < nodes.size(); i++) {
+      VnNode node = nodes.get(i);
+      if (node == null || node.getSourceLine() <= 0) continue;
+      int nodeLine = node.getSourceLine();
+      if (nodeLine >= sourceLine && nodeLine < firstAfterLine) {
+        firstAfterLine = nodeLine;
+        firstAfterIndex = i;
+      }
+      if (nodeLine <= sourceLine && nodeLine >= lastBeforeLine) {
+        lastBeforeLine = nodeLine;
+        lastBeforeIndex = i;
+      }
+    }
+    return firstAfterIndex >= 0 ? firstAfterIndex : lastBeforeIndex;
   }
 
   private void syncStoryboardHud() {

--- a/modules/editor/src/main/java/com/jvn/editor/ui/VnsCodeEditor.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/VnsCodeEditor.java
@@ -17,6 +17,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
+import java.util.function.IntConsumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -72,6 +73,7 @@ public class VnsCodeEditor extends BorderPane {
   private boolean highlightedIssueWarning = false;
   private Consumer<String> onTextChanged;
   private Consumer<String> onLaunchFromHere;
+  private IntConsumer onLaunchFromCursor;
   private EditorSearchBar searchBar;
   private boolean searchBarVisible = false;
   private final Label statusBarLabel = new Label("Ln 1, Col 1");
@@ -269,10 +271,12 @@ public class VnsCodeEditor extends BorderPane {
 
     codeArea.setOnContextMenuRequested(e -> {
       ContextMenu menu = new ContextMenu();
-      // Launch from here
-      MenuItem launchItem = new MenuItem("Launch from here (F5)");
-      launchItem.setOnAction(a -> launchFromHere());
+      MenuItem launchItem = new MenuItem("Run from cursor (F5)");
+      launchItem.setOnAction(a -> launchFromCursor());
       menu.getItems().add(launchItem);
+      MenuItem launchLabelItem = new MenuItem("Run from current label");
+      launchLabelItem.setOnAction(a -> launchFromCurrentLabel());
+      menu.getItems().add(launchLabelItem);
       MenuItem launchStartItem = new MenuItem("Launch from start (Shift+F5)");
       launchStartItem.setOnAction(a -> { if (onLaunchFromHere != null) onLaunchFromHere.accept(null); });
       menu.getItems().add(launchStartItem);
@@ -317,7 +321,7 @@ public class VnsCodeEditor extends BorderPane {
         if (e.isShiftDown()) {
           if (onLaunchFromHere != null) onLaunchFromHere.accept(null);
         } else {
-          launchFromHere();
+          launchFromCursor();
         }
         e.consume();
       }
@@ -720,9 +724,20 @@ public class VnsCodeEditor extends BorderPane {
     this.onLaunchFromHere = listener;
   }
 
+  public void setOnLaunchFromCursor(IntConsumer listener) {
+    this.onLaunchFromCursor = listener;
+  }
+
   /** Launches the script at the nearest label at or above the caret. */
   public void launchFromCurrentLabel() {
     launchFromHere();
+  }
+
+  /** Launches the script at the first executable node at or after the caret line. */
+  public void launchFromCursor() {
+    if (onLaunchFromCursor != null) {
+      onLaunchFromCursor.accept(codeArea.getCurrentParagraph() + 1);
+    }
   }
 
   /** Launches the script through the configured callback from its entry point. */
@@ -744,14 +759,17 @@ public class VnsCodeEditor extends BorderPane {
 
   private void launchFromHere() {
     if (onLaunchFromHere == null) return;
-    int cursorLine = codeArea.getCurrentParagraph(); // 0-based
+    int cursorLine = codeArea.getCurrentParagraph();
     String text = codeArea.getText();
-    if (text == null || text.isEmpty()) { onLaunchFromHere.accept(null); return; }
+    if (text == null || text.isEmpty()) {
+      onLaunchFromHere.accept(null);
+      return;
+    }
     String[] lines = text.split("\\n", -1);
     for (int i = Math.min(cursorLine, lines.length - 1); i >= 0; i--) {
-      Matcher m = LABEL_SCAN_PATTERN.matcher(lines[i]);
-      if (m.find()) {
-        onLaunchFromHere.accept(m.group(1));
+      Matcher matcher = LABEL_SCAN_PATTERN.matcher(lines[i]);
+      if (matcher.find()) {
+        onLaunchFromHere.accept(matcher.group(1));
         return;
       }
     }

--- a/modules/editor/src/main/resources/com/jvn/editor/editor-light.css
+++ b/modules/editor/src/main/resources/com/jvn/editor/editor-light.css
@@ -3474,12 +3474,12 @@
 }
 
 .vns-tools-strip {
-  -fx-spacing: 7;
-  -fx-padding: 8 12 8 12;
+  -fx-spacing: 5;
+  -fx-padding: 3 8 3 8;
   -fx-background-color:
-    linear-gradient(to bottom, rgba(255,255,255,0.76), transparent 46%),
-    linear-gradient(to bottom, #f7f9fb, #e6ebef);
-  -fx-border-color: transparent transparent #bcc6ce transparent;
+    linear-gradient(to bottom, rgba(255,255,255,0.56), transparent 50%),
+    linear-gradient(to bottom, #eeeeee, #e3e3e3);
+  -fx-border-color: transparent transparent #c8c8c8 transparent;
 }
 
 .vns-tools-aero-button {
@@ -3495,20 +3495,20 @@
 
 .vns-tools-aero-button:hover {
   -fx-background-color:
-    linear-gradient(to bottom, rgba(255,255,255,0.86), rgba(141,201,234,0.32));
-  -fx-border-color: rgba(74,137,174,0.38);
+    linear-gradient(to bottom, #ffffff, #d9d9d9);
+  -fx-border-color: #b5b5b5;
 }
 
 .vns-tools-aero-button:pressed {
   -fx-background-color:
-    linear-gradient(to bottom, rgba(102,167,204,0.34), rgba(230,247,255,0.66));
-  -fx-border-color: rgba(48,119,160,0.48);
+    linear-gradient(to bottom, #d2d2d2, #e5e5e5);
+  -fx-border-color: #a0a0a0;
 }
 
 .vns-tools-aero-button:selected {
   -fx-background-color:
-    linear-gradient(to bottom, rgba(255,255,255,0.92), rgba(98,177,219,0.46));
-  -fx-border-color: rgba(42,118,161,0.58);
+    linear-gradient(to bottom, #d0d0d0, #bfbfbf);
+  -fx-border-color: #929292;
 }
 
 .vns-tools-separator > .line {

--- a/modules/editor/src/main/resources/com/jvn/editor/editor.css
+++ b/modules/editor/src/main/resources/com/jvn/editor/editor.css
@@ -3559,12 +3559,12 @@ The editor.css file defines the visual styling for the editor module, including 
 }
 
 .vns-tools-strip {
-  -fx-spacing: 7;
-  -fx-padding: 8 12 8 12;
+  -fx-spacing: 5;
+  -fx-padding: 3 8 3 8;
   -fx-background-color:
-    linear-gradient(to bottom, rgba(255,255,255,0.035), transparent 42%),
-    linear-gradient(to bottom, #181b1e, #0d0f11);
-  -fx-border-color: transparent transparent #343a40 transparent;
+    linear-gradient(to bottom, rgba(255,255,255,0.025), transparent 50%),
+    linear-gradient(to bottom, #181818, #121212);
+  -fx-border-color: transparent transparent #2b2b2b transparent;
 }
 
 .vns-tools-aero-button {
@@ -3580,20 +3580,20 @@ The editor.css file defines the visual styling for the editor module, including 
 
 .vns-tools-aero-button:hover {
   -fx-background-color:
-    linear-gradient(to bottom, rgba(166,224,255,0.16), rgba(72,143,184,0.08));
-  -fx-border-color: rgba(185,229,255,0.20);
+    linear-gradient(to bottom, rgba(255,255,255,0.10), rgba(255,255,255,0.035));
+  -fx-border-color: rgba(255,255,255,0.15);
 }
 
 .vns-tools-aero-button:pressed {
   -fx-background-color:
-    linear-gradient(to bottom, rgba(45,96,126,0.22), rgba(140,210,246,0.10));
-  -fx-border-color: rgba(145,208,241,0.26);
+    linear-gradient(to bottom, rgba(0,0,0,0.20), rgba(255,255,255,0.05));
+  -fx-border-color: rgba(255,255,255,0.20);
 }
 
 .vns-tools-aero-button:selected {
   -fx-background-color:
-    linear-gradient(to bottom, rgba(156,220,255,0.24), rgba(43,112,151,0.16));
-  -fx-border-color: rgba(167,222,252,0.44);
+    linear-gradient(to bottom, #3a3a3a, #292929);
+  -fx-border-color: #616161;
 }
 
 .vns-tools-separator > .line {

--- a/modules/editor/src/test/java/com/jvn/editor/ui/AeroIconTest.java
+++ b/modules/editor/src/test/java/com/jvn/editor/ui/AeroIconTest.java
@@ -90,6 +90,7 @@ class AeroIconTest {
 
     for (AeroIcon.Kind kind : new AeroIcon.Kind[] {
         AeroIcon.Kind.VNS_RUN_LABEL,
+        AeroIcon.Kind.VNS_RUN_CURSOR,
         AeroIcon.Kind.VNS_RUN_ENTRY,
         AeroIcon.Kind.VNS_SYMBOLS,
         AeroIcon.Kind.VNS_SNIPPET,
@@ -120,6 +121,7 @@ class AeroIconTest {
     Set<Long> artworkHashes = new HashSet<>();
     for (AeroIcon.Kind kind : new AeroIcon.Kind[] {
         AeroIcon.Kind.VNS_RUN_LABEL,
+        AeroIcon.Kind.VNS_RUN_CURSOR,
         AeroIcon.Kind.VNS_RUN_ENTRY,
         AeroIcon.Kind.VNS_SYMBOLS,
         AeroIcon.Kind.VNS_SNIPPET,
@@ -140,7 +142,7 @@ class AeroIconTest {
       });
       artworkHashes.add(pixelHash(image));
     }
-    assertEquals(10, artworkHashes.size(), "Every VNS command needs a distinct readable silhouette");
+    assertEquals(11, artworkHashes.size(), "Every VNS command needs a distinct readable silhouette");
   }
 
   @Test

--- a/modules/editor/src/test/java/com/jvn/editor/ui/FileEditorTabVnsLaunchTest.java
+++ b/modules/editor/src/test/java/com/jvn/editor/ui/FileEditorTabVnsLaunchTest.java
@@ -17,9 +17,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import javafx.application.Platform;
+import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.control.ButtonBase;
 import javafx.scene.control.ToggleButton;
+import javafx.scene.layout.HBox;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -86,6 +88,12 @@ class FileEditorTabVnsLaunchTest {
       tab.layout();
       try {
         Set<javafx.scene.Node> controls = tab.lookupAll(".vns-tools-aero-button");
+        Node stripNode = tab.lookup(".vns-tools-strip");
+        assertTrue(stripNode instanceof HBox);
+        assertTrue(stripNode.getBoundsInLocal().getHeight() <= 44.0,
+            "The VNS command strip should remain compact");
+        assertTrue(tab.lookupAll(".script-editor-workspace-title").isEmpty(),
+            "The compact VNS strip should not reserve space for a title or logo");
         ButtonBase diagnostics = controls.stream()
             .filter(ButtonBase.class::isInstance)
             .map(ButtonBase.class::cast)
@@ -98,6 +106,16 @@ class FileEditorTabVnsLaunchTest {
             .filter(button -> "Toggle VNS word wrap".equals(button.getAccessibleText()))
             .findFirst()
             .orElseThrow();
+        ButtonBase runFromCursor = controls.stream()
+            .filter(ButtonBase.class::isInstance)
+            .map(ButtonBase.class::cast)
+            .filter(button -> "Run from cursor".equals(button.getAccessibleText()))
+            .findFirst()
+            .orElseThrow();
+        assertTrue(controls.stream()
+            .filter(ButtonBase.class::isInstance)
+            .map(ButtonBase.class::cast)
+            .anyMatch(button -> "Run from current label".equals(button.getAccessibleText())));
         assertTrue(controls.stream()
             .filter(ButtonBase.class::isInstance)
             .map(ButtonBase.class::cast)
@@ -105,8 +123,10 @@ class FileEditorTabVnsLaunchTest {
 
         diagnostics.fire();
         wordWrap.fire();
+        runFromCursor.fire();
         assertTrue(diagnosticsOpened.get());
         assertTrue(wordWrap.isSelected());
+        assertTrue(tab.isDetachedPreviewVisible());
       } finally {
         tab.dispose();
       }

--- a/modules/editor/src/test/java/com/jvn/editor/ui/FileEditorTabVnsLaunchTest.java
+++ b/modules/editor/src/test/java/com/jvn/editor/ui/FileEditorTabVnsLaunchTest.java
@@ -77,7 +77,25 @@ class FileEditorTabVnsLaunchTest {
   void vnsStripExposesWorkingReviewControls(@TempDir Path tempDir) throws Exception {
     Assumptions.assumeTrue(toolkitAvailable, "JavaFX toolkit is unavailable in this environment");
     Path script = tempDir.resolve("review_controls.vns");
-    Files.writeString(script, "@scenario review_controls\n@label start\nnarrator: Hello.\n");
+    Files.writeString(script, String.join("\n",
+        "@scenario review_controls",
+        "@character narrator \"\"",
+        "@character panel_01_wendi \"\"",
+        "@character panel_mags \"\"",
+        "@background bg_mags bg.png",
+        "",
+        "",
+        "@label start",
+        "",
+        "[bg bg_mags]",
+        "",
+        "",
+        "[show panel_01_wendi center neutral]",
+        "[show panel_mags center neutral]",
+        "narrator:1714",
+        "[show panel_01_wendi center neutral]",
+        "[show panel_mags center neutral]",
+        "narrator:1716"));
 
     onFxThread(() -> {
       FileEditorTab tab = new FileEditorTab(script.toFile());
@@ -86,6 +104,7 @@ class FileEditorTabVnsLaunchTest {
       new Scene(tab, 1400, 180);
       tab.applyCss();
       tab.layout();
+      tab.navigateToLine(18);
       try {
         Set<javafx.scene.Node> controls = tab.lookupAll(".vns-tools-aero-button");
         Node stripNode = tab.lookup(".vns-tools-strip");
@@ -127,6 +146,7 @@ class FileEditorTabVnsLaunchTest {
         assertTrue(diagnosticsOpened.get());
         assertTrue(wordWrap.isSelected());
         assertTrue(tab.isDetachedPreviewVisible());
+        assertEquals(18, tab.getVnsPreviewSourceLine());
       } finally {
         tab.dispose();
       }

--- a/modules/editor/src/test/java/com/jvn/editor/ui/PreviewFramePacerTest.java
+++ b/modules/editor/src/test/java/com/jvn/editor/ui/PreviewFramePacerTest.java
@@ -1,0 +1,53 @@
+package com.jvn.editor.ui;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.jvn.core.diagnostics.GraphicsPipeline;
+import org.junit.jupiter.api.Test;
+
+class PreviewFramePacerTest {
+  @Test
+  void capsRenderingAndCarriesElapsedTimeIntoTheRenderedFrame() {
+    PreviewFramePacer pacer = new PreviewFramePacer(30);
+
+    assertFalse(pacer.next(1_000_000_000L).render());
+    assertFalse(pacer.next(1_020_000_000L).render());
+    PreviewFramePacer.Frame frame = pacer.next(1_034_000_000L);
+
+    assertTrue(frame.render());
+    assertEquals(34L, frame.deltaMs());
+  }
+
+  @Test
+  void clampsLongPausesSoPreviewAnimationsResumeSmoothly() {
+    PreviewFramePacer pacer = new PreviewFramePacer(60);
+    pacer.next(1_000_000_000L);
+
+    PreviewFramePacer.Frame frame = pacer.next(2_000_000_000L);
+
+    assertTrue(frame.render());
+    assertEquals(100L, frame.deltaMs());
+  }
+
+  @Test
+  void softwareRenderingUsesTheConservativeDefaultCap() {
+    String previousMode = System.getProperty(GraphicsPipeline.MODE_PROPERTY);
+    String previousOverride = System.getProperty("jvn.editor.previewMaxFps");
+    try {
+      System.setProperty(GraphicsPipeline.MODE_PROPERTY, "software");
+      System.clearProperty("jvn.editor.previewMaxFps");
+
+      assertEquals(30, PreviewFramePacer.targetFpsForCurrentPipeline());
+    } finally {
+      restore(GraphicsPipeline.MODE_PROPERTY, previousMode);
+      restore("jvn.editor.previewMaxFps", previousOverride);
+    }
+  }
+
+  private static void restore(String key, String value) {
+    if (value == null) System.clearProperty(key);
+    else System.setProperty(key, value);
+  }
+}

--- a/modules/editor/src/test/java/com/jvn/editor/ui/VnPreviewViewTest.java
+++ b/modules/editor/src/test/java/com/jvn/editor/ui/VnPreviewViewTest.java
@@ -4,6 +4,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Properties;
 
+import com.jvn.core.vn.VnNode;
+import com.jvn.core.vn.VnNodeType;
+import com.jvn.core.vn.VnScenario;
+
 import org.junit.jupiter.api.Test;
 
 class VnPreviewViewTest {
@@ -32,5 +36,20 @@ class VnPreviewViewTest {
 
     props.setProperty("runtime.audio", "unknown");
     assertEquals("auto", VnPreviewView.resolveAudioBackend(props));
+  }
+
+  @Test
+  void cursorLaunchSelectsTheFirstNodeAtOrAfterTheCaret() {
+    VnScenario scenario = VnScenario.builder("cursor_launch")
+        .addNode(VnNode.builder(VnNodeType.BACKGROUND).sourceLine(3).build())
+        .addNode(VnNode.builder(VnNodeType.DIALOGUE).sourceLine(7).build())
+        .addNode(VnNode.builder(VnNodeType.CHOICE).sourceLine(11).build())
+        .build();
+
+    assertEquals(0, VnPreviewView.findLaunchNodeIndexForSourceLine(scenario, 1));
+    assertEquals(1, VnPreviewView.findLaunchNodeIndexForSourceLine(scenario, 4));
+    assertEquals(1, VnPreviewView.findLaunchNodeIndexForSourceLine(scenario, 7));
+    assertEquals(2, VnPreviewView.findLaunchNodeIndexForSourceLine(scenario, 9));
+    assertEquals(2, VnPreviewView.findLaunchNodeIndexForSourceLine(scenario, 20));
   }
 }

--- a/modules/editor/src/test/java/com/jvn/editor/ui/VnPreviewViewTest.java
+++ b/modules/editor/src/test/java/com/jvn/editor/ui/VnPreviewViewTest.java
@@ -7,6 +7,7 @@ import java.util.Properties;
 import com.jvn.core.vn.VnNode;
 import com.jvn.core.vn.VnNodeType;
 import com.jvn.core.vn.VnScenario;
+import com.jvn.core.vn.script.VnScriptParser;
 
 import org.junit.jupiter.api.Test;
 
@@ -51,5 +52,33 @@ class VnPreviewViewTest {
     assertEquals(1, VnPreviewView.findLaunchNodeIndexForSourceLine(scenario, 7));
     assertEquals(2, VnPreviewView.findLaunchNodeIndexForSourceLine(scenario, 9));
     assertEquals(2, VnPreviewView.findLaunchNodeIndexForSourceLine(scenario, 20));
+  }
+
+  @Test
+  void cursorLaunchAtLineEighteenSelectsThe1716Dialogue() throws Exception {
+    VnScenario scenario = new VnScriptParser().parseFromString(String.join("\n",
+        "@scenario cursor_repro",
+        "@character narrator \"\"",
+        "@character panel_01_wendi \"\"",
+        "@character panel_mags \"\"",
+        "@background bg_mags bg.png",
+        "",
+        "",
+        "@label start",
+        "",
+        "[bg bg_mags]",
+        "",
+        "",
+        "[show panel_01_wendi center neutral]",
+        "[show panel_mags center neutral]",
+        "narrator:1714",
+        "[show panel_01_wendi center neutral]",
+        "[show panel_mags center neutral]",
+        "narrator:1716"));
+
+    int target = VnPreviewView.findLaunchNodeIndexForSourceLine(scenario, 18);
+
+    assertEquals(18, scenario.getNode(target).getSourceLine());
+    assertEquals("1716", scenario.getNode(target).getDialogue().getText());
   }
 }

--- a/modules/hub/src/main/java/com/jvn/hub/JvnHub.java
+++ b/modules/hub/src/main/java/com/jvn/hub/JvnHub.java
@@ -54,6 +54,7 @@ import java.security.CodeSource;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
@@ -1170,6 +1171,14 @@ public final class JvnHub {
         VectorIcon.Kind.INFO,
         ACCENT_RENDER,
         this::showRenderGraphViewer));
+    JMenuItem profileEditor = hubMenuItem(
+        "Launch Editor with Java Flight Recorder...",
+        "Record CPU, allocation, GC, and JavaFX submission activity while using the selected GPU pipeline.",
+        VectorIcon.Kind.PLAY,
+        ACCENT_RENDER,
+        () -> guardedRun("Profile Editor", this::runProfiledEditor));
+    profileEditor.setEnabled(!busy);
+    diagnostics.add(profileEditor);
     JMenuItem disableDiagnostics = hubMenuItem(
         "Disable All Render Diagnostics",
         renderPipelineOptions.diagnosticsEnabled()
@@ -3067,8 +3076,11 @@ public final class JvnHub {
           tuning.linuxGlxRecovery() ? CheckStatus.PASS : CheckStatus.INFO,
           "Managed GLX recovery",
           tuning.linuxGlxRecovery() ? "Enabled" : "Disabled",
-          "When enabled, JVN retries a broken default GLX provider with Mesa."));
+              "When enabled, JVN retries a broken default GLX provider with Mesa."));
       report.add(linuxOpenGlCheck());
+      if (selected == RenderPipelineSettings.Mode.HARDWARE) {
+        report.add(linuxDiscreteGpuLaunchCheck());
+      }
     }
 
     report.add(new HealthCheck(
@@ -3176,6 +3188,41 @@ public final class JvnHub {
         "Linux OpenGL probe",
         "Direct OpenGL initialization succeeded.",
         summarizeOpenGlProbe(result.output));
+  }
+
+  private HealthCheck linuxDiscreteGpuLaunchCheck() {
+    Path launcher = projectRoot.resolve("scripts").resolve("launch-app.sh");
+    if (!Files.isExecutable(launcher) || !commandExists("env")) {
+      return new HealthCheck(
+          CheckStatus.INFO,
+          "Linux discrete-GPU launch probe",
+          "The managed launch probe is unavailable.",
+          "Expected executable: " + launcher.toAbsolutePath());
+    }
+    CommandResult result = runLocalCommand(
+        List.of(
+            "env",
+            RenderPipelineSettings.GRAPHICS_MODE_ENVIRONMENT + "=hardware",
+            launcher.toString(),
+            "runtime",
+            "--gpu-info"),
+        8);
+    String detail = result.output == null ? "" : result.output.trim();
+    if (result.exitCode != 0) {
+      return new HealthCheck(
+          CheckStatus.WARN,
+          "Linux discrete-GPU launch probe",
+          "The GPU preference probe did not complete.",
+          detail.isBlank() ? "Exit code " + result.exitCode : detail);
+    }
+    boolean rendererReported = detail.toLowerCase(Locale.ROOT).contains("renderer=");
+    return new HealthCheck(
+        rendererReported ? CheckStatus.PASS : CheckStatus.INFO,
+        "Linux discrete-GPU launch probe",
+        rendererReported ? "The managed launch resolved an OpenGL adapter." : "Adapter selection was requested.",
+        detail.isBlank()
+            ? "No OpenGL renderer was reported; install mesa-demos or the distribution's glxinfo package."
+            : detail);
   }
 
   private static String summarizeOpenGlProbe(String output) {
@@ -4097,6 +4144,28 @@ public final class JvnHub {
     startProcess(cmd, label);
   }
 
+  private void runProfiledEditor() {
+    if (!acquire("Profile Editor")) return;
+    List<String> cmd = new ArrayList<>();
+    if (System.getProperty("os.name", "").toLowerCase(Locale.ROOT).contains("win")) {
+      cmd.add(gradleCommand());
+      cmd.add("--console=plain");
+      cmd.add("-D" + RenderPipelineSettings.GRAPHICS_MODE_PROPERTY + "=" + renderPipelineMode.id());
+      cmd.add("--max-workers=" + balancedLaunchWorkerCount());
+      cmd.add(":editor:run");
+    } else {
+      cmd.add(projectRoot.resolve("scripts").resolve("launch-app.sh").toString());
+      cmd.add("editor");
+      cmd.add("--jfr");
+      if (developerModeEnabled) cmd.add("--developer-mode");
+      if (safeModeEnabled) cmd.add("--safe-mode");
+    }
+    completeCurrentStep("Profiled launch command assembled.");
+    advanceStep("Starting the editor with Java Flight Recorder.");
+    appendLog("$ " + String.join(" ", cmd));
+    startProcess(cmd, "Profile Editor", Map.of("JVN_PROFILE_JFR", "1"));
+  }
+
   private String modeLaunchDetail() {
     if (developerModeEnabled && safeModeEnabled) return "Starting background process in Developer + Safe Mode.";
     if (developerModeEnabled) return "Starting background process in Developer Mode.";
@@ -4781,8 +4850,18 @@ public final class JvnHub {
   }
 
   private void startProcess(List<String> command, String label) {
+    startProcess(command, label, Map.of());
+  }
+
+  private void startProcess(
+      List<String> command,
+      String label,
+      Map<String, String> launchEnvironment) {
     RenderPipelineSettings.Mode launchPipelineMode = renderPipelineMode;
     RenderPipelineSettings.Options launchPipelineOptions = renderPipelineOptions;
+    Map<String, String> extraEnvironment = launchEnvironment == null
+        ? Map.of()
+        : Map.copyOf(launchEnvironment);
     new SwingWorker<Integer, String>() {
       private String lastOutput = "";
       private final StringBuilder fullOutput = new StringBuilder();
@@ -4792,6 +4871,7 @@ public final class JvnHub {
         ProcessBuilder pb = new ProcessBuilder(command)
             .directory(projectRoot.toFile())
             .redirectErrorStream(true);
+        pb.environment().putAll(extraEnvironment);
         boolean managedGraphicsLaunch = RenderPipelineSettings.applyLaunchEnvironment(
             pb.environment(), command, launchPipelineMode, launchPipelineOptions);
         if (managedGraphicsLaunch) {

--- a/modules/hub/src/main/java/com/jvn/hub/RenderPipelineSettings.java
+++ b/modules/hub/src/main/java/com/jvn/hub/RenderPipelineSettings.java
@@ -69,9 +69,11 @@ final class RenderPipelineSettings {
       String os = operatingSystem == null ? "" : operatingSystem.toLowerCase(Locale.ROOT);
       return switch (this) {
         case AUTO -> "JavaFX platform default";
-        case HARDWARE -> os.contains("win")
-            ? "Direct3D → OpenGL ES2 → software"
-            : "OpenGL ES2 → software";
+        case HARDWARE -> {
+          if (os.contains("win")) yield "Direct3D → OpenGL ES2 → software";
+          if (os.contains("mac")) yield "Metal → OpenGL ES2 → software";
+          yield "OpenGL ES2 → software";
+        }
         case SOFTWARE -> "Software renderer only";
       };
     }

--- a/modules/hub/src/test/java/com/jvn/hub/RenderPipelineSettingsTest.java
+++ b/modules/hub/src/test/java/com/jvn/hub/RenderPipelineSettingsTest.java
@@ -102,6 +102,9 @@ class RenderPipelineSettingsTest {
         "OpenGL ES2 → software",
         RenderPipelineSettings.Mode.HARDWARE.backendOrder("Linux"));
     assertEquals(
+        "Metal → OpenGL ES2 → software",
+        RenderPipelineSettings.Mode.HARDWARE.backendOrder("macOS"));
+    assertEquals(
         "Software renderer only",
         RenderPipelineSettings.Mode.SOFTWARE.backendOrder("macOS"));
   }

--- a/modules/runtime/build.gradle.kts
+++ b/modules/runtime/build.gradle.kts
@@ -1,4 +1,6 @@
 import java.io.File
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 import java.util.Properties
 
 plugins {
@@ -36,6 +38,25 @@ application {
   mainClass.set("com.jvn.runtime.JvnApp")
 }
 
+fun JavaExec.configureFlightRecordingForLaunch() {
+  val requested = System.getenv("JVN_PROFILE_JFR")?.trim()?.lowercase()
+  if (requested !in setOf("1", "true", "yes", "on")) return
+  val os = System.getProperty("os.name", "").lowercase()
+  val userHome = File(System.getProperty("user.home", "."))
+  val profileDir = when {
+    os.contains("win") -> File(System.getenv("LOCALAPPDATA") ?: userHome.path, "JVN Engine Hub/profiles")
+    os.contains("mac") -> File(userHome, "Library/Application Support/JVN Engine Hub/profiles")
+    else -> File(System.getenv("XDG_STATE_HOME") ?: File(userHome, ".local/state").path,
+      "jvn-engine-hub/profiles")
+  }
+  profileDir.mkdirs()
+  val timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss"))
+  val recording = File(profileDir, "runtime-$timestamp.jfr")
+  jvmArgs("-XX:StartFlightRecording=filename=${recording.absolutePath},settings=profile,dumponexit=true")
+  systemProperty("prism.verbose", "true")
+  logger.lifecycle("JVN Java Flight Recorder: ${recording.absolutePath}")
+}
+
 fun requestedGraphicsModeForLaunch(): String {
   val explicitProperty = System.getProperty("jvn.graphics.mode")?.trim().orEmpty()
   if (explicitProperty.isNotEmpty()) return explicitProperty
@@ -56,13 +77,15 @@ fun requestedGraphicsModeForLaunch(): String {
 }
 
 tasks.named<JavaExec>("run") {
+  configureFlightRecordingForLaunch()
   when (requestedGraphicsModeForLaunch().lowercase()) {
     "gpu", "hardware", "accelerated", "prefer-gpu" -> {
       systemProperty("jvn.graphics.mode", "hardware")
-      val prismOrder = if (System.getProperty("os.name", "").lowercase().contains("win")) {
-        "d3d,es2,sw"
-      } else {
-        "es2,sw"
+      val os = System.getProperty("os.name", "").lowercase()
+      val prismOrder = when {
+        os.contains("win") -> "d3d,es2,sw"
+        os.contains("mac") -> "metal,es2,sw"
+        else -> "es2,sw"
       }
       systemProperty("prism.order", prismOrder)
       systemProperty("prism.forceGPU", "true")

--- a/scripts/launch-app.sh
+++ b/scripts/launch-app.sh
@@ -9,6 +9,8 @@ MODE="${JVN_APP_LAUNCH_MODE:-auto}"
 FORCE_REBUILD=0
 SAFE_MODE=0
 DEVELOPER_MODE=0
+GPU_INFO_ONLY=0
+JFR_PROFILE=0
 declare -a APP_ARGS=()
 
 usage() {
@@ -20,10 +22,13 @@ Usage: scripts/launch-app.sh editor|launcher|runtime [options] [-- app arguments
   --rebuild           Refresh the compiled launch cache before starting.
   --safe-mode         Forward JVN safe-mode properties.
   --developer-mode    Forward JVN developer-mode properties.
+  --gpu-info          Print the GPU that a hardware launch would use, then exit.
+  --jfr               Record the launched Java process with Java Flight Recorder.
 
 Environment: JVN_APP_LAUNCH_MODE=auto|direct|gradle
              JVN_APP_JAVA_OPTS="<additional JVM options>"
              JVN_DISABLE_GLX_FALLBACK=1 disables Linux Mesa GLX recovery
+             JVN_DISABLE_GPU_OFFLOAD=1 disables Linux discrete-GPU selection
 EOF
 }
 
@@ -48,6 +53,8 @@ while (($#)); do
     --rebuild) FORCE_REBUILD=1 ;;
     --safe-mode) SAFE_MODE=1 ;;
     --developer-mode) DEVELOPER_MODE=1 ;;
+    --gpu-info) GPU_INFO_ONLY=1 ;;
+    --jfr) JFR_PROFILE=1 ;;
     --) shift; APP_ARGS+=("$@"); break ;;
     *) APP_ARGS+=("$1") ;;
   esac
@@ -66,6 +73,8 @@ VERSION_FILE="$CACHE_DIR/version.txt"
 STAMP_FILE="$CACHE_DIR/launch.stamp"
 
 declare -a MODE_PROPS=()
+declare -a GPU_LAUNCH_PREFIX=()
+GPU_SELECTION_MESSAGE=""
 if [[ "$SAFE_MODE" -eq 1 ]]; then
   MODE_PROPS+=("-Djvn.hub.safeMode=true" "-Djvn.editor.safeMode=true" "-Djvn.launcher.safeMode=true" "-Djvn.help.safeMode=true")
 fi
@@ -78,7 +87,7 @@ set +u
 run_gradle() {
   local task="$1"
   local workers=2
-  exec "$ROOT_DIR/gradlew" --console=plain --configuration-cache --max-workers="$workers" -p "$ROOT_DIR" \
+  exec "${GPU_LAUNCH_PREFIX[@]}" "$ROOT_DIR/gradlew" --console=plain --configuration-cache --max-workers="$workers" -p "$ROOT_DIR" \
     "${MODE_PROPS[@]}" "$task"
 }
 
@@ -110,6 +119,118 @@ run_glx_probe() {
 lowercase() {
   # macOS still ships Bash 3.2, which does not support ${value,,}.
   printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
+
+likely_discrete_gpu_name() {
+  local name
+  name="$(lowercase "$1")"
+  case "$name" in
+    *nvidia*|*geforce*|*quadro*|*intel*arc*|*radeon*rx*|*radeon*pro*|*firepro*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+configure_linux_discrete_gpu() {
+  [[ "$(uname -s 2>/dev/null)" == "Linux" ]] || return 0
+  [[ "${JVN_DISABLE_GPU_OFFLOAD:-0}" != "1" ]] || return 0
+  case "$GRAPHICS_MODE_NORMALIZED" in
+    gpu|hardware|accelerated|prefer-gpu) ;;
+    *) return 0 ;;
+  esac
+
+  # Respect an adapter choice made by the desktop, Steam, gamescope, or the caller.
+  if [[ -n "${DRI_PRIME:-}" || -n "${__NV_PRIME_RENDER_OFFLOAD:-}" \
+      || -n "${__GLX_VENDOR_LIBRARY_NAME:-}" \
+      || -n "${__VK_LAYER_NV_optimus:-}" ]]; then
+    GPU_SELECTION_MESSAGE="using inherited Linux GPU offload environment"
+    return 0
+  fi
+
+  if ! command -v switcherooctl >/dev/null 2>&1; then
+    configure_linux_sysfs_gpu_fallback
+    return 0
+  fi
+
+  local devices default_name device_count
+  devices="$(switcherooctl list 2>/dev/null || true)"
+  device_count="$(printf '%s\n' "$devices" | awk '/^Device:/ { count++ } END { print count + 0 }')"
+  [[ "$device_count" -gt 0 ]] || {
+    configure_linux_sysfs_gpu_fallback
+    return 0
+  }
+  [[ "$device_count" -gt 1 ]] || {
+    GPU_SELECTION_MESSAGE="one GPU reported; using the desktop's default GPU"
+    return 0
+  }
+  default_name="$(printf '%s\n' "$devices" | awk '
+    /^Device:/ { device=$2 }
+    /^[[:space:]]+Name:/ { line=$0; sub(/^[[:space:]]+Name:[[:space:]]*/, "", line); names[device]=line }
+    /^[[:space:]]+Default:[[:space:]]+yes/ { selected=device }
+    END { if (selected in names) print names[selected] }')"
+
+  # switcherooctl treats the first non-default adapter as the discrete GPU. Some
+  # desktops run on the discrete GPU already; in that case wrapping the command
+  # would incorrectly move JVN back to the integrated adapter.
+  if likely_discrete_gpu_name "$default_name"; then
+    GPU_SELECTION_MESSAGE="desktop default already appears discrete: $default_name"
+    return 0
+  fi
+
+  GPU_LAUNCH_PREFIX=(switcherooctl launch)
+  GPU_SELECTION_MESSAGE="requesting the discrete GPU through switcheroo-control"
+}
+
+configure_linux_sysfs_gpu_fallback() {
+  local vendor_file vendor boot default_vendor="" candidate_vendor="" count=0
+  for vendor_file in /sys/class/drm/card*/device/vendor; do
+    [[ -r "$vendor_file" ]] || continue
+    vendor="$(sed -n '1p' "$vendor_file" 2>/dev/null)"
+    [[ -n "$vendor" ]] || continue
+    count=$((count + 1))
+    boot="$(sed -n '1p' "${vendor_file%/vendor}/boot_vga" 2>/dev/null || true)"
+    if [[ "$boot" == "1" ]]; then
+      default_vendor="$vendor"
+    elif [[ -z "$candidate_vendor" ]]; then
+      candidate_vendor="$vendor"
+    fi
+  done
+  if [[ "$count" -le 1 || -z "$default_vendor" || -z "$candidate_vendor" ]]; then
+    GPU_SELECTION_MESSAGE="discrete-GPU service unavailable; using the desktop's default GPU"
+    return 0
+  fi
+  if [[ "$default_vendor" == "0x10de" ]]; then
+    GPU_SELECTION_MESSAGE="the boot display GPU is NVIDIA; using the desktop's default GPU"
+    return 0
+  fi
+  if [[ "$candidate_vendor" == "0x10de" ]]; then
+    export __NV_PRIME_RENDER_OFFLOAD=1
+    export __GLX_VENDOR_LIBRARY_NAME=nvidia
+    export __VK_LAYER_NV_optimus=NVIDIA_only
+    GPU_SELECTION_MESSAGE="requesting the NVIDIA GPU through PRIME environment variables"
+    return 0
+  fi
+  if [[ "$default_vendor" == "0x8086" && "$candidate_vendor" != "0x8086" ]]; then
+    export DRI_PRIME=1
+    GPU_SELECTION_MESSAGE="requesting the non-Intel GPU through Mesa PRIME"
+    return 0
+  fi
+  GPU_SELECTION_MESSAGE="GPU roles are ambiguous; preserving the desktop's default adapter"
+}
+
+print_gpu_launch_probe() {
+  case "$GRAPHICS_MODE_NORMALIZED" in
+    gpu|hardware|accelerated|prefer-gpu) ;;
+    *) return 0 ;;
+  esac
+  [[ -n "$GPU_SELECTION_MESSAGE" ]] && echo "[jvn] GPU preference: $GPU_SELECTION_MESSAGE." >&2
+  command -v glxinfo >/dev/null 2>&1 || return 0
+  local probe summary
+  probe="$(run_glx_probe "${GPU_LAUNCH_PREFIX[@]}" glxinfo -B 2>/dev/null || true)"
+  summary="$(printf '%s\n' "$probe" | sed -n \
+    -e 's/^[[:space:]]*OpenGL vendor string:[[:space:]]*/vendor=/p' \
+    -e 's/^[[:space:]]*OpenGL renderer string:[[:space:]]*/renderer=/p' \
+    | awk 'NR == 1 { text=$0; next } { text=text " | " $0 } END { print text }')"
+  [[ -n "$summary" ]] && echo "[jvn] GPU probe: $summary" >&2
 }
 
 configure_linux_glx_fallback() {
@@ -165,9 +286,17 @@ cache_is_stale() {
     -newer "$STAMP_FILE" -print -quit | grep -q .
 }
 
+GRAPHICS_MODE="$(requested_graphics_mode)"
+GRAPHICS_MODE_NORMALIZED="$(lowercase "$GRAPHICS_MODE")"
+configure_linux_discrete_gpu
 configure_linux_glx_fallback
+if [[ "$GPU_INFO_ONLY" -eq 1 ]]; then
+  print_gpu_launch_probe
+  exit 0
+fi
 
 if [[ "$MODE" == "gradle" ]]; then
+  print_gpu_launch_probe
   run_gradle "$GRADLE_TASK"
 fi
 
@@ -199,11 +328,10 @@ CLASSPATH="$(join_path_file "$CLASSPATH_FILE")"
 MODULE_PATH="$(join_path_file "$MODULE_PATH_FILE")"
 VERSION="$(sed -n '1p' "$VERSION_FILE")"
 declare -a JAVA_ARGS=("-Djvn.version=$VERSION" "${MODE_PROPS[@]}")
-GRAPHICS_MODE="$(requested_graphics_mode)"
-GRAPHICS_MODE_NORMALIZED="$(lowercase "$GRAPHICS_MODE")"
 HARDWARE_PRISM_ORDER="es2,sw"
 case "$(uname -s 2>/dev/null)" in
   MINGW*|MSYS*|CYGWIN*) HARDWARE_PRISM_ORDER="d3d,es2,sw" ;;
+  Darwin) HARDWARE_PRISM_ORDER="metal,es2,sw" ;;
 esac
 case "$GRAPHICS_MODE_NORMALIZED" in
   gpu|hardware|accelerated|prefer-gpu)
@@ -216,6 +344,14 @@ case "$GRAPHICS_MODE_NORMALIZED" in
     JAVA_ARGS+=("-Djvn.graphics.mode=auto")
     ;;
 esac
+if [[ "$JFR_PROFILE" -eq 1 ]]; then
+  JFR_DIR="${XDG_STATE_HOME:-${HOME:-.}/.local/state}/jvn-engine-hub/profiles"
+  mkdir -p "$JFR_DIR"
+  JFR_FILE="$JFR_DIR/${APP}-$(date '+%Y%m%d-%H%M%S').jfr"
+  JAVA_ARGS+=("-XX:StartFlightRecording=filename=$JFR_FILE,settings=profile,dumponexit=true" \
+    "-Dprism.verbose=true")
+  echo "[jvn] Java Flight Recorder: $JFR_FILE" >&2
+fi
 if [[ -n "${JVN_APP_JAVA_OPTS:-}" ]]; then
   read -r -a USER_JAVA_OPTS <<< "$JVN_APP_JAVA_OPTS"
   JAVA_ARGS+=("${USER_JAVA_OPTS[@]}")
@@ -223,4 +359,5 @@ fi
 if [[ -n "$MODULE_PATH" ]]; then
   JAVA_ARGS+=(--module-path "$MODULE_PATH" --add-modules javafx.controls,javafx.graphics,javafx.base,javafx.media,javafx.swing,javafx.fxml)
 fi
-exec java "${JAVA_ARGS[@]}" -cp "$CLASSPATH" "$MAIN_CLASS" "${APP_ARGS[@]}"
+print_gpu_launch_probe
+exec "${GPU_LAUNCH_PREFIX[@]}" java "${JAVA_ARGS[@]}" -cp "$CLASSPATH" "$MAIN_CLASS" "${APP_ARGS[@]}"


### PR DESCRIPTION
## What changed

- Select platform-native JavaFX hardware pipelines on Windows, macOS, and Linux while retaining a software fallback.
- Prefer the discrete adapter for Hub-managed Linux launches through switcheroo-control, preserving explicit Steam, gamescope, Mesa PRIME, and NVIDIA PRIME settings and using a conservative sysfs fallback.
- Add a Hub render-stack adapter probe and a cross-platform Java Flight Recorder launch action with Prism startup diagnostics.
- Stop reapplying VNS preview UI styles every frame.
- Add stable 60 FPS hardware / 30 FPS software preview pacing with pause clamping and an override property.
- Add a distinct VNS Run from Cursor action that starts at the first executable node at or after the caret while preflighting safe prior state.
- Preserve the existing Run from Current Label and Run from Script Entry workflows as separate toolbar actions.
- Slim the VNS command strip, remove its title/logo block, and replace the blue treatment with editor-matching neutral graphite styling.
- Document GPU verification, JFR locations, and the limits of the current JMH render placeholder.

## Why

A Bazzite user reported that JVN did not use their GPU and that editor VNS previews suffered frequent frame drops, while the standalone runtime performed better. The editor preview was doing avoidable style and asset work every frame, and Linux hybrid-GPU launches did not explicitly request the discrete adapter. The existing launch-from-here behavior also resolved only the nearest label, so it could not start at the blinking caret as expected.

## Impact

Hub-managed launches now provide evidence of the actual OpenGL/Prism renderer, can produce a JFR profile from the UI, and should select a discrete Linux GPU when the desktop is using an integrated adapter. Software-rendered VNS previews perform less work and use a stable frame cap. VNS authors can launch from the exact source area they are editing without losing earlier scene setup, and the editor tool strip consumes less vertical space.

## Validation

- Targeted core, Hub, editor, runtime, JavaFX, preview-pacing, cursor-launch, toolbar-layout, and icon tests pass.
- The cursor-launch test clicks the actual tool-strip button and verifies that a detached preview opens.
- Source-line tests cover exact lines, blank gaps, positions before the first node, and positions after the final node.
- Shell launcher syntax and diff checks pass.
- A real profiled editor launch initialized JavaFX ES2 on an NVIDIA GeForce RTX 5060 Laptop GPU and produced a valid 18-second JFR recording.
- The full 488-test editor suite encountered nine JavaFX timing cascades; every affected test class passed when rerun independently.