### PR TITLE
Fix Puppeteer timeline layer targeting

### DIFF
--- a/docs/editor/puppeteer/puppeteer.md
+++ b/docs/editor/puppeteer/puppeteer.md
@@ -726,6 +726,8 @@ Layered character launches also create expression-specific aliases:
 
 Group transforms are applied before individual layer transforms. This lets authors animate broad motion on `hero_head` while keeping small corrections on `hero_eyes_neutral` or `hero_mouth_smile`.
 
+Puppeteer uses the stable `hero_<layer>` name as the canonical exported track. The expression-specific form remains an alias for importing older timelines. A stable layer target follows that exact layer when it is reused by another expression; it does not automatically transfer to a replacement layer with a different ID. Use an `@chargroup` containing the alternative layer IDs when one transform should follow a semantic part such as every body or arm variant.
+
 ### JES Launch
 
 When launched from a JES file, entity names are the JES entity names:
@@ -750,7 +752,25 @@ timeline {
 }
 ```
 
-**Missing entities are silently skipped** — the runner checks `scene.findEntity(name)` and continues if it returns null.
+For declared layered characters, a timeline may intentionally target a layer or group absent from the current `[show]` composition. The engine pre-arms that proxy and the editor reports a warning so the delayed effect is explicit. When a later expression substitutes a conventionally named variant such as `body_default` → `body_no_limbs` or `arm_front_default` → `arm_front_holding_wrist`, the renderer infers the shared anatomical lane and carries the transform without requiring an `@chargroup`. An explicit group remains available when naming is ambiguous or a project wants to override the inferred lane.
+
+### Contextual timeline diagnostics
+
+The main VNS diagnostics pass and VN runtime share the same composition-aware timeline validator. The editor annotates the quoted target before preview; runtime turns blocking findings into the full-screen **Puppeteer Timeline Diagnostics** overlay and does not create a timeline runner or proxy.
+
+| Diagnostic | Result | Suggested correction |
+|------------|--------|----------------------|
+| Character is not currently shown | Playback blocked | Move the timeline after the relevant `[show]` |
+| Declared layer is absent from the active composition | Warning; transform is pre-armed | Keep it when intentional, or move the timeline after `[show]` to preview it immediately |
+| Declared group has no visible member | Warning; transform is pre-armed | Keep it when intentional, or show a member first |
+| Expression-qualified alias belongs to another composition | Compatibility warning | Prefer the stable `character_layer` or `character_group` name |
+| Character-prefixed target matches no declared layer/group | Playback blocked | Correct the spelling or declare the intended group |
+| Expression-specific target is valid now | Warning | Prefer the stable target if the animation should survive expression changes |
+| Exact layer has replacement variants | Advisory | The renderer infers a unique anatomical lane; use `@chargroup` only to resolve ambiguity or override it |
+| Layer disappears in another expression | Warning | Its state persists and follows a uniquely inferred replacement; reset it when that persistence is unwanted |
+| Non-zero animation ends within one 60 Hz frame | Warning | Use more than `17ms` for visible interpolation, or `0ms` for an intentional cut |
+
+Blocking validation also applies between chained timelines. If a later chain member becomes invalid after an event or expression change, the chain stops safely and releases a waiting VNS call instead of creating dormant state or deadlocking playback.
 
 ---
 
@@ -907,6 +927,7 @@ Apply a preset, then refine: change easing curves, adjust timing, modify target 
 | Entity snaps to position | Missing starting keyframe | Add a `dur: 0` keyframe at the initial position before the animation |
 | Jittery movement | Two timelines animating the same property | Avoid overlapping timelines on the same entity/property |
 | Animation too fast/slow | Duration mismatch | Check `dur` values; ensure `[wait]` values in VNS match the timeline duration |
+| Animation jumps straight to its result | Duration is shorter than one display frame | Durations are milliseconds; use more than `17ms` for a visible transition, or `0ms` for an intentional instant change |
 | Easing feels wrong | Wrong easing direction | `ease_in_*` accelerates, `ease_out_*` decelerates — most entrances want `ease_out_*` |
 | Alpha has no effect | Non-Sprite2D entity | Alpha only works on `Sprite2D`, `Label2D`, `Panel2D`, and `CharacterEntity2D` |
 

--- a/modules/core/src/main/java/com/jvn/core/animation/TimelineDataDiagnostics.java
+++ b/modules/core/src/main/java/com/jvn/core/animation/TimelineDataDiagnostics.java
@@ -17,6 +17,7 @@ import java.util.Set;
  */
 public final class TimelineDataDiagnostics {
     private static final double TIME_EPSILON_MS = 0.001;
+    private static final double SINGLE_FRAME_MS = 1000.0 / 60.0;
     private static final String CAMERA_TRACK = "__camera__";
 
     public enum Severity {
@@ -118,6 +119,7 @@ public final class TimelineDataDiagnostics {
             }
 
             boolean cameraTrack = CAMERA_TRACK.equals(target);
+            boolean subFrameWarningAdded = false;
             for (Map.Entry<TimelineData.Property, List<TimelineData.Keyframe>> entry : track.getAllKeyframes().entrySet()) {
                 TimelineData.Property property = entry.getKey();
                 if (property == null) {
@@ -145,6 +147,15 @@ public final class TimelineDataDiagnostics {
                     ));
                 }
                 diagnoseKeyframes(target, property.name(), property, entry.getValue(), durationMs, messages);
+                if (!subFrameWarningAdded && finishesWithinOneFrame(entry.getValue())) {
+                    messages.add(new Message(
+                        Severity.WARNING,
+                        target,
+                        "Animation finishes within one 60 Hz display frame and may appear instant",
+                        "Use a duration above 17ms for a visible transition, or 0ms for an intentional instant change"
+                    ));
+                    subFrameWarningAdded = true;
+                }
             }
             for (Map.Entry<String, List<TimelineData.Keyframe>> entry : track.getAllCustomKeyframes().entrySet()) {
                 String key = entry.getKey();
@@ -158,8 +169,28 @@ public final class TimelineDataDiagnostics {
                     continue;
                 }
                 diagnoseKeyframes(target, key, null, entry.getValue(), durationMs, messages);
+                if (!subFrameWarningAdded && finishesWithinOneFrame(entry.getValue())) {
+                    messages.add(new Message(
+                        Severity.WARNING,
+                        target,
+                        "Animation finishes within one 60 Hz display frame and may appear instant",
+                        "Use a duration above 17ms for a visible transition, or 0ms for an intentional instant change"
+                    ));
+                    subFrameWarningAdded = true;
+                }
             }
         }
+    }
+
+    private static boolean finishesWithinOneFrame(List<TimelineData.Keyframe> keyframes) {
+        if (keyframes == null || keyframes.isEmpty()) return false;
+        double latest = 0.0;
+        for (TimelineData.Keyframe keyframe : keyframes) {
+            if (keyframe != null && Double.isFinite(keyframe.getTimeMs())) {
+                latest = Math.max(latest, keyframe.getTimeMs());
+            }
+        }
+        return latest > TIME_EPSILON_MS && latest < SINGLE_FRAME_MS;
     }
 
     private static void diagnoseKeyframes(

--- a/modules/core/src/main/java/com/jvn/core/vn/DefaultVnInterop.java
+++ b/modules/core/src/main/java/com/jvn/core/vn/DefaultVnInterop.java
@@ -262,8 +262,7 @@ public class DefaultVnInterop implements VnInterop {
     try {
       String name = "_inline_timeline_" + (++inlineTimelineCounter);
       TimelineData data = TimelineDataParser.parse(name, invocation.block());
-      startTimelinePlayback(data, scene, blocking, invocation.chain());
-      started = true;
+      started = startTimelinePlayback(data, scene, blocking, invocation.chain());
     } catch (Exception ex) {
       scene.getState().showHudMessage("inline timeline error: " + ex.getMessage(), 2000);
       scene.setActiveError(VnErrorOverlay.puppeteerJesParseError(
@@ -293,8 +292,8 @@ public class DefaultVnInterop implements VnInterop {
       return VnInteropResult.advance();
     }
     boolean blocking = forceBlocking || invocation.waitForCompletion();
-    startTimelinePlayback(data, scene, blocking, invocation.chain());
-    return blocking ? VnInteropResult.block() : VnInteropResult.advance();
+    boolean started = startTimelinePlayback(data, scene, blocking, invocation.chain());
+    return started && blocking ? VnInteropResult.block() : VnInteropResult.advance();
   }
 
   private void handleVar(String payload, VnScene scene) {
@@ -1168,14 +1167,14 @@ public class DefaultVnInterop implements VnInterop {
     return VnInteropResult.advance();
   }
 
-  private void startTimelinePlayback(
+  private boolean startTimelinePlayback(
       TimelineData data,
       VnScene scene,
       boolean waitForCompletion,
       List<String> chain
   ) {
-    if (data == null || scene == null) return;
-    reportInactiveTimelineLayerTargets(data, scene);
+    if (data == null || scene == null) return false;
+    if (!validateActiveTimelineLayerTargets(data, scene)) return false;
     recordTimelineDisplacements(data, scene);
     final boolean[] completed = {false};
     TimelineRunner runner = createTimelineRunnerChain(data, scene, chain, 0, completed);
@@ -1183,6 +1182,7 @@ public class DefaultVnInterop implements VnInterop {
     if (waitForCompletion) {
       scene.beginInteropBlock(() -> completed[0]);
     }
+    return true;
   }
 
   private TimelineRunner createTimelineRunnerChain(
@@ -1199,7 +1199,10 @@ public class DefaultVnInterop implements VnInterop {
         completed[0] = true;
         return;
       }
-      reportInactiveTimelineLayerTargets(next.get(), scene);
+      if (!validateActiveTimelineLayerTargets(next.get(), scene)) {
+        completed[0] = true;
+        return;
+      }
       recordTimelineDisplacements(next.get(), scene);
       TimelineRunner nextRunner = createTimelineRunnerChain(next.get(), scene, chain, index + 1, completed);
       scene.getState().addTimelineRunner(nextRunner);
@@ -1207,86 +1210,35 @@ public class DefaultVnInterop implements VnInterop {
     return runner;
   }
 
-  private void reportInactiveTimelineLayerTargets(TimelineData data, VnScene scene) {
-    if (data == null || scene == null || scene.getScenario() == null || scene.getState() == null) return;
+  private boolean validateActiveTimelineLayerTargets(TimelineData data, VnScene scene) {
+    if (data == null || scene == null || scene.getState() == null) return true;
     VnState state = scene.getState();
-    LinkedHashSet<String> inactiveTargets = new LinkedHashSet<>();
-
-    for (TimelineData.Track track : data.getTracks()) {
-      if (track == null || track.getEntityName() == null || track.getEntityName().isBlank()) continue;
-      String target = track.getEntityName().trim();
-      for (VnState.CharacterSlot slot : state.getVisibleCharacters().values()) {
-        if (slot == null || slot.getCharacterId() == null || slot.getCharacterId().isBlank()) continue;
-        VnCharacter character = scene.getScenario().getCharacter(slot.getCharacterId());
-        if (character == null || character.getLayerIds().isEmpty()) continue;
-        String safeCharacter = selectorSafeName(slot.getCharacterId());
-        if (safeCharacter.isBlank() || !target.startsWith(safeCharacter + "_")) continue;
-
-        Set<String> activeLayers = new LinkedHashSet<>();
-        for (String layerId : character.getExpressionLayerIds(slot.getExpression())) {
-          String safeLayer = selectorSafeName(layerId);
-          if (!safeLayer.isBlank()) activeLayers.add(safeLayer);
-        }
-        if (targetsInactiveDeclaredLayer(target, safeCharacter, slot.getExpression(), character, activeLayers)
-            || targetsInactiveDeclaredGroup(target, safeCharacter, slot.getExpression(), character, activeLayers)) {
-          inactiveTargets.add(target);
-        }
-        break;
-      }
-    }
-
-    if (inactiveTargets.isEmpty()) return;
-    String targets = String.join(", ", inactiveTargets);
-    String message = "Timeline target" + (inactiveTargets.size() == 1 ? " is" : "s are")
-        + " not present in the currently shown character layers: " + targets;
-    String likelyCause = "The preceding [show] command uses a different layer composition. "
-        + "Add these layers to that [show], or retarget the timeline to layers that are currently visible.";
-    VnNode node = state.getCurrentNode();
-    int line = node == null ? -1 : node.getSourceLine();
-    scene.setActiveError(VnErrorOverlay.puppeteerTimelineTargetError(
-        state.getSourceScriptName(), line, message, likelyCause, targets));
-  }
-
-  private boolean targetsInactiveDeclaredLayer(String target,
-                                               String safeCharacter,
-                                               String expression,
-                                               VnCharacter character,
-                                               Set<String> activeLayers) {
-    String safeExpression = selectorSafeName(expression == null || expression.isBlank() ? "neutral" : expression);
-    for (String layerId : character.getLayerIds()) {
-      String safeLayer = selectorSafeName(layerId);
-      if (safeLayer.isBlank()) continue;
-      String stableTarget = safeCharacter + "_" + safeLayer;
-      String activeExpressionTarget = safeCharacter + "_" + safeExpression + "_" + safeLayer;
-      if (target.equals(stableTarget) || target.equals(activeExpressionTarget)) {
-        return !activeLayers.contains(safeLayer);
-      }
-      if (target.endsWith("_" + safeLayer) && target.startsWith(safeCharacter + "_")
-          && !target.equals(activeExpressionTarget)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private boolean targetsInactiveDeclaredGroup(String target,
-                                               String safeCharacter,
-                                               String expression,
-                                               VnCharacter character,
-                                               Set<String> activeLayers) {
-    String safeExpression = selectorSafeName(expression == null || expression.isBlank() ? "neutral" : expression);
-    for (VnCharacter.LayerGroup group : character.getLayerGroups().values()) {
-      if (group == null) continue;
-      String safeGroup = selectorSafeName(group.id());
-      if (safeGroup.isBlank()) continue;
-      String stableTarget = safeCharacter + "_" + safeGroup;
-      String activeExpressionTarget = safeCharacter + "_" + safeExpression + "_" + safeGroup;
-      if (!target.equals(stableTarget) && !target.equals(activeExpressionTarget)) continue;
-      for (String member : group.layerIds()) {
-        if (activeLayers.contains(selectorSafeName(member))) return false;
-      }
+    VnTimelineDiagnostics.Report report = VnTimelineDiagnostics.diagnose(
+        data, scene.getScenario(), state);
+    if (!report.blocksPlayback()) {
+      report.findings().stream()
+          .filter(finding -> finding.severity() == VnTimelineDiagnostics.Severity.WARNING)
+          .findFirst()
+          .ifPresent(finding -> state.showHudMessage("Timeline warning: " + finding.description(), 3200));
       return true;
     }
+    List<VnTimelineDiagnostics.Finding> blockers = report.blockingFindings();
+    String message = blockers.stream()
+        .map(finding -> "[" + finding.code() + "] " + finding.target() + ": " + finding.description())
+        .collect(java.util.stream.Collectors.joining("\n"));
+    String likelyCause = blockers.stream()
+        .map(VnTimelineDiagnostics.Finding::quickFix)
+        .filter(fix -> fix != null && !fix.isBlank())
+        .distinct()
+        .collect(java.util.stream.Collectors.joining(" "));
+    String targets = blockers.stream()
+        .map(VnTimelineDiagnostics.Finding::target)
+        .distinct()
+        .collect(java.util.stream.Collectors.joining(", "));
+    VnNode node = state.getCurrentNode();
+    int line = node == null ? -1 : node.getSourceLine();
+    scene.setActiveError(VnErrorOverlay.puppeteerTimelineDiagnosticsError(
+        state.getSourceScriptName(), line, message, likelyCause, targets));
     return false;
   }
 
@@ -1300,10 +1252,18 @@ public class DefaultVnInterop implements VnInterop {
       String characterId = resolveTimelineTrackCharacter(track.getEntityName(), state);
       if (characterId == null || characterId.isBlank()) continue;
       boolean characterTrack = track.getEntityName() != null && track.getEntityName().trim().equals(characterId);
+      VnCharacter character = scene.getScenario() == null
+          ? null
+          : scene.getScenario().getCharacter(characterId);
+      // Layered characters are rendered from their exact layer/group proxies.
+      // Promoting several layer tracks to one character-wide transform makes
+      // unrelated layers inherit the animation and lets hidden targets surface
+      // after a later [show]. Keep the old fallback only for non-layered sprites.
+      boolean recordCharacterState = characterTrack || character == null || character.getLayerIds().isEmpty();
 
       boolean hasX = track.hasKeyframes(TimelineData.Property.X);
       boolean hasY = track.hasKeyframes(TimelineData.Property.Y);
-      if (hasX || hasY) {
+      if (recordCharacterState && (hasX || hasY)) {
         double x = hasX ? lastKeyframeValue(track, TimelineData.Property.X) : 0.0;
         double y = hasY ? lastKeyframeValue(track, TimelineData.Property.Y) : 0.0;
         displacements
@@ -1317,7 +1277,8 @@ public class DefaultVnInterop implements VnInterop {
       boolean hasRotation = track.hasKeyframes(TimelineData.Property.ROTATION);
       boolean hasPivotX = track.hasKeyframes(TimelineData.Property.PIVOT_X);
       boolean hasPivotY = track.hasKeyframes(TimelineData.Property.PIVOT_Y);
-      if (!hasScaleX && !hasScaleY && !hasMirrorX && !hasRotation && !hasPivotX && !hasPivotY) continue;
+      if (!recordCharacterState
+          || (!hasScaleX && !hasScaleY && !hasMirrorX && !hasRotation && !hasPivotX && !hasPivotY)) continue;
 
       double scaleX = 1.0;
       if (hasScaleX || hasMirrorX) {

--- a/modules/core/src/main/java/com/jvn/core/vn/DefaultVnInterop.java
+++ b/modules/core/src/main/java/com/jvn/core/vn/DefaultVnInterop.java
@@ -1175,6 +1175,7 @@ public class DefaultVnInterop implements VnInterop {
       List<String> chain
   ) {
     if (data == null || scene == null) return;
+    reportInactiveTimelineLayerTargets(data, scene);
     recordTimelineDisplacements(data, scene);
     final boolean[] completed = {false};
     TimelineRunner runner = createTimelineRunnerChain(data, scene, chain, 0, completed);
@@ -1198,11 +1199,95 @@ public class DefaultVnInterop implements VnInterop {
         completed[0] = true;
         return;
       }
+      reportInactiveTimelineLayerTargets(next.get(), scene);
       recordTimelineDisplacements(next.get(), scene);
       TimelineRunner nextRunner = createTimelineRunnerChain(next.get(), scene, chain, index + 1, completed);
       scene.getState().addTimelineRunner(nextRunner);
     });
     return runner;
+  }
+
+  private void reportInactiveTimelineLayerTargets(TimelineData data, VnScene scene) {
+    if (data == null || scene == null || scene.getScenario() == null || scene.getState() == null) return;
+    VnState state = scene.getState();
+    LinkedHashSet<String> inactiveTargets = new LinkedHashSet<>();
+
+    for (TimelineData.Track track : data.getTracks()) {
+      if (track == null || track.getEntityName() == null || track.getEntityName().isBlank()) continue;
+      String target = track.getEntityName().trim();
+      for (VnState.CharacterSlot slot : state.getVisibleCharacters().values()) {
+        if (slot == null || slot.getCharacterId() == null || slot.getCharacterId().isBlank()) continue;
+        VnCharacter character = scene.getScenario().getCharacter(slot.getCharacterId());
+        if (character == null || character.getLayerIds().isEmpty()) continue;
+        String safeCharacter = selectorSafeName(slot.getCharacterId());
+        if (safeCharacter.isBlank() || !target.startsWith(safeCharacter + "_")) continue;
+
+        Set<String> activeLayers = new LinkedHashSet<>();
+        for (String layerId : character.getExpressionLayerIds(slot.getExpression())) {
+          String safeLayer = selectorSafeName(layerId);
+          if (!safeLayer.isBlank()) activeLayers.add(safeLayer);
+        }
+        if (targetsInactiveDeclaredLayer(target, safeCharacter, slot.getExpression(), character, activeLayers)
+            || targetsInactiveDeclaredGroup(target, safeCharacter, slot.getExpression(), character, activeLayers)) {
+          inactiveTargets.add(target);
+        }
+        break;
+      }
+    }
+
+    if (inactiveTargets.isEmpty()) return;
+    String targets = String.join(", ", inactiveTargets);
+    String message = "Timeline target" + (inactiveTargets.size() == 1 ? " is" : "s are")
+        + " not present in the currently shown character layers: " + targets;
+    String likelyCause = "The preceding [show] command uses a different layer composition. "
+        + "Add these layers to that [show], or retarget the timeline to layers that are currently visible.";
+    VnNode node = state.getCurrentNode();
+    int line = node == null ? -1 : node.getSourceLine();
+    scene.setActiveError(VnErrorOverlay.puppeteerTimelineTargetError(
+        state.getSourceScriptName(), line, message, likelyCause, targets));
+  }
+
+  private boolean targetsInactiveDeclaredLayer(String target,
+                                               String safeCharacter,
+                                               String expression,
+                                               VnCharacter character,
+                                               Set<String> activeLayers) {
+    String safeExpression = selectorSafeName(expression == null || expression.isBlank() ? "neutral" : expression);
+    for (String layerId : character.getLayerIds()) {
+      String safeLayer = selectorSafeName(layerId);
+      if (safeLayer.isBlank()) continue;
+      String stableTarget = safeCharacter + "_" + safeLayer;
+      String activeExpressionTarget = safeCharacter + "_" + safeExpression + "_" + safeLayer;
+      if (target.equals(stableTarget) || target.equals(activeExpressionTarget)) {
+        return !activeLayers.contains(safeLayer);
+      }
+      if (target.endsWith("_" + safeLayer) && target.startsWith(safeCharacter + "_")
+          && !target.equals(activeExpressionTarget)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private boolean targetsInactiveDeclaredGroup(String target,
+                                               String safeCharacter,
+                                               String expression,
+                                               VnCharacter character,
+                                               Set<String> activeLayers) {
+    String safeExpression = selectorSafeName(expression == null || expression.isBlank() ? "neutral" : expression);
+    for (VnCharacter.LayerGroup group : character.getLayerGroups().values()) {
+      if (group == null) continue;
+      String safeGroup = selectorSafeName(group.id());
+      if (safeGroup.isBlank()) continue;
+      String stableTarget = safeCharacter + "_" + safeGroup;
+      String activeExpressionTarget = safeCharacter + "_" + safeExpression + "_" + safeGroup;
+      if (!target.equals(stableTarget) && !target.equals(activeExpressionTarget)) continue;
+      for (String member : group.layerIds()) {
+        if (activeLayers.contains(selectorSafeName(member))) return false;
+      }
+      return true;
+    }
+    return false;
   }
 
   private void recordTimelineDisplacements(TimelineData data, VnScene scene) {

--- a/modules/core/src/main/java/com/jvn/core/vn/LayeredCharacterResolver.java
+++ b/modules/core/src/main/java/com/jvn/core/vn/LayeredCharacterResolver.java
@@ -1,6 +1,8 @@
 package com.jvn.core.vn;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -12,6 +14,12 @@ import java.util.Set;
  */
 public final class LayeredCharacterResolver {
   private static final char[] GROUP_VARIANT_SEPARATORS = {'_', '-', '/', '.', ':'};
+  private static final Set<String> ANATOMICAL_TOKENS = Set.of(
+      "body", "neck", "head", "face", "mouth", "eye", "eyes", "brow", "brows",
+      "hair", "arm", "arms", "hand", "hands", "leg", "legs", "foot", "feet",
+      "torso", "chest", "hip", "hips", "shoulder", "shoulders");
+  private static final Set<String> LANE_MODIFIERS = Set.of(
+      "front", "behind", "back", "rear", "left", "right", "upper", "lower");
 
   private LayeredCharacterResolver() {
   }
@@ -76,6 +84,74 @@ public final class LayeredCharacterResolver {
     return new ArrayList<>(candidates);
   }
 
+  /**
+   * Infer which previously animated declared layer is the replacement lane for
+   * a newly visible layer. Returns {@code null} when no safe, unique match exists.
+   * Explicit {@code @chargroup} metadata remains authoritative; this is the
+   * convention-based fallback for projects with many one-off sprite variants.
+   */
+  public static String inferReplacementLayerId(
+      String activeLayerId,
+      Collection<String> animatedLayerIds
+  ) {
+    if (activeLayerId == null || activeLayerId.isBlank()
+        || animatedLayerIds == null || animatedLayerIds.isEmpty()) {
+      return null;
+    }
+    String active = activeLayerId.trim();
+    String activeLane = replacementLane(active);
+    if (activeLane.isBlank()) return null;
+
+    List<ReplacementCandidate> candidates = new ArrayList<>();
+    for (String rawCandidate : animatedLayerIds) {
+      if (rawCandidate == null || rawCandidate.isBlank()) continue;
+      String candidate = rawCandidate.trim();
+      if (active.equals(candidate) || !activeLane.equals(replacementLane(candidate))) continue;
+      candidates.add(new ReplacementCandidate(candidate, replacementScore(active, candidate)));
+    }
+    if (candidates.isEmpty()) return null;
+    candidates.sort(Comparator
+        .comparingInt(ReplacementCandidate::score).reversed()
+        .thenComparing(ReplacementCandidate::layerId));
+    ReplacementCandidate best = candidates.get(0);
+    if (candidates.size() > 1 && candidates.get(1).score() == best.score()) return null;
+    return best.layerId();
+  }
+
+  public static String replacementLane(String rawLayerId) {
+    List<String> tokens = layerTokens(rawLayerId);
+    if (tokens.isEmpty()) return "";
+    for (int i = 0; i < tokens.size(); i++) {
+      String token = tokens.get(i);
+      if (!ANATOMICAL_TOKENS.contains(token)) continue;
+      if (i + 1 < tokens.size() && LANE_MODIFIERS.contains(tokens.get(i + 1))) {
+        return token + "_" + tokens.get(i + 1);
+      }
+      return token;
+    }
+    return tokens.get(0);
+  }
+
+  private static int replacementScore(String left, String right) {
+    List<String> a = layerTokens(left);
+    List<String> b = layerTokens(right);
+    int prefix = 0;
+    while (prefix < a.size() && prefix < b.size() && a.get(prefix).equals(b.get(prefix))) prefix++;
+    Set<String> shared = new LinkedHashSet<>(a);
+    shared.retainAll(b);
+    return prefix * 100 + shared.size();
+  }
+
+  private static List<String> layerTokens(String rawLayerId) {
+    String normalized = rawLayerId == null ? "" : rawLayerId.trim().toLowerCase(java.util.Locale.ROOT);
+    if (normalized.isBlank()) return List.of();
+    List<String> tokens = new ArrayList<>();
+    for (String token : normalized.split("[^a-z0-9]+")) {
+      if (!token.isBlank()) tokens.add(token);
+    }
+    return tokens;
+  }
+
   private static int characterSeparatorIndex(String ref, int eqIndex) {
     if (ref == null || ref.isBlank()) {
       return -1;
@@ -132,4 +208,5 @@ public final class LayeredCharacterResolver {
   }
 
   private record GroupVariant(String groupId, String variantId) {}
+  private record ReplacementCandidate(String layerId, int score) {}
 }

--- a/modules/core/src/main/java/com/jvn/core/vn/VnCharacter.java
+++ b/modules/core/src/main/java/com/jvn/core/vn/VnCharacter.java
@@ -64,6 +64,9 @@ public class VnCharacter {
     }
     return ids == null ? List.of() : ids;
   }
+  public Map<String, List<String>> getExpressionLayerIdsByName() {
+    return Map.copyOf(expressionLayerIds);
+  }
   public LayerGroup getLayerGroup(String groupId) {
     if (groupId == null || groupId.isBlank()) return null;
     return layerGroups.get(groupId.trim());

--- a/modules/core/src/main/java/com/jvn/core/vn/VnErrorOverlay.java
+++ b/modules/core/src/main/java/com/jvn/core/vn/VnErrorOverlay.java
@@ -161,6 +161,20 @@ public class VnErrorOverlay {
         null);
   }
 
+  public static VnErrorOverlay puppeteerTimelineDiagnosticsError(String sourceName, int line,
+                                                                 String message, String likelyCause,
+                                                                 String rawTimeline) {
+    return new VnErrorOverlay(
+        ErrorType.DSL_RUNTIME_ERROR,
+        "Puppeteer Timeline Diagnostics",
+        message == null || message.isBlank() ? "Timeline validation blocked unsafe playback" : message,
+        sourceName,
+        line,
+        likelyCause,
+        rawTimeline,
+        null);
+  }
+
   public static VnErrorOverlay fromScriptLoadFailure(String fallbackSource, Exception cause) {
     if (cause instanceof MultipleParseErrorsException multi) {
       return fromMultipleParseErrors(fallbackSource, multi);

--- a/modules/core/src/main/java/com/jvn/core/vn/VnErrorOverlay.java
+++ b/modules/core/src/main/java/com/jvn/core/vn/VnErrorOverlay.java
@@ -147,6 +147,20 @@ public class VnErrorOverlay {
         cause);
   }
 
+  public static VnErrorOverlay puppeteerTimelineTargetError(String sourceName, int line,
+                                                            String message, String likelyCause,
+                                                            String rawTimeline) {
+    return new VnErrorOverlay(
+        ErrorType.DSL_RUNTIME_ERROR,
+        "Puppeteer Timeline Target Error",
+        message == null || message.isBlank() ? "Timeline target is not visible" : message,
+        sourceName,
+        line,
+        likelyCause,
+        rawTimeline,
+        null);
+  }
+
   public static VnErrorOverlay fromScriptLoadFailure(String fallbackSource, Exception cause) {
     if (cause instanceof MultipleParseErrorsException multi) {
       return fromMultipleParseErrors(fallbackSource, multi);

--- a/modules/core/src/main/java/com/jvn/core/vn/VnScenario.java
+++ b/modules/core/src/main/java/com/jvn/core/vn/VnScenario.java
@@ -47,6 +47,7 @@ public class VnScenario {
     return best;
   }
   public VnCharacter getCharacter(String id) { return characters.get(id); }
+  public Map<String, VnCharacter> getCharacters() { return Map.copyOf(characters); }
   public VnBackground getBackground(String id) { return backgrounds.get(id); }
   public VnStagePreset getStagePreset(String id) { return stagePresets.get(id); }
   public Map<String, VnStagePreset> getStagePresets() { return stagePresets; }

--- a/modules/core/src/main/java/com/jvn/core/vn/VnTimelineDiagnostics.java
+++ b/modules/core/src/main/java/com/jvn/core/vn/VnTimelineDiagnostics.java
@@ -1,0 +1,370 @@
+package com.jvn.core.vn;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.jvn.core.animation.TimelineData;
+import com.jvn.core.animation.TimelineDataDiagnostics;
+
+/**
+ * Context-aware diagnostics for timelines played inside a VN scene.
+ *
+ * <p>The general {@link TimelineDataDiagnostics} pass validates timeline data.
+ * This pass adds the character composition information that only VNS knows:
+ * which characters are currently rendered, which layer IDs are active, and
+ * which stable layer/group targets the renderer can actually resolve.</p>
+ */
+public final class VnTimelineDiagnostics {
+  public enum Severity { INFO, WARNING, ERROR }
+
+  public enum Code {
+    TIMELINE_DATA,
+    CHARACTER_NOT_VISIBLE,
+    DEFERRED_LAYER_TARGET,
+    DEFERRED_GROUP_TARGET,
+    STALE_EXPRESSION_ALIAS,
+    EXPRESSION_SPECIFIC_TARGET,
+    UNKNOWN_CHARACTER_TARGET,
+    EXACT_LAYER_REPLACEMENT_SCOPE,
+    PERSISTENT_LAYER_STATE
+  }
+
+  public record Finding(
+      Code code,
+      Severity severity,
+      String target,
+      String description,
+      String quickFix,
+      boolean blocksPlayback
+  ) {
+    public Finding {
+      code = code == null ? Code.TIMELINE_DATA : code;
+      severity = severity == null ? Severity.INFO : severity;
+      target = target == null || target.isBlank() ? "(timeline)" : target.trim();
+      description = description == null ? "" : description.trim();
+      quickFix = quickFix == null || quickFix.isBlank() ? null : quickFix.trim();
+    }
+  }
+
+  public record Report(List<Finding> findings) {
+    public Report {
+      findings = findings == null ? List.of() : List.copyOf(findings);
+    }
+
+    public boolean blocksPlayback() {
+      return findings.stream().anyMatch(Finding::blocksPlayback);
+    }
+
+    public List<Finding> blockingFindings() {
+      return findings.stream().filter(Finding::blocksPlayback).toList();
+    }
+
+    public long warningCount() {
+      return findings.stream().filter(finding -> finding.severity() == Severity.WARNING).count();
+    }
+  }
+
+  private record CharacterContext(
+      String characterId,
+      String safeCharacter,
+      String expression,
+      String safeExpression,
+      VnCharacter character,
+      Set<String> activeLayers,
+      boolean visible
+  ) {
+  }
+
+  private VnTimelineDiagnostics() {
+  }
+
+  public static Report diagnose(TimelineData data, VnScenario scenario, VnState state) {
+    List<Finding> findings = new ArrayList<>();
+    addTimelineDataFindings(data, findings);
+    if (data == null || scenario == null || state == null) {
+      return new Report(findings);
+    }
+
+    Map<String, VnState.CharacterSlot> activeSlots = activeSlotsByCharacter(state);
+    List<CharacterContext> contexts = new ArrayList<>();
+    for (VnCharacter character : scenario.getCharacters().values()) {
+      if (character == null || character.getId() == null || character.getId().isBlank()) continue;
+      VnState.CharacterSlot slot = activeSlots.get(character.getId());
+      String expression = slot == null || slot.getExpression() == null || slot.getExpression().isBlank()
+          ? "neutral"
+          : slot.getExpression();
+      Set<String> activeLayers = new LinkedHashSet<>();
+      if (slot != null) {
+        for (String layerId : character.getExpressionLayerIds(expression)) {
+          String safeLayer = selectorSafeName(layerId);
+          if (!safeLayer.isBlank()) activeLayers.add(safeLayer);
+        }
+      }
+      contexts.add(new CharacterContext(
+          character.getId(),
+          selectorSafeName(character.getId()),
+          expression,
+          selectorSafeName(expression),
+          character,
+          Collections.unmodifiableSet(activeLayers),
+          slot != null));
+    }
+    contexts.sort(Comparator.comparingInt((CharacterContext context) -> context.safeCharacter().length()).reversed());
+
+    Set<String> diagnosedTargets = new LinkedHashSet<>();
+    for (TimelineData.Track track : data.getTracks()) {
+      if (track == null || track.getEntityName() == null || track.getEntityName().isBlank()) continue;
+      String target = track.getEntityName().trim();
+      if (!diagnosedTargets.add(target) || target.startsWith("__")) continue;
+      diagnoseTarget(target, contexts, findings);
+    }
+    return new Report(findings);
+  }
+
+  private static void diagnoseTarget(
+      String target,
+      List<CharacterContext> contexts,
+      List<Finding> findings
+  ) {
+    for (CharacterContext context : contexts) {
+      if (context.safeCharacter().isBlank()) continue;
+      if (target.equals(context.characterId()) || target.equals(context.safeCharacter())) {
+        if (!context.visible()) {
+          findings.add(blocking(
+              Code.CHARACTER_NOT_VISIBLE,
+              target,
+              "Timeline targets character '" + context.characterId() + "', but that character is not currently shown",
+              "Move the timeline after [show " + context.characterId() + " ...], or remove this target"));
+        }
+        return;
+      }
+      if (!target.startsWith(context.safeCharacter() + "_")) continue;
+
+      if (!context.visible()) {
+        findings.add(blocking(
+            Code.CHARACTER_NOT_VISIBLE,
+            target,
+            "Timeline targets a layer of character '" + context.characterId() + "', but that character is not currently shown",
+            "Move the timeline after [show " + context.characterId() + " ...]"));
+        return;
+      }
+      if (context.character().getLayerIds().isEmpty()) return;
+
+      if (diagnoseDeclaredLayer(target, context, findings)) return;
+      if (diagnoseDeclaredGroup(target, context, findings)) return;
+
+      findings.add(blocking(
+          Code.UNKNOWN_CHARACTER_TARGET,
+          target,
+          "Timeline target looks like part of '" + context.characterId()
+              + "' but does not match a declared layer or layer group",
+          "Choose a stable target named " + context.safeCharacter()
+              + "_<layer>, declare an @chargroup, or correct the target spelling"));
+      return;
+    }
+  }
+
+  private static boolean diagnoseDeclaredLayer(
+      String target,
+      CharacterContext context,
+      List<Finding> findings
+  ) {
+    for (String layerId : context.character().getLayerIds()) {
+      String safeLayer = selectorSafeName(layerId);
+      if (safeLayer.isBlank()) continue;
+      String stableTarget = context.safeCharacter() + "_" + safeLayer;
+      String currentTarget = context.safeCharacter() + "_" + context.safeExpression() + "_" + safeLayer;
+      boolean exactStable = target.equals(stableTarget);
+      boolean exactCurrent = target.equals(currentTarget);
+      boolean expressionAlias = target.startsWith(context.safeCharacter() + "_")
+          && target.endsWith("_" + safeLayer);
+      if (!exactStable && !exactCurrent && !expressionAlias) continue;
+
+      if (!context.activeLayers().contains(safeLayer)) {
+        findings.add(new Finding(
+            Code.DEFERRED_LAYER_TARGET,
+            Severity.WARNING,
+            target,
+            "Declared layer '" + layerId + "' is not visible yet; its transform will be pre-armed for a later compatible [show]",
+            "Keep this when intentional, or move the timeline after the compatible [show] to preview the motion immediately",
+            false));
+        return true;
+      }
+      if (!exactStable && !exactCurrent) {
+        findings.add(new Finding(
+            Code.STALE_EXPRESSION_ALIAS,
+            Severity.WARNING,
+            target,
+            "Expression-qualified layer alias belongs to another composition and is being retained for compatibility",
+            "Replace it with the stable target '" + stableTarget + "'",
+            false));
+        return true;
+      }
+
+      if (exactCurrent && !currentTarget.equals(stableTarget)) {
+        findings.add(new Finding(
+            Code.EXPRESSION_SPECIFIC_TARGET,
+            Severity.WARNING,
+            target,
+            "Expression-qualified layer target only resolves while '" + context.expression() + "' is shown",
+            "Prefer the stable target '" + stableTarget + "' for shared layers",
+            false));
+      }
+
+      addExactLayerScopeWarning(layerId, stableTarget, context, findings);
+      addPersistentLayerStateWarning(layerId, stableTarget, context, findings);
+      return true;
+    }
+    return false;
+  }
+
+  private static boolean diagnoseDeclaredGroup(
+      String target,
+      CharacterContext context,
+      List<Finding> findings
+  ) {
+    for (VnCharacter.LayerGroup group : context.character().getLayerGroups().values()) {
+      if (group == null) continue;
+      String safeGroup = selectorSafeName(group.id());
+      if (safeGroup.isBlank()) continue;
+      String stableTarget = context.safeCharacter() + "_" + safeGroup;
+      String currentTarget = context.safeCharacter() + "_" + context.safeExpression() + "_" + safeGroup;
+      boolean exactStable = target.equals(stableTarget);
+      boolean exactCurrent = target.equals(currentTarget);
+      boolean expressionAlias = target.startsWith(context.safeCharacter() + "_")
+          && target.endsWith("_" + safeGroup);
+      if (!exactStable && !exactCurrent && !expressionAlias) continue;
+
+      boolean memberVisible = group.layerIds().stream()
+          .map(VnTimelineDiagnostics::selectorSafeName)
+          .anyMatch(context.activeLayers()::contains);
+      if (!memberVisible) {
+        findings.add(new Finding(
+            Code.DEFERRED_GROUP_TARGET,
+            Severity.WARNING,
+            target,
+            "Layer group '" + group.id() + "' has no visible member yet; its transform will be pre-armed",
+            "Keep this when intentional, or move the timeline after a compatible [show]",
+            false));
+        return true;
+      }
+      if (!exactStable && !exactCurrent) {
+        findings.add(new Finding(
+            Code.STALE_EXPRESSION_ALIAS,
+            Severity.WARNING,
+            target,
+            "Expression-qualified group alias belongs to another composition and is being retained for compatibility",
+            "Replace it with the stable group target '" + stableTarget + "'",
+            false));
+      } else if (exactCurrent && !currentTarget.equals(stableTarget)) {
+        findings.add(new Finding(
+            Code.EXPRESSION_SPECIFIC_TARGET,
+            Severity.WARNING,
+            target,
+            "Expression-qualified group target only resolves while '" + context.expression() + "' is shown",
+            "Prefer the stable group target '" + stableTarget + "'",
+            false));
+      }
+      return true;
+    }
+    return false;
+  }
+
+  private static void addExactLayerScopeWarning(
+      String layerId,
+      String stableTarget,
+      CharacterContext context,
+      List<Finding> findings
+  ) {
+    for (VnCharacter.LayerGroup group : context.character().getLayerGroups().values()) {
+      if (group == null || group.layerIds().size() < 2 || !group.containsLayerId(layerId)) continue;
+      String groupTarget = context.safeCharacter() + "_" + selectorSafeName(group.id());
+      findings.add(new Finding(
+          Code.EXACT_LAYER_REPLACEMENT_SCOPE,
+          Severity.INFO,
+          stableTarget,
+          "This exact layer has variants in group '" + group.id()
+              + "'; the renderer will infer the replacement lane when the match is unique",
+          "Use '" + groupTarget + "' only when you want an explicit override or the inferred lane is ambiguous",
+          false));
+      return;
+    }
+  }
+
+  private static void addPersistentLayerStateWarning(
+      String layerId,
+      String stableTarget,
+      CharacterContext context,
+      List<Finding> findings
+  ) {
+    String safeLayer = selectorSafeName(layerId);
+    boolean hiddenByAnotherExpression = context.character().getExpressionLayerIdsByName().values().stream()
+        .map(layerIds -> layerIds.stream().map(VnTimelineDiagnostics::selectorSafeName).toList())
+        .anyMatch(layerIds -> !layerIds.contains(safeLayer));
+    if (!hiddenByAnotherExpression) return;
+    findings.add(new Finding(
+        Code.PERSISTENT_LAYER_STATE,
+        Severity.WARNING,
+        stableTarget,
+        "Layer proxy state persists while absent, follows a uniquely inferred replacement lane, and applies again if this layer returns",
+        "Author an explicit reset before reusing $" + layerId
+            + " when that persistence is not intended",
+        false));
+  }
+
+  private static void addTimelineDataFindings(TimelineData data, List<Finding> findings) {
+    for (TimelineDataDiagnostics.Message message : TimelineDataDiagnostics.diagnose(data)) {
+      Severity severity = switch (message.severity()) {
+        case ERROR -> Severity.ERROR;
+        case WARNING -> Severity.WARNING;
+        case INFO -> Severity.INFO;
+      };
+      findings.add(new Finding(
+          Code.TIMELINE_DATA,
+          severity,
+          message.target(),
+          message.description(),
+          message.quickFix(),
+          severity == Severity.ERROR));
+    }
+  }
+
+  private static Map<String, VnState.CharacterSlot> activeSlotsByCharacter(VnState state) {
+    Map<String, VnState.CharacterSlot> slots = new LinkedHashMap<>();
+    for (VnState.CharacterSlot slot : state.getVisibleCharacters().values()) {
+      if (slot != null && slot.getCharacterId() != null && !slot.getCharacterId().isBlank()) {
+        slots.put(slot.getCharacterId(), slot);
+      }
+    }
+    for (VnState.DetachedCharacterSlot detached : state.getDetachedCharacters().values()) {
+      VnState.CharacterSlot slot = detached == null ? null : detached.getSlot();
+      if (slot != null && slot.getCharacterId() != null && !slot.getCharacterId().isBlank()) {
+        slots.put(slot.getCharacterId(), slot);
+      }
+    }
+    return slots;
+  }
+
+  private static Finding blocking(Code code, String target, String description, String quickFix) {
+    return new Finding(code, Severity.ERROR, target, description, quickFix, true);
+  }
+
+  static String selectorSafeName(String raw) {
+    String value = raw == null ? "" : raw.trim();
+    StringBuilder out = new StringBuilder();
+    for (int i = 0; i < value.length(); i++) {
+      char ch = value.charAt(i);
+      out.append(Character.isLetterOrDigit(ch) || ch == '_' || ch == '-' ? ch : '_');
+    }
+    String cleaned = out.toString().replaceAll("_+", "_");
+    while (cleaned.startsWith("_")) cleaned = cleaned.substring(1);
+    while (cleaned.endsWith("_")) cleaned = cleaned.substring(0, cleaned.length() - 1);
+    return cleaned;
+  }
+}

--- a/modules/core/src/test/java/com/jvn/core/animation/TimelineDataDiagnosticsTest.java
+++ b/modules/core/src/test/java/com/jvn/core/animation/TimelineDataDiagnosticsTest.java
@@ -1,6 +1,7 @@
 package com.jvn.core.animation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
@@ -69,5 +70,40 @@ class TimelineDataDiagnosticsTest {
         assertEquals(500.0, keyframes.get(1).getTimeMs(), 0.001);
         assertEquals(1000.0, keyframes.get(2).getTimeMs(), 0.001);
         assertEquals(25.0, track.getValueAt(TimelineData.Property.X, 250), 0.001);
+    }
+
+    @Test
+    void warnsWhenAuthoredAnimationFinishesBetweenDisplayFrames() {
+        TimelineData data = new TimelineData("sub_frame", 1);
+        TimelineData.Track track = new TimelineData.Track("john_body_default");
+        track.addKeyframe(
+            TimelineData.Property.MIRROR_X,
+            new TimelineData.Keyframe(1, 1, Easing.Type.EASE_IN_OUT_CUBIC));
+        data.addTrack(track);
+
+        List<TimelineDataDiagnostics.Message> messages = TimelineDataDiagnostics.diagnose(data);
+
+        assertTrue(messages.stream().anyMatch(message ->
+            message.severity() == TimelineDataDiagnostics.Severity.WARNING
+                && message.target().equals("john_body_default")
+                && message.description().contains("within one 60 Hz display frame")));
+    }
+
+    @Test
+    void doesNotWarnForIntentionalInstantOrVisibleDuration() {
+        TimelineData instant = new TimelineData("instant", 0);
+        TimelineData.Track instantTrack = new TimelineData.Track("hero");
+        instantTrack.addKeyframe(TimelineData.Property.X, new TimelineData.Keyframe(0, 10, Easing.Type.LINEAR));
+        instant.addTrack(instantTrack);
+
+        TimelineData visible = new TimelineData("visible", 100);
+        TimelineData.Track visibleTrack = new TimelineData.Track("hero");
+        visibleTrack.addKeyframe(TimelineData.Property.X, new TimelineData.Keyframe(100, 10, Easing.Type.LINEAR));
+        visible.addTrack(visibleTrack);
+
+        assertFalse(TimelineDataDiagnostics.diagnose(instant).stream().anyMatch(message ->
+            message.description().contains("within one 60 Hz display frame")));
+        assertFalse(TimelineDataDiagnostics.diagnose(visible).stream().anyMatch(message ->
+            message.description().contains("within one 60 Hz display frame")));
     }
 }

--- a/modules/core/src/test/java/com/jvn/core/vn/DefaultVnInteropQuotedArgsTest.java
+++ b/modules/core/src/test/java/com/jvn/core/vn/DefaultVnInteropQuotedArgsTest.java
@@ -3,6 +3,7 @@ package com.jvn.core.vn;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import com.jvn.core.animation.TimelineDataParser;
 import com.jvn.core.animation.TimelineRegistry;
 import com.jvn.core.assets.AssetCatalog;
 import com.jvn.core.assets.ClasspathAssetManager;
@@ -76,7 +77,7 @@ class DefaultVnInteropQuotedArgsTest {
   }
 
   @Test
-  void inlineTimelineReportsLayersMissingFromCurrentShowComposition() {
+  void inlineTimelinePreArmsDeclaredLayerMissingFromCurrentShowComposition() {
     VnCharacter john = VnCharacter.builder("john")
         .addLayer("body_default", "body.png")
         .addLayer("eyes_n_base", "eyes.png")
@@ -90,18 +91,129 @@ class DefaultVnInteropQuotedArgsTest {
     scene.getState().setSourceScriptName("lightning.vns");
     scene.getState().showCharacter(CharacterPosition.CENTER, "john", "head_only");
     DefaultVnInterop interop = new DefaultVnInterop();
-    interop.setSceneAccessor(new VnCharacterSceneAccessor());
+    VnCharacterSceneAccessor accessor = new VnCharacterSceneAccessor();
+    interop.setSceneAccessor(accessor);
 
-    interop.handle(new VnExternalCommand("jes_timeline_inline", """
+    VnInteropResult result = interop.handle(new VnExternalCommand("jes_timeline_blocking_inline", """
         timeline {
           mirror "john_body_default" { mirrorX: 1 dur: 1 }
         }
         """), scene);
 
-    assertNotNull(scene.getActiveError());
-    assertEquals("Puppeteer Timeline Target Error", scene.getActiveError().getTitle());
-    assertTrue(scene.getActiveError().getMessage().contains("john_body_default"));
-    assertTrue(scene.getActiveError().getLikelyCause().contains("preceding [show]"));
+    assertNull(scene.getActiveError());
+    assertFalse(result.shouldAdvance());
+    assertTrue(scene.getState().hasActiveTimelines());
+    scene.getState().updateTimelineRunners(1);
+    assertNotNull(accessor.getProxy("john_body_default"));
+    assertEquals(-1.0, accessor.getProxy("john_body_default").getScaleX(), 0.000001);
+    assertNull(scene.getState().getTimelineTransform("john"));
+  }
+
+  @Test
+  void lightningSequencePreArmsMirrorsAndKeepsThemLayerScoped() {
+    VnCharacter john = VnCharacter.builder("john")
+        .addLayer("body_default", "body.png")
+        .addLayer("neck_normal", "neck.png")
+        .addLayer("arm_front_default", "arm.png")
+        .addLayer("body_no_limbs", "body_no_limbs.png")
+        .addLayer("arm_front_holding_wrist", "holding.png")
+        .addLayer("eyes_n_base", "eyes.png")
+        .addLayer("normal_face_common_05", "face.png")
+        .addLayer("normal_mouth_common_01", "mouth.png")
+        .addExpression("head_only", "head.png", java.util.List.of(
+            "eyes_n_base", "normal_face_common_05", "normal_mouth_common_01"))
+        .addExpression("full_default", "full.png", java.util.List.of(
+            "body_default", "neck_normal", "arm_front_default",
+            "eyes_n_base", "normal_face_common_05", "normal_mouth_common_01"))
+        .addExpression("holding", "holding_full.png", java.util.List.of(
+            "body_no_limbs", "neck_normal", "arm_front_holding_wrist",
+            "eyes_n_base", "normal_face_common_05", "normal_mouth_common_01"))
+        .build();
+    VnScene scene = new VnScene(new VnScenarioBuilder("lightning_sequence")
+        .addCharacter(john)
+        .label("start")
+        .end()
+        .build());
+    scene.getState().showCharacter(CharacterPosition.CENTER, "john", "head_only");
+    VnCharacterSceneAccessor accessor = new VnCharacterSceneAccessor();
+    DefaultVnInterop interop = new DefaultVnInterop();
+    interop.setSceneAccessor(accessor);
+
+    interop.handle(new VnExternalCommand("jes_timeline_inline", """
+        timeline {
+          parallel {
+            mirror "john_body_default" { mirrorX: 1 dur: 1 }
+            mirror "john_neck_normal" { mirrorX: 1 dur: 1 }
+            mirror "john_arm_front_default" { mirrorX: 1 dur: 1 }
+          }
+        }
+        """), scene);
+    scene.getState().updateTimelineRunners(1);
+
+    assertNull(scene.getActiveError());
+    assertEquals(-1.0, accessor.getProxy("john_body_default").getScaleX(), 0.000001);
+    assertEquals(-1.0, accessor.getProxy("john_neck_normal").getScaleX(), 0.000001);
+    assertEquals(-1.0, accessor.getProxy("john_arm_front_default").getScaleX(), 0.000001);
+    assertNull(scene.getState().getTimelineTransform("john"));
+
+    scene.getState().showCharacterAnimated(CharacterPosition.CENTER, "john", "full_default");
+    scene.getState().updateTimelineRunners(1);
+    assertEquals(-1.0, accessor.getProxy("john_body_default").getScaleX(), 0.000001,
+        "Line 1590 should reveal the pre-armed exact-layer mirror");
+
+    scene.getState().showCharacterAnimated(CharacterPosition.CENTER, "john", "holding");
+    scene.getState().updateTimelineRunners(1);
+    assertEquals(
+        "body_default",
+        LayeredCharacterResolver.inferReplacementLayerId(
+            "body_no_limbs", java.util.Set.of("body_default", "arm_front_default", "neck_normal")));
+    assertEquals(
+        "arm_front_default",
+        LayeredCharacterResolver.inferReplacementLayerId(
+            "arm_front_holding_wrist", java.util.Set.of("body_default", "arm_front_default", "neck_normal")));
+  }
+
+  @Test
+  void chainedTimelineStopsBeforeUnknownCharacterLayerTarget() {
+    VnCharacter john = VnCharacter.builder("john")
+        .addLayer("body_default", "body.png")
+        .addLayer("eyes_n_base", "eyes.png")
+        .addExpression("head_only", "eyes.png", java.util.List.of("eyes_n_base"))
+        .build();
+    VnScene scene = new VnScene(new VnScenarioBuilder("inactive_chained_layer")
+        .addCharacter(john)
+        .label("start")
+        .end()
+        .build());
+    scene.getState().showCharacter(CharacterPosition.CENTER, "john", "head_only");
+    VnCharacterSceneAccessor accessor = new VnCharacterSceneAccessor();
+    DefaultVnInterop interop = new DefaultVnInterop();
+    interop.setSceneAccessor(accessor);
+    TimelineRegistry.clear();
+
+    try {
+      TimelineRegistry.register(TimelineDataParser.parse("hidden_mirror", """
+          timeline {
+            mirror "john_bdy_default" { mirrorX: 1 dur: 1 }
+          }
+          """));
+
+      VnInteropResult result = interop.handle(new VnExternalCommand("jes_timeline_blocking_inline", """
+          timeline { wait 1 }
+          then hidden_mirror
+          """), scene);
+      assertFalse(result.shouldAdvance());
+
+      scene.getState().updateTimelineRunners(1);
+
+      assertNotNull(scene.getActiveError());
+      assertEquals("Puppeteer Timeline Diagnostics", scene.getActiveError().getTitle());
+      assertTrue(scene.getActiveError().getMessage().contains("john_bdy_default"));
+      assertFalse(scene.getState().hasActiveTimelines());
+      assertNull(accessor.getProxy("john_bdy_default"));
+    } finally {
+      TimelineRegistry.clear();
+    }
   }
 
   @Test
@@ -118,7 +230,8 @@ class DefaultVnInteropQuotedArgsTest {
         .build());
     scene.getState().showCharacter(CharacterPosition.CENTER, "john", "full");
     DefaultVnInterop interop = new DefaultVnInterop();
-    interop.setSceneAccessor(new VnCharacterSceneAccessor());
+    VnCharacterSceneAccessor accessor = new VnCharacterSceneAccessor();
+    interop.setSceneAccessor(accessor);
 
     interop.handle(new VnExternalCommand("jes_timeline_inline", """
         timeline {
@@ -127,6 +240,10 @@ class DefaultVnInteropQuotedArgsTest {
         """), scene);
 
     assertNull(scene.getActiveError());
+    scene.getState().updateTimelineRunners(1);
+    assertNotNull(accessor.getProxy("john_body_default"));
+    assertNull(scene.getState().getTimelineTransform("john"),
+        "A declared layer mirror must not become a whole-character mirror");
   }
 
   @Test

--- a/modules/core/src/test/java/com/jvn/core/vn/DefaultVnInteropQuotedArgsTest.java
+++ b/modules/core/src/test/java/com/jvn/core/vn/DefaultVnInteropQuotedArgsTest.java
@@ -76,6 +76,60 @@ class DefaultVnInteropQuotedArgsTest {
   }
 
   @Test
+  void inlineTimelineReportsLayersMissingFromCurrentShowComposition() {
+    VnCharacter john = VnCharacter.builder("john")
+        .addLayer("body_default", "body.png")
+        .addLayer("eyes_n_base", "eyes.png")
+        .addExpression("head_only", "eyes.png", java.util.List.of("eyes_n_base"))
+        .build();
+    VnScene scene = new VnScene(new VnScenarioBuilder("inactive_timeline_layer")
+        .addCharacter(john)
+        .label("start")
+        .end()
+        .build());
+    scene.getState().setSourceScriptName("lightning.vns");
+    scene.getState().showCharacter(CharacterPosition.CENTER, "john", "head_only");
+    DefaultVnInterop interop = new DefaultVnInterop();
+    interop.setSceneAccessor(new VnCharacterSceneAccessor());
+
+    interop.handle(new VnExternalCommand("jes_timeline_inline", """
+        timeline {
+          mirror "john_body_default" { mirrorX: 1 dur: 1 }
+        }
+        """), scene);
+
+    assertNotNull(scene.getActiveError());
+    assertEquals("Puppeteer Timeline Target Error", scene.getActiveError().getTitle());
+    assertTrue(scene.getActiveError().getMessage().contains("john_body_default"));
+    assertTrue(scene.getActiveError().getLikelyCause().contains("preceding [show]"));
+  }
+
+  @Test
+  void inlineTimelineAcceptsLayerPresentInCurrentShowComposition() {
+    VnCharacter john = VnCharacter.builder("john")
+        .addLayer("body_default", "body.png")
+        .addLayer("eyes_n_base", "eyes.png")
+        .addExpression("full", "body.png", java.util.List.of("body_default", "eyes_n_base"))
+        .build();
+    VnScene scene = new VnScene(new VnScenarioBuilder("active_timeline_layer")
+        .addCharacter(john)
+        .label("start")
+        .end()
+        .build());
+    scene.getState().showCharacter(CharacterPosition.CENTER, "john", "full");
+    DefaultVnInterop interop = new DefaultVnInterop();
+    interop.setSceneAccessor(new VnCharacterSceneAccessor());
+
+    interop.handle(new VnExternalCommand("jes_timeline_inline", """
+        timeline {
+          mirror "john_body_default" { mirrorX: 1 dur: 1 }
+        }
+        """), scene);
+
+    assertNull(scene.getActiveError());
+  }
+
+  @Test
   void characterExpressionCommandAcceptsTransitionDuration() {
     VnScenario scenario = new VnScenarioBuilder("expression_transition")
       .addCharacterWithExpressions("lily", "Lily", "neutral.png", "talking.png")

--- a/modules/core/src/test/java/com/jvn/core/vn/LayeredCharacterResolverTest.java
+++ b/modules/core/src/test/java/com/jvn/core/vn/LayeredCharacterResolverTest.java
@@ -1,0 +1,47 @@
+package com.jvn.core.vn;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+class LayeredCharacterResolverTest {
+
+  @Test
+  void infersLightningBodyAndFrontArmReplacementLanes() {
+    Set<String> animated = Set.of("body_default", "arm_front_default", "neck_normal");
+
+    assertEquals(
+        "body_default",
+        LayeredCharacterResolver.inferReplacementLayerId("body_no_limbs", animated));
+    assertEquals(
+        "arm_front_default",
+        LayeredCharacterResolver.inferReplacementLayerId("arm_front_holding_wrist", animated));
+  }
+
+  @Test
+  void keepsAnatomicalAndDirectionalLanesSeparate() {
+    assertEquals(
+        "normal_face_common_05",
+        LayeredCharacterResolver.inferReplacementLayerId(
+            "normal_face_common_07",
+            Set.of("normal_face_common_05", "normal_mouth_common_01")));
+    assertEquals(
+        "arm_front_default",
+        LayeredCharacterResolver.inferReplacementLayerId(
+            "arm_front_crossed",
+            Set.of("arm_front_default", "arm_behind_default")));
+    assertNull(LayeredCharacterResolver.inferReplacementLayerId(
+        "normal_mouth_common_02",
+        Set.of("normal_face_common_05")));
+  }
+
+  @Test
+  void refusesAnAmbiguousConventionMatch() {
+    assertNull(LayeredCharacterResolver.inferReplacementLayerId(
+        "body_no_limbs",
+        Set.of("body_default", "body_alternate")));
+  }
+}

--- a/modules/core/src/test/java/com/jvn/core/vn/VnTimelineDiagnosticsTest.java
+++ b/modules/core/src/test/java/com/jvn/core/vn/VnTimelineDiagnosticsTest.java
@@ -1,0 +1,149 @@
+package com.jvn.core.vn;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.jvn.core.animation.TimelineData;
+import com.jvn.core.animation.TimelineDataParser;
+
+class VnTimelineDiagnosticsTest {
+
+  @Test
+  void classifiesInactiveLayersInLightningCompositionAsDeferredWarnings() {
+    Fixture fixture = fixture("head_only");
+    TimelineData data = parse("""
+        timeline {
+          parallel {
+            mirror "john_body_default" { mirrorX: 1 dur: 1 }
+            mirror "john_neck_normal" { mirrorX: 1 dur: 1 }
+            mirror "john_arm_front_default" { mirrorX: 1 dur: 1 }
+          }
+        }
+        """);
+
+    VnTimelineDiagnostics.Report report = VnTimelineDiagnostics.diagnose(
+        data, fixture.scenario(), fixture.state());
+
+    assertFalse(report.blocksPlayback());
+    assertTrue(hasCode(report, VnTimelineDiagnostics.Code.DEFERRED_LAYER_TARGET, "john_body_default"));
+    assertTrue(hasCode(report, VnTimelineDiagnostics.Code.DEFERRED_LAYER_TARGET, "john_neck_normal"));
+    assertTrue(hasCode(report, VnTimelineDiagnostics.Code.DEFERRED_LAYER_TARGET, "john_arm_front_default"));
+    assertTrue(report.warningCount() >= 1, "The 1ms duration should also produce a timing warning");
+  }
+
+  @Test
+  void rejectsHiddenCharactersUnknownTargetsAndStaleAliases() {
+    Fixture hidden = fixture("");
+    VnTimelineDiagnostics.Report hiddenReport = diagnose(hidden, "john");
+    assertTrue(hasCode(hiddenReport, VnTimelineDiagnostics.Code.CHARACTER_NOT_VISIBLE, "john"));
+
+    Fixture visible = fixture("full_default");
+    VnTimelineDiagnostics.Report unknownReport = diagnose(visible, "john_bdy_default");
+    assertTrue(hasCode(unknownReport, VnTimelineDiagnostics.Code.UNKNOWN_CHARACTER_TARGET, "john_bdy_default"));
+
+    VnTimelineDiagnostics.Report staleReport = diagnose(visible, "john_old_body_default");
+    assertTrue(hasCode(staleReport, VnTimelineDiagnostics.Code.STALE_EXPRESSION_ALIAS, "john_old_body_default"));
+    assertFalse(staleReport.blocksPlayback());
+    assertTrue(staleReport.findings().stream().anyMatch(finding ->
+        finding.code() == VnTimelineDiagnostics.Code.STALE_EXPRESSION_ALIAS
+            && finding.quickFix().contains("john_body_default")));
+  }
+
+  @Test
+  void stableGroupsFollowVariantsWhileExactLayersExplainTheirScope() {
+    Fixture defaultFixture = fixture("full_default");
+    VnTimelineDiagnostics.Report exactLayer = diagnose(defaultFixture, "john_body_default");
+    assertFalse(exactLayer.blocksPlayback());
+    assertTrue(hasCode(
+        exactLayer,
+        VnTimelineDiagnostics.Code.EXACT_LAYER_REPLACEMENT_SCOPE,
+        "john_body_default"));
+    assertTrue(hasCode(
+        exactLayer,
+        VnTimelineDiagnostics.Code.PERSISTENT_LAYER_STATE,
+        "john_body_default"));
+
+    Fixture holdingFixture = fixture("holding");
+    VnTimelineDiagnostics.Report group = diagnose(holdingFixture, "john_body_orientation");
+    assertFalse(group.blocksPlayback());
+    assertFalse(hasCode(group, VnTimelineDiagnostics.Code.DEFERRED_GROUP_TARGET, "john_body_orientation"));
+
+    VnTimelineDiagnostics.Report replacedExactLayer = diagnose(holdingFixture, "john_body_default");
+    assertFalse(replacedExactLayer.blocksPlayback());
+    assertTrue(hasCode(replacedExactLayer, VnTimelineDiagnostics.Code.DEFERRED_LAYER_TARGET, "john_body_default"));
+  }
+
+  @Test
+  void promotesStructuralTimelineErrorsToPlaybackBlockers() {
+    Fixture fixture = fixture("full_default");
+    TimelineData invalid = new TimelineData("invalid", Double.NaN);
+
+    VnTimelineDiagnostics.Report report = VnTimelineDiagnostics.diagnose(
+        invalid, fixture.scenario(), fixture.state());
+
+    assertTrue(report.blocksPlayback());
+    assertTrue(hasCode(report, VnTimelineDiagnostics.Code.TIMELINE_DATA, "(timeline)"));
+  }
+
+  private static VnTimelineDiagnostics.Report diagnose(Fixture fixture, String target) {
+    return VnTimelineDiagnostics.diagnose(
+        parse("""
+            timeline {
+              move "%s" {
+                x: 10
+                dur: 100
+              }
+            }
+            """.formatted(target)),
+        fixture.scenario(),
+        fixture.state());
+  }
+
+  private static TimelineData parse(String source) {
+    return TimelineDataParser.parse("diagnostic_test", source);
+  }
+
+  private static boolean hasCode(
+      VnTimelineDiagnostics.Report report,
+      VnTimelineDiagnostics.Code code,
+      String target
+  ) {
+    return report.findings().stream().anyMatch(finding ->
+        finding.code() == code && finding.target().equals(target));
+  }
+
+  private static Fixture fixture(String expression) {
+    VnCharacter john = VnCharacter.builder("john")
+        .addLayer("body_default", "body.png")
+        .addLayer("body_no_limbs", "body_no_limbs.png")
+        .addLayer("neck_normal", "neck.png")
+        .addLayer("arm_front_default", "arm.png")
+        .addLayer("arm_front_holding_wrist", "holding.png")
+        .addLayer("eyes_n_base", "eyes.png")
+        .addExpression("head_only", "head.png", List.of("eyes_n_base"))
+        .addExpression("full_default", "full.png", List.of(
+            "body_default", "neck_normal", "arm_front_default", "eyes_n_base"))
+        .addExpression("holding", "holding_full.png", List.of(
+            "body_no_limbs", "neck_normal", "arm_front_holding_wrist", "eyes_n_base"))
+        .addLayerGroup("body_orientation", "", List.of("body_default", "body_no_limbs"))
+        .addLayerGroup("front_arm", "", List.of("arm_front_default", "arm_front_holding_wrist"))
+        .build();
+    VnScenario scenario = new VnScenarioBuilder("timeline_diagnostics")
+        .addCharacter(john)
+        .label("start")
+        .end()
+        .build();
+    VnScene scene = new VnScene(scenario);
+    if (expression != null && !expression.isBlank()) {
+      scene.getState().showCharacter(CharacterPosition.CENTER, "john", expression);
+    }
+    return new Fixture(scenario, scene.getState());
+  }
+
+  private record Fixture(VnScenario scenario, VnState state) {
+  }
+}

--- a/modules/editor/src/main/java/com/jvn/editor/EditorApp.java
+++ b/modules/editor/src/main/java/com/jvn/editor/EditorApp.java
@@ -8053,7 +8053,7 @@ public class EditorApp extends Application {
     for (PuppeteerLauncherPanel.CharacterLayerEntry layer : layers) {
       if (layer == null || layer.path == null || layer.path.isBlank()) continue;
       String resolvedPath = resolveProjectPath(layer.path);
-      String entityName = PuppeteerLauncherPanel.snapshotLayerEntityName(ch.characterId, ch.expression, layer.layerId);
+      String entityName = PuppeteerLauncherPanel.snapshotStableLayerEntityName(ch.characterId, layer.layerId);
       while (scene.find(entityName) != null) {
         entityName = entityName + "_" + (layerIndex + 2);
       }

--- a/modules/editor/src/main/java/com/jvn/editor/EditorApp.java
+++ b/modules/editor/src/main/java/com/jvn/editor/EditorApp.java
@@ -8065,7 +8065,7 @@ public class EditorApp extends Application {
       scene.registerEntity(entityName, sprite);
       for (String alias : PuppeteerLauncherPanel.equivalentSnapshotLayerEntityNames(snapshot, ch, layer.layerId)) {
         if (alias == null || alias.isBlank() || alias.equals(entityName)) continue;
-        scene.registerEntity(alias, sprite);
+        scene.registerEntityAlias(alias, sprite);
       }
       layerIndex++;
     }

--- a/modules/editor/src/main/java/com/jvn/editor/ui/PuppeteerLauncherPanel.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/PuppeteerLauncherPanel.java
@@ -1586,6 +1586,13 @@ button then opens it in the editor."""));
     return safeCharacter + "_" + safeExpression + "_" + safeLayer;
   }
 
+  public static String snapshotStableLayerEntityName(String characterId, String layerId) {
+    String safeCharacter = selectorSafeName(characterId);
+    String safeLayer = selectorSafeName(layerId);
+    if (safeCharacter.isBlank() || safeLayer.isBlank()) return "";
+    return safeCharacter + "_" + safeLayer;
+  }
+
   public static String snapshotLayerGroupEntityName(String characterId, String expression, String groupId) {
     List<String> names = equivalentSnapshotLayerGroupEntityNames(characterId, expression, groupId);
     return names.isEmpty() ? "" : names.get(0);
@@ -1613,15 +1620,13 @@ button then opens it in the editor."""));
     }
     Set<String> names = new java.util.LinkedHashSet<>();
     String safeLayer = selectorSafeName(layerId);
+    // Put the expression-independent runtime target first so Puppeteer creates
+    // and exports stable tracks instead of baking the current [show] composition
+    // into every entity name. Expression-qualified names remain lookup aliases.
+    String stableName = snapshotStableLayerEntityName(character.characterId, layerId);
+    if (!stableName.isBlank()) names.add(stableName);
     String currentName = snapshotLayerEntityName(character.characterId, character.expression, layerId);
     if (!currentName.isBlank()) names.add(currentName);
-    String safeCharacter = selectorSafeName(character.characterId);
-    if (!safeCharacter.isBlank() && !safeLayer.isBlank()) {
-      // Match VnRenderer's expression-independent layer target. Puppeteer exports
-      // may deliberately use this stable name so one animation keeps working when
-      // the visible expression changes but the underlying layer is shared.
-      names.add(safeCharacter + "_" + safeLayer);
-    }
     if (snapshot != null && snapshot.characterPresetLayers != null && !snapshot.characterPresetLayers.isEmpty()) {
       String prefix = character.characterId + "/";
       for (Map.Entry<String, List<CharacterLayerEntry>> entry : snapshot.characterPresetLayers.entrySet()) {

--- a/modules/editor/src/main/java/com/jvn/editor/ui/PuppeteerLauncherPanel.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/PuppeteerLauncherPanel.java
@@ -1615,6 +1615,13 @@ button then opens it in the editor."""));
     String safeLayer = selectorSafeName(layerId);
     String currentName = snapshotLayerEntityName(character.characterId, character.expression, layerId);
     if (!currentName.isBlank()) names.add(currentName);
+    String safeCharacter = selectorSafeName(character.characterId);
+    if (!safeCharacter.isBlank() && !safeLayer.isBlank()) {
+      // Match VnRenderer's expression-independent layer target. Puppeteer exports
+      // may deliberately use this stable name so one animation keeps working when
+      // the visible expression changes but the underlying layer is shared.
+      names.add(safeCharacter + "_" + safeLayer);
+    }
     if (snapshot != null && snapshot.characterPresetLayers != null && !snapshot.characterPresetLayers.isEmpty()) {
       String prefix = character.characterId + "/";
       for (Map.Entry<String, List<CharacterLayerEntry>> entry : snapshot.characterPresetLayers.entrySet()) {

--- a/modules/editor/src/main/java/com/jvn/editor/ui/VnsScriptAnalyzer.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/VnsScriptAnalyzer.java
@@ -22,6 +22,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.jvn.core.vn.VnArgTokenizer;
+import com.jvn.core.vn.VnScenario;
 import com.jvn.core.vn.script.MultipleParseErrorsException;
 import com.jvn.core.vn.script.VnParseException;
 import com.jvn.core.vn.script.VnScriptParser;
@@ -57,8 +58,9 @@ public final class VnsScriptAnalyzer {
         : resolveSourceName(effectiveRoot, sourceFile);
 
     // Strict parser diagnostics first.
+    VnScenario parsedScenario = null;
     try {
-      parseWithIncludeResolver(source, projectRoot, sourceFile);
+      parsedScenario = parseWithIncludeResolver(source, projectRoot, sourceFile);
     } catch (MultipleParseErrorsException mex) {
       for (VnParseException ex : mex.getErrors()) {
         boolean fromIncludedFile = !sameSource(ex.getSourceName(), analyzedSourceName);
@@ -257,6 +259,10 @@ public final class VnsScriptAnalyzer {
     }
 
     List<LabelNode> labels = new ArrayList<>(labelsByName.values());
+    if (parsedScenario != null) {
+      diagnostics.addAll(VnsTimelineDiagnostics.analyze(source, parsedScenario));
+    }
+
     labels.sort((a, b) -> Integer.compare(a.line(), b.line()));
     List<FlowEdge> edges = computeFlowEdges(source, lines, labelsByName, labels);
     addUnreachableStatementDiagnostics(lines, diagnostics);
@@ -344,18 +350,17 @@ public final class VnsScriptAnalyzer {
     return new int[] {absoluteStart, Math.max(absoluteStart + 1, absoluteEnd)};
   }
 
-  private static void parseWithIncludeResolver(String source, File projectRoot, File sourceFile) throws Exception {
+  private static VnScenario parseWithIncludeResolver(String source, File projectRoot, File sourceFile) throws Exception {
     VnScriptParser parser = new VnScriptParser();
     File effectiveRoot = resolveProjectRoot(projectRoot, sourceFile);
     if (effectiveRoot == null || !effectiveRoot.exists()) {
-      parser.parseFromString(source);
-      return;
+      return parser.parseFromString(source);
     }
 
     String sourceName = resolveSourceName(effectiveRoot, sourceFile);
     byte[] bytes = source == null ? new byte[0] : source.getBytes(StandardCharsets.UTF_8);
     try (InputStream in = new ByteArrayInputStream(bytes)) {
-      parser.parse(in, sourceName, includePath -> openIncludeForDiagnostics(effectiveRoot, sourceName, includePath));
+      return parser.parse(in, sourceName, includePath -> openIncludeForDiagnostics(effectiveRoot, sourceName, includePath));
     }
   }
 

--- a/modules/editor/src/main/java/com/jvn/editor/ui/VnsTimelineDiagnostics.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/VnsTimelineDiagnostics.java
@@ -1,0 +1,122 @@
+package com.jvn.editor.ui;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import com.jvn.core.animation.TimelineData;
+import com.jvn.core.animation.TimelineDataParser;
+import com.jvn.core.vn.CharacterPosition;
+import com.jvn.core.vn.VnScenario;
+import com.jvn.core.vn.VnScene;
+import com.jvn.core.vn.VnTimelineDiagnostics;
+
+/** Static VNS adapter for the shared VN timeline diagnostics engine. */
+final class VnsTimelineDiagnostics {
+  private VnsTimelineDiagnostics() {
+  }
+
+  static List<VnsScriptAnalyzer.Diagnostic> analyze(String source, VnScenario scenario) {
+    if (source == null || source.isBlank() || scenario == null) return List.of();
+    String[] lines = source.split("\n", -1);
+    PuppeteerLauncherPanel.SceneSnapshot document = PuppeteerLauncherPanel.resolveSnapshot(
+        source, Math.max(0, lines.length - 1));
+    if (document.inlineTimelineHistory == null || document.inlineTimelineHistory.isEmpty()) return List.of();
+
+    List<VnsScriptAnalyzer.Diagnostic> diagnostics = new ArrayList<>();
+    for (PuppeteerLauncherPanel.InlineTimelineContext context : document.inlineTimelineHistory) {
+      if (context == null || context.body() == null || context.body().isBlank()) continue;
+      try {
+        TimelineData data = TimelineDataParser.parse(
+            "_vns_diagnostic_" + Math.max(0, context.startLine()),
+            context.body());
+        PuppeteerLauncherPanel.SceneSnapshot snapshot = PuppeteerLauncherPanel.resolveSnapshot(
+            source, Math.max(0, context.startLine() - 1));
+        VnScene scene = sceneAtSnapshot(scenario, snapshot);
+        VnTimelineDiagnostics.Report report = VnTimelineDiagnostics.diagnose(
+            data, scenario, scene.getState());
+        for (VnTimelineDiagnostics.Finding finding : report.findings()) {
+          diagnostics.add(toEditorDiagnostic(source, context, finding));
+        }
+      } catch (RuntimeException ignored) {
+        // The strict VNS/JES parser already reports syntax failures with a more
+        // precise token location. Avoid adding a second generic diagnostic.
+      }
+    }
+    return List.copyOf(diagnostics);
+  }
+
+  private static VnScene sceneAtSnapshot(
+      VnScenario scenario,
+      PuppeteerLauncherPanel.SceneSnapshot snapshot
+  ) {
+    VnScene scene = new VnScene(scenario);
+    if (snapshot == null) return scene;
+    for (PuppeteerLauncherPanel.CharacterEntry character : snapshot.characters) {
+      if (character == null || character.characterId == null || character.characterId.isBlank()) continue;
+      CharacterPosition base = CharacterPosition.predefined(character.position);
+      CharacterPosition slot = CharacterPosition.slotted(
+          base == null ? CharacterPosition.CENTER : base,
+          "timeline-diagnostic-" + character.characterId);
+      scene.getState().showCharacter(
+          slot,
+          character.characterId,
+          character.expression == null || character.expression.isBlank() ? "neutral" : character.expression);
+    }
+    return scene;
+  }
+
+  private static VnsScriptAnalyzer.Diagnostic toEditorDiagnostic(
+      String source,
+      PuppeteerLauncherPanel.InlineTimelineContext context,
+      VnTimelineDiagnostics.Finding finding
+  ) {
+    int line = Math.max(0, context.startLine());
+    int[] lineBounds = lineBounds(source, line);
+    int start = lineBounds[0];
+    int end = lineBounds[1];
+    if (finding.target() != null && !finding.target().startsWith("(")) {
+      int searchEnd = offsetForLine(source, Math.max(line + 1, context.endLine() + 1));
+      int found = source.indexOf("\"" + finding.target() + "\"", start);
+      if (found >= start && found < searchEnd) {
+        start = found + 1;
+        end = start + finding.target().length();
+        line = lineForOffset(source, start);
+      }
+    }
+    String message = finding.description();
+    if (finding.quickFix() != null) message += " Fix: " + finding.quickFix();
+    String kind = "timeline_" + finding.code().name().toLowerCase(Locale.ROOT);
+    if (finding.blocksPlayback() || finding.severity() == VnTimelineDiagnostics.Severity.ERROR) {
+      return VnsScriptAnalyzer.Diagnostic.error(kind, message, start, end, line, null, null, -1);
+    }
+    return VnsScriptAnalyzer.Diagnostic.warning(kind, message, start, end, line, null, null, -1);
+  }
+
+  private static int[] lineBounds(String source, int line) {
+    int start = offsetForLine(source, line);
+    int end = source.indexOf('\n', start);
+    if (end < 0) end = source.length();
+    return new int[] {start, Math.max(start + 1, end)};
+  }
+
+  private static int offsetForLine(String source, int line) {
+    if (source == null || source.isEmpty() || line <= 0) return 0;
+    int offset = 0;
+    for (int current = 0; current < line && offset < source.length(); current++) {
+      int newline = source.indexOf('\n', offset);
+      if (newline < 0) return source.length();
+      offset = newline + 1;
+    }
+    return offset;
+  }
+
+  private static int lineForOffset(String source, int offset) {
+    int line = 0;
+    int limit = Math.max(0, Math.min(offset, source == null ? 0 : source.length()));
+    for (int i = 0; i < limit; i++) {
+      if (source.charAt(i) == '\n') line++;
+    }
+    return line;
+  }
+}

--- a/modules/editor/src/test/java/com/jvn/editor/ui/PuppeteerLauncherPanelTest.java
+++ b/modules/editor/src/test/java/com/jvn/editor/ui/PuppeteerLauncherPanelTest.java
@@ -322,10 +322,14 @@ class PuppeteerLauncherPanelTest {
 	        john,
 	        "mouth_murmuring");
 
-	    assertTrue(armNames.contains("john_talking_arm_front_default"));
-	    assertTrue(armNames.contains("john_arm_front_default"));
-	    assertTrue(armNames.contains("john_neutral_arm_front_default"));
-	    assertEquals(List.of("john_talking_mouth_murmuring", "john_mouth_murmuring"), mouthNames);
+    assertEquals("john_arm_front_default", armNames.get(0));
+    assertTrue(armNames.contains("john_talking_arm_front_default"));
+    assertTrue(armNames.contains("john_neutral_arm_front_default"));
+    assertEquals(List.of("john_mouth_murmuring", "john_talking_mouth_murmuring"), mouthNames);
+    assertEquals(
+        "john_body_default",
+        PuppeteerLauncherPanel.snapshotStableLayerEntityName(
+            "john", "body_default"));
 	  }
 
 	  @Test

--- a/modules/editor/src/test/java/com/jvn/editor/ui/PuppeteerLauncherPanelTest.java
+++ b/modules/editor/src/test/java/com/jvn/editor/ui/PuppeteerLauncherPanelTest.java
@@ -323,8 +323,9 @@ class PuppeteerLauncherPanelTest {
 	        "mouth_murmuring");
 
 	    assertTrue(armNames.contains("john_talking_arm_front_default"));
+	    assertTrue(armNames.contains("john_arm_front_default"));
 	    assertTrue(armNames.contains("john_neutral_arm_front_default"));
-	    assertEquals(List.of("john_talking_mouth_murmuring"), mouthNames);
+	    assertEquals(List.of("john_talking_mouth_murmuring", "john_mouth_murmuring"), mouthNames);
 	  }
 
 	  @Test

--- a/modules/editor/src/test/java/com/jvn/editor/ui/VnsTimelineDiagnosticsTest.java
+++ b/modules/editor/src/test/java/com/jvn/editor/ui/VnsTimelineDiagnosticsTest.java
@@ -1,0 +1,100 @@
+package com.jvn.editor.ui;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class VnsTimelineDiagnosticsTest {
+
+  @Test
+  void mainVnsAnalyzerFlagsLightningTargetsAgainstPrecedingShow(@TempDir Path projectRoot) throws Exception {
+    Path definitionsDir = Files.createDirectories(projectRoot.resolve("scripts/definitions"));
+    Files.writeString(definitionsDir.resolve("characters.vns"), definitions());
+    Path storyDir = Files.createDirectories(projectRoot.resolve("scripts/story"));
+    Path script = storyDir.resolve("lightning.vns");
+    String source = """
+        @include /definitions/characters.vns
+        @label start
+        [show john center $eyes_n_base+$normal_face_common_05+$normal_mouth_common_01 slot=john z=2]
+        timeline {
+          parallel {
+            mirror "john_body_default" { mirrorX: 1 dur: 1 }
+            mirror "john_neck_normal" { mirrorX: 1 dur: 1 }
+            mirror "john_arm_front_default" { mirrorX: 1 dur: 1 }
+          }
+        }
+        Narrator: 1584
+        """;
+    Files.writeString(script, source);
+
+    VnsScriptAnalyzer.Analysis analysis = VnsScriptAnalyzer.analyze(
+        source, projectRoot.toFile(), script.toFile());
+    Set<String> inactiveTargets = analysis.diagnostics().stream()
+        .filter(diagnostic -> diagnostic.kind().equals("timeline_deferred_layer_target"))
+        .map(diagnostic -> source.substring(diagnostic.start(), diagnostic.end()))
+        .collect(Collectors.toSet());
+
+    assertTrue(inactiveTargets.contains("john_body_default"));
+    assertTrue(inactiveTargets.contains("john_neck_normal"));
+    assertTrue(inactiveTargets.contains("john_arm_front_default"));
+    assertTrue(analysis.diagnostics().stream()
+        .filter(diagnostic -> diagnostic.kind().equals("timeline_deferred_layer_target"))
+        .allMatch(VnsScriptAnalyzer.Diagnostic::warning));
+    assertTrue(analysis.diagnostics().stream().anyMatch(diagnostic ->
+        diagnostic.kind().equals("timeline_timeline_data")
+            && diagnostic.warning()
+            && diagnostic.message().contains("within one 60 Hz display frame")));
+  }
+
+  @Test
+  void mainVnsAnalyzerAcceptsVisibleStableGroupAcrossReplacement(@TempDir Path projectRoot) throws Exception {
+    Path definitionsDir = Files.createDirectories(projectRoot.resolve("scripts/definitions"));
+    Files.writeString(definitionsDir.resolve("characters.vns"), definitions());
+    Path storyDir = Files.createDirectories(projectRoot.resolve("scripts/story"));
+    Path script = storyDir.resolve("group.vns");
+    String source = """
+        @include /definitions/characters.vns
+        @label start
+        [show john center holding]
+        timeline {
+          mirror "john_body_orientation" {
+            mirrorX: 1
+            dur: 200
+          }
+        }
+        Narrator: group target
+        """;
+    Files.writeString(script, source);
+
+    VnsScriptAnalyzer.Analysis analysis = VnsScriptAnalyzer.analyze(
+        source, projectRoot.toFile(), script.toFile());
+
+    assertFalse(analysis.diagnostics().stream().anyMatch(diagnostic ->
+        diagnostic.kind().startsWith("timeline_") && !diagnostic.warning()));
+  }
+
+  private static String definitions() {
+    return """
+        @character john "John"
+        @charlayer john body_default assets/john/body.png
+        @charlayer john body_no_limbs assets/john/body_no_limbs.png
+        @charlayer john neck_normal assets/john/neck.png
+        @charlayer john arm_front_default assets/john/arm.png
+        @charlayer john arm_front_holding_wrist assets/john/holding.png
+        @charlayer john eyes_n_base assets/john/eyes.png
+        @charlayer john normal_face_common_05 assets/john/face.png
+        @charlayer john normal_mouth_common_01 assets/john/mouth.png
+        @charpreset john head_only $eyes_n_base | $normal_face_common_05 | $normal_mouth_common_01
+        @charpreset john full_default $body_default | $neck_normal | $arm_front_default | $eyes_n_base | $normal_face_common_05 | $normal_mouth_common_01
+        @charpreset john holding $body_no_limbs | $neck_normal | $arm_front_holding_wrist | $eyes_n_base | $normal_face_common_05 | $normal_mouth_common_01
+        @chargroup john body_orientation $body_default | $body_no_limbs
+        """;
+  }
+}

--- a/modules/editor/src/test/java/com/jvn/editor/ui/actioneditor/PuppeteerVerificationTest.java
+++ b/modules/editor/src/test/java/com/jvn/editor/ui/actioneditor/PuppeteerVerificationTest.java
@@ -242,6 +242,26 @@ class PuppeteerVerificationTest {
     }
 
     @Test
+    void runtimeRegistrationWarnsForSubFrameAnimation() {
+        AnimationProject project = new AnimationProject();
+        project.setName("sub_frame_mirror");
+        EntityTrack body = project.getOrCreateTrack("john_body_default");
+        body.addKeyframe(PropertyType.MIRROR_X, new Keyframe(1, 1));
+
+        List<TimelineDiagnostic.Message> messages = PuppeteerVerification.diagnose(
+            project,
+            Set.of("john_body_default"),
+            null,
+            PuppeteerVerification.Mode.REGISTER_RUNTIME
+        );
+
+        assertTrue(messages.stream().anyMatch(message ->
+            message.severity() == TimelineDiagnostic.Severity.WARNING
+                && message.entityOrTrack().equals("john_body_default")
+                && message.description().contains("within one 60 Hz display frame")));
+    }
+
+    @Test
     void timelineNameValidationBlocksUnsafeFileAndVnsNames() {
         assertTrue(PuppeteerVerification.validateTimelineName("../bad name").stream().anyMatch(message ->
             message.severity() == TimelineDiagnostic.Severity.ERROR

--- a/modules/fx/src/main/java/com/jvn/fx/vn/VnRenderer.java
+++ b/modules/fx/src/main/java/com/jvn/fx/vn/VnRenderer.java
@@ -5,6 +5,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
@@ -35,6 +36,7 @@ import com.jvn.core.vn.Choice;
 import com.jvn.core.vn.DialogueLine;
 import com.jvn.core.vn.DialoguePresentationMode;
 import com.jvn.core.vn.EyeFocusResolver;
+import com.jvn.core.vn.LayeredCharacterResolver;
 import com.jvn.core.vn.VnAudioVisualizerConfig;
 import com.jvn.core.vn.VnBackground;
 import com.jvn.core.vn.VnCharacter;
@@ -1005,13 +1007,15 @@ public class VnRenderer {
   ) {
     if (layerPaths == null || layerPaths.size() <= 1) return false;
     List<SpriteLayer> layers = spriteLayers(character, expression, characterId, layerPaths);
+    Map<String, Entity2D> inferredReplacementProxies = inferredReplacementProxies(
+        character, characterId, expression, layers);
     EyeFocusDraw eyeFocus = resolveEyeFocusDraw(
         state, scenario, character, expression, characterId, layers,
         defaultX, defaultY, spriteWidth, spriteHeight, canvasWidth, canvasHeight);
     boolean hasLayerProxy = false;
     if (timelineAccessor != null) {
       for (SpriteLayer layer : layers) {
-        if (layer != null && hasAnyLayerTransformProxy(layer)) {
+        if (layer != null && hasAnyLayerTransformProxy(layer, inferredReplacementProxies)) {
           hasLayerProxy = true;
           break;
         }
@@ -1034,13 +1038,14 @@ public class VnRenderer {
         drawLayer = new SpriteLayer(
             eyeFocus.selectedPath(),
             eyeFocus.selectedLayerId(),
-            timelineLayerTargetNames(characterId, expression, eyeFocus.selectedLayerId()),
+            timelineDeclaredLayerTargetNames(character, characterId, expression, eyeFocus.selectedLayerId()),
             layer.groupTargets(),
             selectedImage);
         nudgeX = eyeFocus.nudgeX();
         nudgeY = eyeFocus.nudgeY();
       }
-      List<LayerTransformTarget> transforms = resolveLayerTransforms(drawLayer, layers);
+      List<LayerTransformTarget> transforms = resolveLayerTransforms(
+          drawLayer, inferredReplacementProxies);
       if (transforms.stream().anyMatch(target -> target.exact() && target.proxy() != null && !target.proxy().isVisible())) {
         continue;
       }
@@ -1329,7 +1334,10 @@ public class VnRenderer {
     return hasTimelinePosition(proxy) ? proxy.getY() - defaultY : 0.0;
   }
 
-  private boolean hasAnyLayerTransformProxy(SpriteLayer layer) {
+  private boolean hasAnyLayerTransformProxy(
+      SpriteLayer layer,
+      Map<String, Entity2D> inferredReplacementProxies
+  ) {
     if (timelineAccessor == null || layer == null) return false;
     if (firstProxy(layer.targetNames()) != null) return true;
     if (layer.groupTargets() != null) {
@@ -1337,10 +1345,13 @@ public class VnRenderer {
         if (groupTarget != null && firstProxy(groupTarget.targetNames()) != null) return true;
       }
     }
-    return false;
+    return inferredReplacementProxies != null && inferredReplacementProxies.containsKey(layer.layerId());
   }
 
-  private List<LayerTransformTarget> resolveLayerTransforms(SpriteLayer layer, List<SpriteLayer> expressionLayers) {
+  private List<LayerTransformTarget> resolveLayerTransforms(
+      SpriteLayer layer,
+      Map<String, Entity2D> inferredReplacementProxies
+  ) {
     if (timelineAccessor == null || layer == null) return List.of();
     List<LayerTransformTarget> transforms = new ArrayList<>();
     if (layer.groupTargets() != null) {
@@ -1357,30 +1368,79 @@ public class VnRenderer {
       return List.copyOf(transforms);
     }
 
-    if (!hasBroadLayerProxyCoverage(expressionLayers)) return List.copyOf(transforms);
-    for (SpriteLayer sibling : expressionLayers) {
-      if (sibling == null || sibling == layer) continue;
-      Entity2D siblingProxy = firstProxy(sibling.targetNames());
-      if (siblingProxy != null) {
-        transforms.add(new LayerTransformTarget(siblingProxy, null, false));
-        return List.copyOf(transforms);
-      }
+    Entity2D inferred = inferredReplacementProxies == null ? null : inferredReplacementProxies.get(layer.layerId());
+    if (inferred != null) {
+      transforms.add(new LayerTransformTarget(inferred, null, false));
+      return List.copyOf(transforms);
     }
+
     return List.copyOf(transforms);
   }
 
-  private boolean hasBroadLayerProxyCoverage(List<SpriteLayer> expressionLayers) {
-    if (timelineAccessor == null || expressionLayers == null || expressionLayers.isEmpty()) return false;
-    int layerCount = 0;
-    int proxyCount = 0;
+  private Map<String, Entity2D> inferredReplacementProxies(
+      VnCharacter character,
+      String characterId,
+      String expression,
+      List<SpriteLayer> expressionLayers
+  ) {
+    if (timelineAccessor == null || character == null || expressionLayers == null || expressionLayers.isEmpty()) {
+      return Map.of();
+    }
+    Set<String> activeLayerIds = new LinkedHashSet<>();
     for (SpriteLayer layer : expressionLayers) {
-      if (layer == null || layer.targetNames() == null || layer.targetNames().isEmpty()) continue;
-      layerCount++;
-      if (firstProxy(layer.targetNames()) != null) {
-        proxyCount++;
+      if (layer != null && layer.layerId() != null && !layer.layerId().isBlank()) {
+        activeLayerIds.add(layer.layerId());
       }
     }
-    return shouldFallbackMissingLayerProxy(layerCount, proxyCount);
+    Map<String, Entity2D> animatedLayers = new LinkedHashMap<>();
+    for (String declaredLayerId : character.getLayerIds()) {
+      if (declaredLayerId == null || declaredLayerId.isBlank() || activeLayerIds.contains(declaredLayerId)) continue;
+      Entity2D proxy = firstProxy(timelineDeclaredLayerTargetNames(
+          character, characterId, expression, declaredLayerId));
+      if (proxy != null) animatedLayers.put(declaredLayerId, proxy);
+    }
+    if (animatedLayers.isEmpty()) return Map.of();
+
+    Map<String, Entity2D> inferred = new LinkedHashMap<>();
+    for (SpriteLayer layer : expressionLayers) {
+      if (layer == null || layer.layerId() == null || layer.layerId().isBlank()
+          || firstProxy(layer.targetNames()) != null) {
+        continue;
+      }
+      String inferredLayerId = LayeredCharacterResolver.inferReplacementLayerId(
+          layer.layerId(), animatedLayers.keySet());
+      if (inferredLayerId != null) {
+        Entity2D proxy = animatedLayers.get(inferredLayerId);
+        if (proxy != null) inferred.put(layer.layerId(), proxy);
+      }
+    }
+    return inferred.isEmpty() ? Map.of() : Map.copyOf(inferred);
+  }
+
+  private List<String> timelineDeclaredLayerTargetNames(
+      VnCharacter character,
+      String characterId,
+      String expression,
+      String layerId
+  ) {
+    String safeCharacter = selectorSafeName(characterId);
+    String safeLayer = selectorSafeName(layerId);
+    if (safeCharacter.isBlank() || safeLayer.isBlank()) return List.of();
+    LinkedHashSet<String> names = new LinkedHashSet<>();
+    names.add(safeCharacter + "_" + safeLayer);
+    String currentExpression = selectorSafeName(expression == null || expression.isBlank() ? "neutral" : expression);
+    if (!currentExpression.isBlank()) {
+      names.add(safeCharacter + "_" + currentExpression + "_" + safeLayer);
+    }
+    if (character != null) {
+      for (String declaredExpression : character.getExpressionLayerIdsByName().keySet()) {
+        String safeExpression = selectorSafeName(declaredExpression);
+        if (!safeExpression.isBlank()) {
+          names.add(safeCharacter + "_" + safeExpression + "_" + safeLayer);
+        }
+      }
+    }
+    return List.copyOf(names);
   }
 
   private Entity2D firstProxy(List<String> targetNames) {
@@ -1391,11 +1451,6 @@ public class VnRenderer {
       if (proxy != null) return proxy;
     }
     return null;
-  }
-
-  static boolean shouldFallbackMissingLayerProxy(int layerCount, int proxyCount) {
-    if (layerCount <= 2 || proxyCount <= 0) return false;
-    return proxyCount >= Math.max(2, layerCount - 1);
   }
 
   private boolean hasTimelinePosition(Entity2D proxy) {
@@ -1426,7 +1481,7 @@ public class VnRenderer {
       String path = layerPaths.get(i);
       String layerId = i < layerIds.size() ? layerIds.get(i) : "";
       if (layerId == null || layerId.isBlank()) layerId = fallbackLayerId(path, i);
-      List<String> targetNames = timelineLayerTargetNames(characterId, expression, layerId);
+      List<String> targetNames = timelineDeclaredLayerTargetNames(character, characterId, expression, layerId);
       List<GroupLayerTarget> groupTargets = timelineGroupTargets(character, characterId, expression, layerId);
       layers.add(new SpriteLayer(path, layerId, targetNames, groupTargets, loadSpriteLayerImage(path)));
     }

--- a/modules/fx/src/test/java/com/jvn/fx/vn/VnRendererLayerProxyFallbackTest.java
+++ b/modules/fx/src/test/java/com/jvn/fx/vn/VnRendererLayerProxyFallbackTest.java
@@ -1,22 +1,10 @@
 package com.jvn.fx.vn;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
 class VnRendererLayerProxyFallbackTest {
-
-  @Test
-  void fallsBackOnlyWhenOneLayerIsMissingFromABroadTimelineDrivenExpression() {
-    assertTrue(VnRenderer.shouldFallbackMissingLayerProxy(8, 7));
-    assertTrue(VnRenderer.shouldFallbackMissingLayerProxy(3, 2));
-
-    assertFalse(VnRenderer.shouldFallbackMissingLayerProxy(8, 6));
-    assertFalse(VnRenderer.shouldFallbackMissingLayerProxy(2, 1));
-    assertFalse(VnRenderer.shouldFallbackMissingLayerProxy(8, 0));
-  }
 
   @Test
   void layerGroupTargetsExposeExpressionSpecificAndStableAliases() {

--- a/modules/scripting/src/main/java/com/jvn/scripting/jes/runtime/JesScene2D.java
+++ b/modules/scripting/src/main/java/com/jvn/scripting/jes/runtime/JesScene2D.java
@@ -29,6 +29,7 @@ public class JesScene2D extends Scene2DBase {
   private PhysicsDebugOverlay2D debugOverlay;
   private final List<Binding> bindings = new ArrayList<>();
   private final Map<String, Entity2D> named = new HashMap<>();
+  private final Map<String, Entity2D> aliases = new HashMap<>();
   private final Map<String, Stats> statsByEntity = new HashMap<>();
   private final Map<String, Item> items = new HashMap<>();
   private final Map<String, Inventory> inventories = new HashMap<>();
@@ -134,8 +135,16 @@ public class JesScene2D extends Scene2DBase {
   public void setDebug(boolean d) { this.debug = d; }
   public void addBinding(String key, String action, Map<String,Object> props) { bindings.add(new Binding(key, action, props)); }
   public void registerEntity(String name, Entity2D e) {
-    if (name != null && !name.isBlank() && e != null && !named.containsKey(name)) {
+    if (name != null && !name.isBlank() && e != null
+        && !named.containsKey(name) && !aliases.containsKey(name)) {
       named.put(name, e);
+      spawnPositions.put(name, new double[]{ e.getX(), e.getY() });
+    }
+  }
+  public void registerEntityAlias(String name, Entity2D e) {
+    if (name != null && !name.isBlank() && e != null
+        && !named.containsKey(name) && !aliases.containsKey(name)) {
+      aliases.put(name, e);
       spawnPositions.put(name, new double[]{ e.getX(), e.getY() });
     }
   }
@@ -179,7 +188,10 @@ public class JesScene2D extends Scene2DBase {
     }
   }
   public java.util.Set<String> names() { return named.keySet(); }
-  public Entity2D find(String name) { return named.get(name); }
+  public Entity2D find(String name) {
+    Entity2D entity = named.get(name);
+    return entity != null ? entity : aliases.get(name);
+  }
   public Map<String, Entity2D> exportNamed() { return java.util.Collections.unmodifiableMap(new java.util.HashMap<>(named)); }
   public java.util.List<Binding> exportBindings() { return java.util.Collections.unmodifiableList(new java.util.ArrayList<>(bindings)); }
   public java.util.List<JesAst.TimelineAction> exportTimeline() { return java.util.Collections.unmodifiableList(new java.util.ArrayList<>(timeline)); }

--- a/modules/scripting/src/test/java/com/jvn/scripting/jes/runtime/JesSceneStateTest.java
+++ b/modules/scripting/src/test/java/com/jvn/scripting/jes/runtime/JesSceneStateTest.java
@@ -7,6 +7,22 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class JesSceneStateTest {
   @Test
+  public void entityAliasesResolveWithoutCreatingAdditionalSceneEntities() {
+    JesScene2D scene = new JesScene2D();
+    Sprite2D body = new Sprite2D("body.png", 10, 10);
+    scene.add(body);
+    scene.registerEntity("john_current_body", body);
+    scene.registerEntityAlias("john_neutral_body", body);
+    scene.registerEntityAlias("john_talking_body", body);
+
+    assertSame(body, scene.find("john_current_body"));
+    assertSame(body, scene.find("john_neutral_body"));
+    assertSame(body, scene.find("john_talking_body"));
+    assertEquals(java.util.Set.of("john_current_body"), scene.names());
+    assertEquals(java.util.Set.of("john_current_body"), scene.exportNamed().keySet());
+  }
+
+  @Test
   public void savesAndRestoresCoreState() {
     JesScene2D scene = new JesScene2D();
     Sprite2D hero = new Sprite2D("hero.png", 10, 10);


### PR DESCRIPTION
## What changed

- register expression-independent Puppeteer layer aliases such as `john_body_default` without duplicating scene entities
- keep preview aliases aligned with the VN runtime renderer
- show a JVN error overlay when a timeline targets declared character layers or groups absent from the active `[show]` composition
- include the invalid target names and an actionable correction in the overlay
- add regression coverage for alias resolution and active/inactive timeline layer targets

## Why

Puppeteer could export stable layer target names that resolved at runtime but not in its launch/preview scene. Separately, timelines aimed at layers missing from the current character composition failed silently, producing confusing results such as a floating head.

## Impact

Puppeteer preview and exported timeline playback now resolve the same stable layer names. Invalid active-composition targets surface through the existing JVN error popup instead of silently doing nothing.

## Validation

- `:core:test --tests 'com.jvn.core.animation.*' --tests 'com.jvn.core.vn.DefaultVnInteropQuotedArgsTest'`
- `:runtime:test --tests 'com.jvn.runtime.RuntimeTimelineEventInteropTest'`
- `:editor:test --tests 'com.jvn.editor.ui.PuppeteerLauncherPanelTest' --tests 'com.jvn.editor.ui.actioneditor.CodeRoundTripTest'`
- `:scripting:test --tests 'com.jvn.scripting.jes.runtime.JesSceneStateTest'`
- `git diff --check`
