### PR TITLE
Make character animation groups resilient

### DIFF
--- a/docs/editor/puppeteer/puppeteer.md
+++ b/docs/editor/puppeteer/puppeteer.md
@@ -726,7 +726,7 @@ Layered character launches also create expression-specific aliases:
 
 Group transforms are applied before individual layer transforms. This lets authors animate broad motion on `hero_head` while keeping small corrections on `hero_eyes_neutral` or `hero_mouth_smile`.
 
-Puppeteer uses the stable `hero_<layer>` name as the canonical exported track. The expression-specific form remains an alias for importing older timelines. A stable layer target follows that exact layer when it is reused by another expression; it does not automatically transfer to a replacement layer with a different ID. Use an `@chargroup` containing the alternative layer IDs when one transform should follow a semantic part such as every body or arm variant.
+Puppeteer uses the stable `hero_<layer>` name as the canonical exported track. The expression-specific form remains an alias for importing older timelines. A stable layer target follows that exact layer when it is reused by another expression and transfers to a uniquely inferred same-lane replacement. Use an `@chargroup` when several variants should share one explicit semantic target or naming is ambiguous.
 
 ### JES Launch
 
@@ -753,6 +753,8 @@ timeline {
 ```
 
 For declared layered characters, a timeline may intentionally target a layer or group absent from the current `[show]` composition. The engine pre-arms that proxy and the editor reports a warning so the delayed effect is explicit. When a later expression substitutes a conventionally named variant such as `body_default` → `body_no_limbs` or `arm_front_default` → `arm_front_holding_wrist`, the renderer infers the shared anatomical lane and carries the transform without requiring an `@chargroup`. An explicit group remains available when naming is ambiguous or a project wants to override the inferred lane.
+
+Large rigs can keep that override concise. `@chargroup john body_orientation $body_* | $neck_* | $arm_front_* | $arm_behind_*` expands all matching declared layers, and Puppeteer exports the expression-independent `john_body_orientation` target as the canonical group track. Expression-qualified group names remain import aliases for older timelines.
 
 ### Contextual timeline diagnostics
 

--- a/docs/scripting/vns/language/vns-directives.md
+++ b/docs/scripting/vns/language/vns-directives.md
@@ -180,6 +180,8 @@ Registers a named movable group of character layers. Groups make large rigs easi
 ```
 
 - `layerSpec` uses the same pipe-separated `$layerId` references as `@charpreset`.
+- Layer globs are supported: `$body_*`, `$arm_front_*`, and `?` for one character. They expand to declared layer IDs in deterministic name order; a glob that matches nothing is an error.
+- Long `@chargroup` and `@charpreset` declarations may continue onto the next line with a trailing `\`.
 - `$groupId` can reference an earlier `@chargroup`, allowing nested groups.
 - `parent=<parentGroupId>` makes this group inherit the parent group's timeline transform.
 - `pivot=<x>,<y>` sets the default group pivot for rotation/scale until a timeline pivot overrides it.
@@ -196,6 +198,7 @@ Registers a named movable group of character layers. Groups make large rigs easi
 @charlayer john mouth_smile assets/characters/john/mouth_smile.png
 
 @chargroup john head pivot=0.5,0.28 $head_base | $eyes_neutral | $mouth_smile
+@chargroup john body_orientation pivot=0.5,1 $body_* | $neck_* | $arm_front_* | $arm_behind_*
 @charpreset john neutral $body_default | $head
 ```
 

--- a/docs/scripting/vns/presentation/vns-movable-layer-groups.md
+++ b/docs/scripting/vns/presentation/vns-movable-layer-groups.md
@@ -82,6 +82,16 @@ With `@chargroup`, write the layer list once:
 
 You can choose how much to group. If every expression uses the same head base but different eyes and mouths, keep only stable layers in `head_base_group`, or define expression-specific groups such as `head_neutral`, `head_happy`, and `head_angry`.
 
+For characters with many one-off variants, use layer globs instead of listing every sprite:
+
+```vns
+@chargroup john body_orientation pivot=0.5,1 \
+  $body_* | $neck_* | \
+  $arm_front_* | $arm_behind_*
+```
+
+The glob expands against previously declared `@charlayer` IDs. Expansion is deterministic, and a pattern that matches nothing is a script error rather than a broken runtime target. Animate the resulting group through the stable `john_body_orientation` target across expression changes.
+
 ---
 
 ## Nested Groups

--- a/modules/core/src/main/java/com/jvn/core/project/ProjectDependencyValidator.java
+++ b/modules/core/src/main/java/com/jvn/core/project/ProjectDependencyValidator.java
@@ -41,6 +41,7 @@ import com.jvn.core.menu.config.MenuProfile;
 import com.jvn.core.menu.config.MenuProfileLoader;
 import com.jvn.core.menu.config.MenuScreenSpec;
 import com.jvn.core.vn.VnArgTokenizer;
+import com.jvn.core.vn.LayeredCharacterResolver;
 import com.jvn.core.vn.script.VnScriptParser;
 import com.jvn.core.vn.stage.VnStagePresetLoader;
 
@@ -434,7 +435,10 @@ public final class ProjectDependencyValidator {
 
   private static void inspectVnsFile(ValidationContext ctx, Path file, VnScriptParser parser) {
     String rel = ctx.rel(file);
-    List<String> lines = readLines(ctx, file);
+    List<String> physicalLines = readLines(ctx, file);
+    List<String> lines = List.of(LayeredCharacterResolver
+        .collapseLayerDirectiveContinuations(String.join("\n", physicalLines))
+        .split("\\R", -1));
     for (int i = 0; i < lines.size(); i++) {
       String trimmed = lines.get(i).trim();
       if (!ctx.inlineJavaReported && isInlineJavaStart(trimmed)) {

--- a/modules/core/src/main/java/com/jvn/core/vn/LayeredCharacterResolver.java
+++ b/modules/core/src/main/java/com/jvn/core/vn/LayeredCharacterResolver.java
@@ -25,6 +25,7 @@ public final class LayeredCharacterResolver {
   }
 
   public record CharacterRef(String characterId, String localId) {}
+  public record LayerMatch(String characterId, String layerId, String path) {}
 
   public static CharacterRef parseReference(String rawRef, String defaultCharacterId) {
     String ref = rawRef == null ? "" : rawRef.trim();
@@ -44,24 +45,123 @@ public final class LayeredCharacterResolver {
   public static String resolveLayerPath(Map<String, ? extends Map<String, String>> layersByCharacter,
                                         String defaultCharacterId,
                                         String rawRef) {
-    if (layersByCharacter == null || rawRef == null || rawRef.isBlank()) {
-      return null;
-    }
+    List<LayerMatch> matches = resolveLayerMatches(layersByCharacter, defaultCharacterId, rawRef);
+    return matches.isEmpty() ? null : matches.get(0).path();
+  }
+
+  /**
+   * Resolve an exact layer reference or a glob such as {@code body_*}. Globs
+   * are useful in {@code @chargroup} declarations so a semantic animation
+   * group can cover many sprite variants without repeating every identifier.
+   */
+  public static List<LayerMatch> resolveLayerMatches(
+      Map<String, ? extends Map<String, String>> layersByCharacter,
+      String defaultCharacterId,
+      String rawRef
+  ) {
+    if (layersByCharacter == null || rawRef == null || rawRef.isBlank()) return List.of();
     CharacterRef ref = parseReference(rawRef, defaultCharacterId);
-    if (ref.characterId() == null || ref.characterId().isBlank() || ref.localId() == null || ref.localId().isBlank()) {
-      return null;
+    if (ref.characterId() == null || ref.characterId().isBlank()
+        || ref.localId() == null || ref.localId().isBlank()) {
+      return List.of();
     }
     Map<String, String> layerMap = layersByCharacter.get(ref.characterId());
-    if (layerMap == null || layerMap.isEmpty()) {
-      return null;
+    if (layerMap == null || layerMap.isEmpty()) return List.of();
+
+    String localId = ref.localId();
+    if (!containsGlob(localId)) {
+      for (String candidate : candidateLayerIds(localId)) {
+        String path = layerMap.get(candidate);
+        if (path != null && !path.isBlank()) {
+          return List.of(new LayerMatch(ref.characterId(), candidate, path.trim()));
+        }
+      }
+      return List.of();
     }
-    for (String candidate : candidateLayerIds(ref.localId())) {
-      String path = layerMap.get(candidate);
-      if (path != null && !path.isBlank()) {
-        return path.trim();
+
+    return layerMap.entrySet().stream()
+        .filter(entry -> entry.getKey() != null && globMatches(localId, entry.getKey()))
+        .filter(entry -> entry.getValue() != null && !entry.getValue().isBlank())
+        .sorted(Map.Entry.comparingByKey())
+        .map(entry -> new LayerMatch(ref.characterId(), entry.getKey(), entry.getValue().trim()))
+        .toList();
+  }
+
+  public static boolean containsGlob(String value) {
+    return value != null && (value.indexOf('*') >= 0 || value.indexOf('?') >= 0);
+  }
+
+  /**
+   * Joins backslash-continued layered declarations while retaining the same
+   * number of physical lines, so editor and parser diagnostics keep accurate
+   * source locations.
+   */
+  public static String collapseLayerDirectiveContinuations(String source) {
+    if (source == null || source.isEmpty()) return source == null ? "" : source;
+    String[] lines = source.split("\\R", -1);
+    for (int start = 0; start < lines.length; start++) {
+      String trimmed = lines[start] == null ? "" : lines[start].trim();
+      if (!startsLayerDirective(trimmed) || !hasTrailingContinuation(trimmed)) continue;
+      StringBuilder logical = new StringBuilder(lines[start]);
+      int cursor = start;
+      while (hasTrailingContinuation(logical.toString().trim()) && cursor + 1 < lines.length) {
+        String withoutSlash = removeTrailingContinuation(logical.toString());
+        logical.setLength(0);
+        logical.append(withoutSlash).append(' ').append(lines[++cursor].trim());
+        lines[cursor] = "";
+      }
+      lines[start] = logical.toString();
+      start = cursor;
+    }
+    return String.join("\n", lines);
+  }
+
+  private static boolean startsLayerDirective(String trimmed) {
+    if (trimmed == null) return false;
+    return trimmed.regionMatches(true, 0, "@chargroup", 0, "@chargroup".length())
+        || trimmed.regionMatches(true, 0, "@charpreset", 0, "@charpreset".length());
+  }
+
+  private static boolean hasTrailingContinuation(String value) {
+    if (value == null) return false;
+    int index = value.length() - 1;
+    while (index >= 0 && Character.isWhitespace(value.charAt(index))) index--;
+    return index >= 0 && value.charAt(index) == '\\';
+  }
+
+  private static String removeTrailingContinuation(String value) {
+    if (value == null || value.isEmpty()) return "";
+    int index = value.length() - 1;
+    while (index >= 0 && Character.isWhitespace(value.charAt(index))) index--;
+    if (index >= 0 && value.charAt(index) == '\\') {
+      return value.substring(0, index).stripTrailing();
+    }
+    return value;
+  }
+
+  static boolean globMatches(String pattern, String value) {
+    if (pattern == null || value == null) return false;
+    int patternIndex = 0;
+    int valueIndex = 0;
+    int starIndex = -1;
+    int starValueIndex = -1;
+    while (valueIndex < value.length()) {
+      if (patternIndex < pattern.length()
+          && (pattern.charAt(patternIndex) == '?' || pattern.charAt(patternIndex) == value.charAt(valueIndex))) {
+        patternIndex++;
+        valueIndex++;
+      } else if (patternIndex < pattern.length() && pattern.charAt(patternIndex) == '*') {
+        starIndex = patternIndex++;
+        starValueIndex = valueIndex;
+      } else if (starIndex >= 0) {
+        patternIndex = starIndex + 1;
+        valueIndex = ++starValueIndex;
+      } else {
+        return false;
       }
     }
-    return null;
+    while (patternIndex < pattern.length() && pattern.charAt(patternIndex) == '*') patternIndex++;
+    return patternIndex == pattern.length();
   }
 
   public static List<String> candidateLayerIds(String rawLayerId) {

--- a/modules/core/src/main/java/com/jvn/core/vn/script/VnScriptParser.java
+++ b/modules/core/src/main/java/com/jvn/core/vn/script/VnScriptParser.java
@@ -3,7 +3,7 @@ package com.jvn.core.vn.script;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
+import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -480,7 +480,9 @@ public class VnScriptParser {
                          IncludeResolver resolver,
                          ParseState state,
                          Deque<String> includeStack) throws IOException {
-    BufferedReader reader = new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8));
+    String sourceText = new String(input.readAllBytes(), StandardCharsets.UTF_8);
+    BufferedReader reader = new BufferedReader(new StringReader(
+        LayeredCharacterResolver.collapseLayerDirectiveContinuations(sourceText)));
     String line;
     int lineNumber = 0;
 
@@ -800,7 +802,8 @@ public class VnScriptParser {
         if (options.spec().isBlank()) {
           throw parseError(sourceName, lineNumber, "@chargroup layer spec cannot be empty", rawLine);
         }
-        LayerPresetSpec resolvedSpec = resolveLayerPresetSpec(state, id, options.spec(), sourceName, lineNumber, rawLine);
+        LayerPresetSpec resolvedSpec = resolveLayerPresetSpec(
+            state, id, options.spec(), sourceName, lineNumber, rawLine, "@chargroup");
         getOrCreateCharacterBuilder(state, id).addLayerGroup(
             groupId,
             options.parentId(),
@@ -820,7 +823,8 @@ public class VnScriptParser {
         if (spec.isEmpty()) {
           throw parseError(sourceName, lineNumber, "@charpreset layer spec cannot be empty", rawLine);
         }
-        LayerPresetSpec resolvedSpec = resolveLayerPresetSpec(state, id, spec, sourceName, lineNumber, rawLine);
+        LayerPresetSpec resolvedSpec = resolveLayerPresetSpec(
+            state, id, spec, sourceName, lineNumber, rawLine, "@charpreset");
         com.jvn.core.vn.VnCharacter.Builder cb = state.charBuilders.get(id);
         if (cb == null) {
           cb = com.jvn.core.vn.VnCharacter.builder(id);
@@ -2820,7 +2824,8 @@ public class VnScriptParser {
                                                  String spec,
                                                  String sourceName,
                                                  int lineNumber,
-                                                 String rawLine) throws IOException {
+                                                 String rawLine,
+                                                 String context) throws IOException {
     String[] tokens = spec.split("\\|");
     List<String> resolved = new ArrayList<>();
     List<String> layerIds = new ArrayList<>();
@@ -2831,7 +2836,7 @@ public class VnScriptParser {
       if (part.startsWith("$")) {
         String rawRef = part.substring(1).trim();
         if (rawRef.isEmpty()) {
-          throw parseError(sourceName, lineNumber, "@charpreset contains empty $layer reference", rawLine);
+          throw parseError(sourceName, lineNumber, context + " contains empty $layer reference", rawLine);
         }
         List<LayerReference> refs = resolveLayerOrGroupReference(
             state,
@@ -2840,7 +2845,7 @@ public class VnScriptParser {
             sourceName,
             lineNumber,
             rawLine,
-            "@charpreset");
+            context);
         for (LayerReference ref : refs) {
           resolved.add(ref.path());
           layerIds.add(ref.layerId());
@@ -2873,7 +2878,7 @@ public class VnScriptParser {
       }
     }
     if (resolved.isEmpty()) {
-      throw parseError(sourceName, lineNumber, "@charpreset produced no layers", rawLine);
+      throw parseError(sourceName, lineNumber, context + " produced no layers", rawLine);
     }
     return new LayerPresetSpec(String.join(" | ", resolved), layerIds);
   }
@@ -3196,8 +3201,17 @@ public class VnScriptParser {
                                                             int lineNumber,
                                                             String rawLine,
                                                             String context) throws IOException {
-    LayerReference layer = tryResolveLayerReference(state, defaultCharacterId, rawRef);
-    if (layer != null) return List.of(layer);
+    List<LayeredCharacterResolver.LayerMatch> layerMatches =
+        LayeredCharacterResolver.resolveLayerMatches(state.charLayers, defaultCharacterId, rawRef);
+    if (!layerMatches.isEmpty()) {
+      LayeredCharacterResolver.CharacterRef layerRef =
+          LayeredCharacterResolver.parseReference(rawRef, defaultCharacterId);
+      boolean glob = LayeredCharacterResolver.containsGlob(layerRef.localId());
+      return layerMatches.stream()
+          .map(match -> new LayerReference(
+              match.path(), glob ? match.layerId() : layerRef.localId()))
+          .toList();
+    }
 
     LayeredCharacterResolver.CharacterRef groupRef = LayeredCharacterResolver.parseReference(rawRef, defaultCharacterId);
     com.jvn.core.vn.VnCharacter.Builder groupCharacter = state.charBuilders.get(groupRef.characterId());
@@ -3210,6 +3224,15 @@ public class VnScriptParser {
         if (groupLayer != null) out.add(groupLayer);
       }
       if (!out.isEmpty()) return out;
+    }
+
+    if (LayeredCharacterResolver.containsGlob(groupRef.localId())) {
+      throw parseError(
+          sourceName,
+          lineNumber,
+          context + " layer glob '$" + rawRef + "' matched no declared @charlayer IDs for character '"
+              + groupRef.characterId() + "'",
+          rawLine);
     }
 
     if (groupCharacter == null || groupCharacter.getLayerGroups().isEmpty()) {

--- a/modules/core/src/test/java/com/jvn/core/project/ProjectDependencyValidatorTest.java
+++ b/modules/core/src/test/java/com/jvn/core/project/ProjectDependencyValidatorTest.java
@@ -34,7 +34,9 @@ class ProjectDependencyValidatorTest {
         @background missing assets/backgrounds/missing.png
         @charimg hero neutral assets/characters/hero.png
         @charlayer hero base assets/characters/hero_base.png
-        @chargroup hero head pivot=0.5,0.28 $base | assets/characters/hero_head.png
+        @chargroup hero head pivot=0.5,0.28 \\
+          $base | \\
+          assets/characters/hero_head.png
         @charpreset hero special $base | assets/characters/hero_smile.png
         @stagepreset sunset config/stage/sunset.stagepreset
 

--- a/modules/core/src/test/java/com/jvn/core/vn/LayeredCharacterResolverTest.java
+++ b/modules/core/src/test/java/com/jvn/core/vn/LayeredCharacterResolverTest.java
@@ -3,11 +3,42 @@ package com.jvn.core.vn;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
 class LayeredCharacterResolverTest {
+
+  @Test
+  void expandsLayerGlobsDeterministically() {
+    Map<String, Map<String, String>> layers = Map.of("john", Map.of(
+        "body_no_limbs", "body-no-limbs.png",
+        "arm_front_default", "arm.png",
+        "body_default", "body.png"));
+
+    assertEquals(
+        List.of("body_default", "body_no_limbs"),
+        LayeredCharacterResolver.resolveLayerMatches(layers, "john", "body_*").stream()
+            .map(LayeredCharacterResolver.LayerMatch::layerId)
+            .toList());
+    assertEquals(
+        List.of("arm_front_default"),
+        LayeredCharacterResolver.resolveLayerMatches(layers, "", "john.arm_front_*").stream()
+            .map(LayeredCharacterResolver.LayerMatch::layerId)
+            .toList());
+  }
+
+  @Test
+  void collapsesLayerDirectiveContinuationsWithoutChangingLineCount() {
+    String source = "@chargroup john body \\\n  $body_* | \\\n  $neck_*\n@label start\n";
+
+    String collapsed = LayeredCharacterResolver.collapseLayerDirectiveContinuations(source);
+
+    assertEquals(source.split("\\n", -1).length, collapsed.split("\\n", -1).length);
+    assertEquals("@chargroup john body $body_* | $neck_*", collapsed.lines().findFirst().orElseThrow());
+  }
 
   @Test
   void infersLightningBodyAndFrontArmReplacementLanes() {

--- a/modules/core/src/test/java/com/jvn/core/vn/VnScriptParserTest.java
+++ b/modules/core/src/test/java/com/jvn/core/vn/VnScriptParserTest.java
@@ -251,6 +251,58 @@ public class VnScriptParserTest {
   }
 
   @Test
+  public void characterLayerGroupsExpandVariantGlobs() throws Exception {
+    String script = """
+      @scenario layered_demo
+      @character john "John"
+      @charlayer john arm_behind_default assets/john/arm_behind.png
+      @charlayer john body_default assets/john/body.png
+      @charlayer john body_no_limbs assets/john/body_no_limbs.png
+      @charlayer john neck_normal assets/john/neck.png
+      @charlayer john arm_front_default assets/john/arm_front.png
+      @charlayer john arm_front_holding_wrist assets/john/holding.png
+      @chargroup john body_orientation pivot=0.5,1 \\
+        $arm_behind_* | $body_* | \\
+        $neck_* | $arm_front_*
+      @charpreset john holding $body_no_limbs | $neck_normal | $arm_front_holding_wrist
+
+      @label start
+      [show john center holding]
+      [end]
+    """;
+
+    VnCharacter john = new VnScriptParser().parseFromString(script).getCharacter("john");
+
+    assertNotNull(john);
+    VnCharacter.LayerGroup group = john.getLayerGroup("body_orientation");
+    assertNotNull(group);
+    assertEquals(List.of(
+        "arm_behind_default",
+        "body_default",
+        "body_no_limbs",
+        "neck_normal",
+        "arm_front_default",
+        "arm_front_holding_wrist"), group.layerIds());
+    assertEquals(List.of(group), john.getLayerGroupChainForLayer("body_no_limbs"));
+    assertEquals(List.of(group), john.getLayerGroupChainForLayer("arm_front_holding_wrist"));
+  }
+
+  @Test
+  public void characterLayerGroupRejectsGlobThatMatchesNothing() {
+    IOException error = assertThrows(IOException.class, () -> new VnScriptParser().parseFromString("""
+      @scenario layered_demo
+      @character john "John"
+      @charlayer john body_default assets/john/body.png
+      @chargroup john body_orientation $missing_*
+      @label start
+      [end]
+    """));
+
+    assertTrue(error.getMessage().contains("$missing_*"));
+    assertTrue(error.getMessage().contains("@chargroup"));
+  }
+
+  @Test
   public void parsesNestedCharacterLayerGroups() throws Exception {
     String script = """
       @scenario layered_demo

--- a/modules/editor/src/main/java/com/jvn/editor/ui/LayeredCharacterProjectCatalog.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/LayeredCharacterProjectCatalog.java
@@ -266,6 +266,7 @@ public final class LayeredCharacterProjectCatalog {
                                   Map<String, LinkedHashMap<String, String>> rawGroupsByCharacter,
                                   Map<String, LinkedHashMap<String, String>> rawPresetsByCharacter) {
     if (source == null || source.isBlank()) return;
+    source = LayeredCharacterResolver.collapseLayerDirectiveContinuations(source);
     String[] lines = source.split("\\R");
     for (String line : lines) {
       if (line == null) continue;
@@ -390,8 +391,14 @@ public final class LayeredCharacterProjectCatalog {
       String rawRef,
       Deque<String> groupStack
   ) {
-    ResolvedLayer layer = resolveLayerReference(layersByCharacter, defaultCharacterId, rawRef);
-    if (layer != null) return List.of(layer);
+    List<LayeredCharacterResolver.LayerMatch> layerMatches =
+        LayeredCharacterResolver.resolveLayerMatches(layersByCharacter, defaultCharacterId, rawRef);
+    if (!layerMatches.isEmpty()) {
+      return layerMatches.stream()
+          .map(match -> new ResolvedLayer(
+              match.characterId(), match.layerId(), normalizeRelativePath(match.path())))
+          .toList();
+    }
 
     LayeredCharacterResolver.CharacterRef ref = LayeredCharacterResolver.parseReference(rawRef, defaultCharacterId);
     if (ref.characterId() == null || ref.characterId().isBlank()

--- a/modules/editor/src/main/java/com/jvn/editor/ui/PuppeteerLauncherPanel.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/PuppeteerLauncherPanel.java
@@ -1221,6 +1221,7 @@ button then opens it in the editor."""));
       String sourceName,
       IncludeSourceResolver includeResolver
   ) {
+    source = LayeredCharacterResolver.collapseLayerDirectiveContinuations(source);
     String[] lines = source.split("\n", -1);
     int limit = Math.max(0, Math.min(upToLine, lines.length - 1));
 
@@ -1604,8 +1605,8 @@ button then opens it in the editor."""));
     String safeGroup = selectorSafeName(groupId);
     if (safeCharacter.isBlank() || safeExpression.isBlank() || safeGroup.isBlank()) return List.of();
     LinkedHashSet<String> names = new LinkedHashSet<>();
-    names.add(safeCharacter + "_" + safeExpression + "_" + safeGroup);
     names.add(safeCharacter + "_" + safeGroup);
+    names.add(safeCharacter + "_" + safeExpression + "_" + safeGroup);
     return List.copyOf(names);
   }
 
@@ -2049,6 +2050,7 @@ button then opens it in the editor."""));
       Set<String> includeStack
   ) {
     if (source == null || source.isBlank()) return;
+    source = LayeredCharacterResolver.collapseLayerDirectiveContinuations(source);
     String normalizedSource = normalizeSourceName(sourceName);
     if (!includeStack.add(normalizedSource)) return;
     try {
@@ -2314,8 +2316,13 @@ button then opens it in the editor."""));
       String defaultCharacterId,
       String rawRef
   ) {
-    CharacterLayerEntry layer = resolveLayerEntry(layersByCharacter, defaultCharacterId, rawRef);
-    if (layer != null) return List.of(layer);
+    List<LayeredCharacterResolver.LayerMatch> layerMatches =
+        LayeredCharacterResolver.resolveLayerMatches(layersByCharacter, defaultCharacterId, rawRef);
+    if (!layerMatches.isEmpty()) {
+      return layerMatches.stream()
+          .map(match -> new CharacterLayerEntry(match.layerId(), match.path()))
+          .toList();
+    }
 
     LayeredCharacterResolver.CharacterRef ref = LayeredCharacterResolver.parseReference(rawRef, defaultCharacterId);
     CharacterLayerGroupEntry group = groupsByCharacter == null ? null : groupsByCharacter.get(ref.characterId() + "/" + ref.localId());

--- a/modules/editor/src/main/java/com/jvn/editor/ui/actioneditor/AssetPickerPanel.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/actioneditor/AssetPickerPanel.java
@@ -1127,7 +1127,10 @@ public class AssetPickerPanel extends VBox {
             Map<String, Map<String, List<String>>> presetPaths = new LinkedHashMap<>();
             List<String> lines;
             try {
-                lines = Files.readAllLines(scriptPath, StandardCharsets.UTF_8);
+                String source = Files.readString(scriptPath, StandardCharsets.UTF_8);
+                lines = List.of(LayeredCharacterResolver
+                    .collapseLayerDirectiveContinuations(source)
+                    .split("\\R", -1));
             } catch (IOException ignored) {
             // reason: I/O failure on best-effort save/load; in-memory state remains valid
                 continue;
@@ -1309,9 +1312,12 @@ public class AssetPickerPanel extends VBox {
             if (part.isEmpty()) continue;
             if (part.startsWith("$")) {
                 String rawRef = part.substring(1).trim();
-                String path = LayeredCharacterResolver.resolveLayerPath(charLayerPaths, defaultCharacterId, rawRef);
-                if (path != null && !path.isBlank()) {
-                    resolved.add(normalizeDeclaredAssetPath(path));
+                List<LayeredCharacterResolver.LayerMatch> matches =
+                    LayeredCharacterResolver.resolveLayerMatches(charLayerPaths, defaultCharacterId, rawRef);
+                if (!matches.isEmpty()) {
+                    for (LayeredCharacterResolver.LayerMatch match : matches) {
+                        resolved.add(normalizeDeclaredAssetPath(match.path()));
+                    }
                 } else {
                     resolved.addAll(resolveGroupPaths(charLayerPaths, charGroupLayerIds, defaultCharacterId, rawRef));
                 }
@@ -1362,20 +1368,12 @@ public class AssetPickerPanel extends VBox {
             if (part.isEmpty() || !part.startsWith("$")) continue;
             String rawRef = part.substring(1).trim();
             LayeredCharacterResolver.CharacterRef ref = LayeredCharacterResolver.parseReference(rawRef, defaultCharacterId);
-            String path = LayeredCharacterResolver.resolveLayerPath(charLayerPaths, defaultCharacterId, rawRef);
-            if (path != null && !path.isBlank()) {
-                String resolvedLayerId = ref.localId();
-                Map<String, String> layerMap = charLayerPaths.get(ref.characterId());
-                if (layerMap != null) {
-                    for (String candidate : LayeredCharacterResolver.candidateLayerIds(ref.localId())) {
-                        String candidatePath = layerMap.get(candidate);
-                        if (candidatePath != null && candidatePath.trim().equals(path.trim())) {
-                            resolvedLayerId = candidate;
-                            break;
-                        }
-                    }
+            List<LayeredCharacterResolver.LayerMatch> matches =
+                LayeredCharacterResolver.resolveLayerMatches(charLayerPaths, defaultCharacterId, rawRef);
+            if (!matches.isEmpty()) {
+                for (LayeredCharacterResolver.LayerMatch match : matches) {
+                    if (!out.contains(match.layerId())) out.add(match.layerId());
                 }
-                if (!out.contains(resolvedLayerId)) out.add(resolvedLayerId);
                 continue;
             }
             List<String> nested = charGroupLayerIds.getOrDefault(ref.characterId(), Map.of()).get(ref.localId());

--- a/modules/editor/src/main/java/com/jvn/editor/ui/actioneditor/PuppeteerWindow.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/actioneditor/PuppeteerWindow.java
@@ -7121,7 +7121,6 @@ public class PuppeteerWindow extends Stage {
             launchSceneSnapshot,
             character,
             groupId);
-        if (names.size() > 1) return names.get(1);
         return names.isEmpty() ? "" : names.get(0);
     }
 

--- a/modules/editor/src/test/java/com/jvn/editor/ui/PuppeteerLauncherPanelTest.java
+++ b/modules/editor/src/test/java/com/jvn/editor/ui/PuppeteerLauncherPanelTest.java
@@ -147,8 +147,36 @@ class PuppeteerLauncherPanelTest {
     assertEquals(List.of("head_base", "eyes_neutral", "mouth_smile"), head.layerIds);
     assertTrue(head.hasPivot);
     assertEquals(
-        List.of("john_neutral_head", "john_head"),
+        List.of("john_head", "john_neutral_head"),
         PuppeteerLauncherPanel.equivalentSnapshotLayerGroupEntityNames("john", "neutral", "head"));
+  }
+
+  @Test
+  void resolveSnapshotExpandsCharacterLayerGroupGlobs() {
+    String source = """
+        @charlayer john body_default assets/john/body.png
+        @charlayer john body_no_limbs assets/john/body_no_limbs.png
+        @charlayer john arm_front_default assets/john/arm.png
+        @charlayer john arm_front_holding_wrist assets/john/holding.png
+        @chargroup john body_orientation pivot=0.5,1 \\
+          $body_* | \\
+          $arm_front_*
+        @charpreset john holding $body_no_limbs | $arm_front_holding_wrist
+        @label start
+        [show john center holding]
+        """;
+
+    PuppeteerLauncherPanel.SceneSnapshot snapshot =
+        PuppeteerLauncherPanel.resolveSnapshot(source, 7);
+
+    PuppeteerLauncherPanel.CharacterLayerGroupEntry group =
+        snapshot.resolveCharacterLayerGroup("john", "body_orientation");
+    assertEquals(
+        List.of("body_default", "body_no_limbs", "arm_front_default", "arm_front_holding_wrist"),
+        group.layerIds);
+    assertEquals(
+        "john_body_orientation",
+        PuppeteerLauncherPanel.snapshotLayerGroupEntityName("john", "holding", "body_orientation"));
   }
 
   @Test

--- a/modules/editor/src/test/java/com/jvn/editor/ui/actioneditor/AssetPickerPanelTest.java
+++ b/modules/editor/src/test/java/com/jvn/editor/ui/actioneditor/AssetPickerPanelTest.java
@@ -115,4 +115,22 @@ class AssetPickerPanelTest {
             AssetPickerPanel.resolvePresetPaths(layers, groups, Map.of(), "john", "$body | $head")
         );
     }
+
+    @Test
+    void resolveCharacterGroupsExpandsLayerGlobs() {
+        Map<String, Map<String, String>> layers = Map.of(
+            "john",
+            Map.of(
+                "body_default", "assets/characters/john/body.png",
+                "body_no_limbs", "assets/characters/john/body_no_limbs.png",
+                "arm_front_default", "assets/characters/john/arm.png"
+            )
+        );
+
+        assertEquals(
+            List.of("body_default", "body_no_limbs"),
+            AssetPickerPanel.resolveGroupLayerIds(
+                layers, Map.of(), "john", "pivot=0.5,1 $body_*")
+        );
+    }
 }

--- a/modules/fx/src/main/java/com/jvn/fx/vn/VnRenderer.java
+++ b/modules/fx/src/main/java/com/jvn/fx/vn/VnRenderer.java
@@ -1528,8 +1528,8 @@ public class VnRenderer {
     String safeGroup = selectorSafeNameStatic(groupId);
     if (safeCharacter.isBlank() || safeExpression.isBlank() || safeGroup.isBlank()) return List.of();
     LinkedHashSet<String> names = new LinkedHashSet<>();
-    names.add(safeCharacter + "_" + safeExpression + "_" + safeGroup);
     names.add(safeCharacter + "_" + safeGroup);
+    names.add(safeCharacter + "_" + safeExpression + "_" + safeGroup);
     return List.copyOf(names);
   }
 

--- a/modules/fx/src/test/java/com/jvn/fx/vn/VnRendererLayerProxyFallbackTest.java
+++ b/modules/fx/src/test/java/com/jvn/fx/vn/VnRendererLayerProxyFallbackTest.java
@@ -9,7 +9,7 @@ class VnRendererLayerProxyFallbackTest {
   @Test
   void layerGroupTargetsExposeExpressionSpecificAndStableAliases() {
     assertEquals(
-        java.util.List.of("john_neutral_head", "john_head"),
+        java.util.List.of("john_head", "john_neutral_head"),
         VnRenderer.timelineGroupTargetNames("john", "neutral", "head"));
   }
 


### PR DESCRIPTION
## What changed
- make stable character-group timeline targets canonical across Puppeteer and runtime
- support deterministic `*` and `?` layer globs in `@chargroup` declarations
- support backslash-wrapped `@chargroup` and `@charpreset` declarations while preserving source lines
- keep parser, snapshot, Asset Picker, project catalog, dependency validation, and renderer behavior aligned
- report no-match globs as script errors instead of creating broken groups

## Why
Large layered characters such as John have many body and arm variants. Authors need one reusable animation group without enumerating every sprite, while direct layer timelines must continue to work without groups.

## Validation
- full `:core:test`
- full `:fx:test`
- focused Puppeteer Launcher, layered catalog, Asset Picker, and timeline diagnostics editor tests