### PR TITLE
Wrap preview HUD notifications

### DIFF
--- a/modules/fx/src/main/java/com/jvn/fx/vn/HudToastLayout.java
+++ b/modules/fx/src/main/java/com/jvn/fx/vn/HudToastLayout.java
@@ -1,0 +1,110 @@
+package com.jvn.fx.vn;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.ToDoubleFunction;
+
+/** Computes a viewport-bounded, content-sized layout for VN HUD toasts. */
+final class HudToastLayout {
+  static final double HORIZONTAL_PADDING = 12.0;
+  static final double VERTICAL_PADDING = 10.0;
+
+  private HudToastLayout() {
+  }
+
+  record Layout(double width, double height, List<String> lines) {
+    Layout {
+      lines = lines == null ? List.of() : List.copyOf(lines);
+    }
+  }
+
+  static Layout compute(
+      String message,
+      double viewportWidth,
+      double lineHeight,
+      ToDoubleFunction<String> measure
+  ) {
+    String text = message == null ? "" : message.strip();
+    double safeViewportWidth = Math.max(1.0, viewportWidth);
+    double maxBoxWidth = Math.max(
+        40.0,
+        Math.min(Math.min(720.0, safeViewportWidth * 0.72), safeViewportWidth - 32.0));
+    double maxTextWidth = Math.max(16.0, maxBoxWidth - HORIZONTAL_PADDING * 2.0);
+    double safeLineHeight = Math.max(1.0, lineHeight);
+
+    List<String> lines = wrap(text, maxTextWidth, measure);
+    if (lines.isEmpty()) lines = List.of("");
+    double longestLine = lines.stream().mapToDouble(measure).max().orElse(0.0);
+    double minimumWidth = Math.min(140.0, maxBoxWidth);
+    double boxWidth = Math.min(
+        maxBoxWidth,
+        Math.max(minimumWidth, longestLine + HORIZONTAL_PADDING * 2.0));
+    double boxHeight = VERTICAL_PADDING * 2.0 + safeLineHeight * lines.size();
+    return new Layout(boxWidth, boxHeight, lines);
+  }
+
+  private static List<String> wrap(
+      String text,
+      double maxWidth,
+      ToDoubleFunction<String> measure
+  ) {
+    List<String> lines = new ArrayList<>();
+    if (text == null || text.isBlank()) return lines;
+    for (String paragraph : text.split("\\R", -1)) {
+      if (paragraph.isBlank()) {
+        lines.add("");
+        continue;
+      }
+      StringBuilder current = new StringBuilder();
+      for (String word : paragraph.trim().split("\\s+")) {
+        String candidate = current.isEmpty() ? word : current + " " + word;
+        if (measure.applyAsDouble(candidate) <= maxWidth) {
+          current.setLength(0);
+          current.append(candidate);
+          continue;
+        }
+        if (!current.isEmpty()) {
+          lines.add(current.toString());
+          current.setLength(0);
+        }
+        appendBrokenWord(lines, current, word, maxWidth, measure);
+      }
+      if (!current.isEmpty()) lines.add(current.toString());
+    }
+    return lines;
+  }
+
+  private static void appendBrokenWord(
+      List<String> lines,
+      StringBuilder current,
+      String word,
+      double maxWidth,
+      ToDoubleFunction<String> measure
+  ) {
+    String remaining = word == null ? "" : word;
+    while (!remaining.isEmpty() && measure.applyAsDouble(remaining) > maxWidth) {
+      int end = fittingEnd(remaining, maxWidth, measure);
+      lines.add(remaining.substring(0, end));
+      remaining = remaining.substring(end);
+    }
+    current.append(remaining);
+  }
+
+  private static int fittingEnd(
+      String text,
+      double maxWidth,
+      ToDoubleFunction<String> measure
+  ) {
+    int low = 1;
+    int high = text.length();
+    while (low < high) {
+      int middle = (low + high + 1) >>> 1;
+      if (measure.applyAsDouble(text.substring(0, middle)) <= maxWidth) {
+        low = middle;
+      } else {
+        high = middle - 1;
+      }
+    }
+    return low;
+  }
+}

--- a/modules/fx/src/main/java/com/jvn/fx/vn/VnRenderer.java
+++ b/modules/fx/src/main/java/com/jvn/fx/vn/VnRenderer.java
@@ -455,16 +455,27 @@ public class VnRenderer {
     // HUD message (toast)
     long now = System.currentTimeMillis();
     if (state.getHudMessage() != null && now < state.getHudMessageExpireAt()) {
-      gc.setFont(Font.font(nameFont.getFamily(), FontWeight.BOLD, 16));
+      Font hudFont = Font.font(nameFont.getFamily(), FontWeight.BOLD, 16);
+      gc.setFont(hudFont);
+      String msg = state.getHudMessage();
+      double lineHeight = Math.max(hudFont.getSize() * 1.25, computeTextHeight(hudFont) + 3.0);
+      HudToastLayout.Layout toast = HudToastLayout.compute(
+          msg,
+          width,
+          lineHeight,
+          line -> computeTextWidth(line, hudFont));
       gc.setFill(Color.rgb(0, 0, 0, 0.6));
-      double boxW = Math.min(width * 0.6, 360);
-      double boxH = 40;
+      double boxW = toast.width();
+      double boxH = toast.height();
       double bx = (width - boxW) / 2;
-      double by = height * 0.1;
+      double by = clamp(height * 0.1, 16.0, Math.max(16.0, height - boxH - 16.0));
       gc.fillRoundRect(bx, by, boxW, boxH, 10, 10);
       gc.setFill(Color.WHITE);
-      String msg = state.getHudMessage();
-      gc.fillText(msg, bx + 12, by + 25);
+      double baseline = by + HudToastLayout.VERTICAL_PADDING + computeTextAscent(hudFont);
+      for (String line : toast.lines()) {
+        gc.fillText(line, bx + HudToastLayout.HORIZONTAL_PADDING, baseline);
+        baseline += lineHeight;
+      }
     }
 
     if (shaking) {

--- a/modules/fx/src/test/java/com/jvn/fx/vn/HudToastLayoutTest.java
+++ b/modules/fx/src/test/java/com/jvn/fx/vn/HudToastLayoutTest.java
@@ -1,0 +1,41 @@
+package com.jvn.fx.vn;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class HudToastLayoutTest {
+  private static final java.util.function.ToDoubleFunction<String> MONOSPACE = text -> text.length() * 8.0;
+
+  @Test
+  void sizesShortToastAroundItsText() {
+    HudToastLayout.Layout layout = HudToastLayout.compute("Saved", 1280, 22, MONOSPACE);
+
+    assertEquals(1, layout.lines().size());
+    assertEquals(140.0, layout.width(), 0.001);
+    assertEquals(42.0, layout.height(), 0.001);
+  }
+
+  @Test
+  void wrapsLongTimelineWarningAndGrowsBoxHeight() {
+    String warning = "Timeline warning: Animation finishes within one 60 Hz display frame and may appear instant";
+    HudToastLayout.Layout layout = HudToastLayout.compute(warning, 640, 22, MONOSPACE);
+
+    assertTrue(layout.lines().size() >= 2);
+    assertEquals(20.0 + layout.lines().size() * 22.0, layout.height(), 0.001);
+    assertTrue(layout.width() <= 640 * 0.72);
+    double contentWidth = layout.width() - HudToastLayout.HORIZONTAL_PADDING * 2.0;
+    assertTrue(layout.lines().stream().allMatch(line -> MONOSPACE.applyAsDouble(line) <= contentWidth));
+  }
+
+  @Test
+  void breaksAnUnspacedTokenInsteadOfOverflowingViewport() {
+    HudToastLayout.Layout layout = HudToastLayout.compute("x".repeat(200), 240, 20, MONOSPACE);
+
+    assertTrue(layout.lines().size() > 1);
+    assertTrue(layout.width() <= 240 - 32);
+    double contentWidth = layout.width() - HudToastLayout.HORIZONTAL_PADDING * 2.0;
+    assertTrue(layout.lines().stream().allMatch(line -> MONOSPACE.applyAsDouble(line) <= contentWidth));
+  }
+}


### PR DESCRIPTION
## What changed
- size VN preview HUD toasts from rendered text metrics
- wrap long diagnostics and grow the box vertically
- constrain the box to the preview viewport and split long unbroken tokens
- add focused layout regression tests

## Why
Timeline diagnostics could overflow the fixed 360px HUD box and be clipped in detached previews.

## Validation
- `:fx:test --tests com.jvn.fx.vn.HudToastLayoutTest --tests com.jvn.fx.vn.VnRendererLayerProxyFallbackTest`