### PR TITLE
Add editor memory protection and JVM controls

### DIFF
--- a/docs/architecture/quality/debugging.md
+++ b/docs/architecture/quality/debugging.md
@@ -228,6 +228,21 @@ A manual GC that briefly lowers the heap is evidence of allocation churn, not a 
 collector. A heap that remains high can also be normal until the JVM needs space; the
 failure signal is retained usage that continues increasing with each identical loop.
 
+For a controlled reproduction, set the next application launch under **Engine Hub >
+Tools > JVM Memory Settings...**. A smaller explicit maximum heap can make a retention
+regression fail sooner; enable an OOM heap dump to capture the retained-object graph.
+Do not treat a larger maximum heap as the fix for unbounded growth—the preview caches
+must remain bounded independently of `-Xmx`.
+
+The editor also classifies memory pressure before an `OutOfMemoryError` occurs. It warns
+once when the launched maximum heap is below 768 MiB, after heap use stays at or above
+84% for 15 seconds, after it stays at or above 94% for 3 seconds, or when a 10-second
+window contains at least four collections and two seconds of GC time while at least 78%
+of the heap remains occupied. Alerts are cooldown-limited so a pressured process does
+not create a dialog loop. From the alert, **Release Preview Caches** drops reloadable
+preview rasters without closing the project, **Save Diagnostics...** captures evidence,
+and **Open JVM Settings** opens the Engine Hub policy for the next launch.
+
 ### Build Performance
 
 ```bash

--- a/docs/editor/core/engine-hub.md
+++ b/docs/editor/core/engine-hub.md
@@ -246,6 +246,38 @@ When the launcher opens the editor in Developer Mode, it also forwards Developer
 
 Developer Mode also adds a **DevTools** menu to the editor and launcher menu bars. It includes runtime/JVM diagnostics, manual GC, log-panel refresh, a developer settings file shortcut, a launcher output-capture toggle, an editor JVM heap setting, and **Save Diagnostics Bundle...**. The editor DevTools menu also includes **Auto-write Editor Diagnostics**. The diagnostics bundle writes a timestamped folder and `.zip` containing discovered logs, crash/audit/diagnostic files, Gradle daemon output, launcher logs, a manifest of copied/skipped files, and JVM/runtime memory details. The heap setting is stored in `~/.jvn-editor/devtools.properties` and applies to the next editor launch started from the launcher.
 
+### JVM memory settings
+
+Open **Tools > JVM Memory Settings...** to configure the JVM used by applications
+started through Engine Hub. The policy applies on the next launch to the editor,
+launcher, embedded preview tools in those processes, and the game runtime. The Hub
+passes it through both cache-first and Gradle fallback paths; Windows uses its Gradle
+launch path.
+
+Available controls have direct JVM effects:
+
+- **Initial heap** emits `-Xms<n>m`. Leave it automatic unless pre-reserving the heap
+  is useful for a known workload.
+- **Maximum heap** emits `-Xmx<n>m` and is the precise Java heap ceiling. It does not
+  include JavaFX native textures, thread stacks, code cache, or other process memory.
+- **Garbage collector** selects the JDK default, G1, ZGC, or Serial collector. G1 is a
+  balanced explicit choice, ZGC prioritizes short pauses, and Serial minimizes GC
+  overhead for small heaps.
+- **Heap dump on OutOfMemoryError** emits the standard heap-dump flags and stores HPROF
+  files under `~/.jvn/heap-dumps`.
+- **Exit after OutOfMemoryError** emits `-XX:+ExitOnOutOfMemoryError`, avoiding a process
+  continuing after memory exhaustion has left it unusable.
+- **String deduplication** emits `-XX:+UseStringDeduplication` and requires G1 or ZGC.
+- **Extra JVM arguments** accepts advanced options with quote-aware tokenization.
+  Options managed by the dedicated controls are rejected here so conflicting heap or
+  GC flags cannot silently override the visible values.
+
+Settings are persisted in `~/.jvn/jvm-launch.properties`; the resolved, one-option-per-line
+launch file is `~/.jvn/jvm-launch.args`. The latter format preserves argument values that
+contain spaces. **Reset to JDK Defaults** removes explicit heap and collector choices.
+The older Developer Mode editor-only maximum-heap setting remains compatible, but an
+Engine Hub `-Xmx` value takes precedence when both are present.
+
 Use **DevTools > Auto-write Editor Diagnostics** when diagnosing freezes or machine slowdowns. While enabled, the editor appends a heartbeat line every few seconds under the current project or workspace `.jvn/logs` folder, in a file named like `editor-heartbeat-20260713-184500.log`. Each line records uptime, active file, dirty-tab count, CPU text, heap/non-heap/JVM memory, FPS, thread counts, and GC deltas. Because the file is appended continuously, it can still contain useful evidence after a forced restart.
 
 ## Install Desktop Shortcuts

--- a/modules/editor/build.gradle.kts
+++ b/modules/editor/build.gradle.kts
@@ -156,6 +156,21 @@ fun JavaExec.configureFlightRecordingForLaunch() {
   logger.lifecycle("JVN Java Flight Recorder: ${recording.absolutePath}")
 }
 
+fun JavaExec.configureManagedJvmLaunchSettings() {
+  val defaultFile = File(System.getProperty("user.home", "."), ".jvn/jvm-launch.args")
+  val argumentsFile = providers.environmentVariable("JVN_APP_JAVA_OPTS_FILE")
+    .map(::File)
+    .orElse(defaultFile)
+  inputs.file(argumentsFile)
+    .withPropertyName("jvnManagedJvmArguments")
+    .optional()
+  jvmArgumentProviders.add(CommandLineArgumentProvider {
+    val file = argumentsFile.get()
+    if (!file.isFile) emptyList()
+    else file.readLines().map(String::trim).filter(String::isNotEmpty)
+  })
+}
+
 fun JavaExec.forwardHubLaunchSystemProps() {
   listOf(
     "jvn.hub.safeMode",
@@ -179,6 +194,7 @@ fun JavaExec.forwardHubLaunchSystemProps() {
 tasks.named<JavaExec>("run") {
   configureJavaFxRuntime()
   configureFlightRecordingForLaunch()
+  configureManagedJvmLaunchSettings()
   systemProperty("jvn.version", rootProject.version.toString())
   forwardHubLaunchSystemProps()
 }
@@ -191,6 +207,7 @@ tasks.register<JavaExec>("runLauncher") {
   workingDir = rootProject.projectDir
   systemProperty("jvn.version", rootProject.version.toString())
   configureFlightRecordingForLaunch()
+  configureManagedJvmLaunchSettings()
   forwardHubLaunchSystemProps()
   configureJavaFxRuntime()
 }

--- a/modules/editor/src/main/java/com/jvn/editor/EditorApp.java
+++ b/modules/editor/src/main/java/com/jvn/editor/EditorApp.java
@@ -47,6 +47,7 @@ import com.jvn.editor.ui.AssetBrowserView;
 import com.jvn.editor.ui.CssIcon;
 import com.jvn.editor.ui.CompositionGuideOverlay;
 import com.jvn.editor.ui.DeveloperLogPanel;
+import com.jvn.editor.ui.DeveloperDiagnosticsExporter;
 import com.jvn.editor.ui.DeveloperToolsMenu;
 import com.jvn.editor.ui.DslPropertyDiagnostics;
 import com.jvn.editor.ui.EditorDialogs;
@@ -264,6 +265,8 @@ public class EditorApp extends Application {
   private double smoothedFps = Double.NaN;
   private long lastGcCollectionCount = -1L;
   private long lastGcCollectionTimeMs = -1L;
+  private final EditorMemoryPressureMonitor memoryPressureMonitor = new EditorMemoryPressureMonitor();
+  private boolean memoryPressureDialogShowing;
   private File perfEnvironmentProjectRoot;
   private PerfEnvironment perfEnvironment;
   private static final long PERF_UPDATE_INTERVAL_NS = 300_000_000L;
@@ -3056,6 +3059,12 @@ public class EditorApp extends Application {
     long gcTimeDelta = (lastGcCollectionTimeMs >= 0L) ? Math.max(0L, gcTimeMs - lastGcCollectionTimeMs) : 0L;
     lastGcCollectionCount = gcCount;
     lastGcCollectionTimeMs = gcTimeMs;
+    memoryPressureMonitor.sample(
+        nowNs,
+        heap == null ? 0L : heap.getUsed(),
+        heapMaxBytes,
+        gcCountDelta,
+        gcTimeDelta).ifPresent(this::showMemoryPressureAlert);
     String gcText = gcCountDelta > 0
         ? String.format(Locale.ROOT, "GC +%d/%dms", gcCountDelta, gcTimeDelta)
         : "GC idle";
@@ -3137,6 +3146,128 @@ public class EditorApp extends Application {
         gcTimeDelta,
         cpuTextValue,
         fpsTextValue);
+  }
+
+  private void showMemoryPressureAlert(EditorMemoryPressureMonitor.Snapshot snapshot) {
+    if (snapshot == null || memoryPressureDialogShowing || shutdownInProgress) return;
+    memoryPressureDialogShowing = true;
+    try {
+      long usedMiB = Math.max(0L, snapshot.heapUsedBytes() / EditorMemoryPressureMonitor.MIB);
+      long maxMiB = Math.max(1L, snapshot.heapMaxBytes() / EditorMemoryPressureMonitor.MIB);
+      String percent = String.format(Locale.ROOT, "%.0f%%", snapshot.heapRatio() * 100.0);
+      String title;
+      String message;
+      String explanation;
+      switch (snapshot.event()) {
+        case LOW_MAX_HEAP -> {
+          title = "Editor Heap Is Configured Too Low";
+          message = "This editor process has a maximum Java heap of " + maxMiB + " MiB.";
+          explanation = "Large projects and animated previews are more reliable with at least 768 MiB. "
+              + "This is a launch setting, so changing it takes effect after restarting the editor.";
+        }
+        case SUSTAINED_HIGH_HEAP -> {
+          title = "Sustained Editor Memory Pressure";
+          message = "Java heap use has remained high: " + usedMiB + " / " + maxMiB + " MiB (" + percent + ").";
+          explanation = "This was sustained rather than a short allocation spike. Release reloadable preview caches, "
+              + "close unused tabs, or save diagnostics if the value continues rising.";
+        }
+        case CRITICAL_HEAP -> {
+          title = "Editor Memory Is Nearly Exhausted";
+          message = "Java heap use is critical: " + usedMiB + " / " + maxMiB + " MiB (" + percent + ").";
+          explanation = "Save important work now. Releasing preview caches can recover space; a diagnostics bundle "
+              + "and OOM heap dump are the most useful evidence if pressure returns.";
+        }
+        case GC_THRASHING -> {
+          title = "Garbage Collection Cannot Recover Enough Memory";
+          message = "The JVM spent " + snapshot.windowGcTimeMs() + " ms in "
+              + snapshot.windowGcCount() + " collections while heap use stayed at " + percent + ".";
+          explanation = "The collector is running, but live objects still occupy most of the heap. This usually means "
+              + "retained caches/data or a heap ceiling that is too low—not a broken garbage collector.";
+        }
+        default -> throw new IllegalStateException("Unexpected memory event: " + snapshot.event());
+      }
+
+      Label details = new Label(explanation + "\n\nCurrent heap: " + usedMiB + " MiB used / "
+          + maxMiB + " MiB maximum\nAlert policy: sustained and cooldown-limited");
+      details.setWrapText(true);
+      details.getStyleClass().add("editor-dialog-message");
+      details.setMaxWidth(520);
+
+      List<EditorDialogs.ActionSpec> actions = new ArrayList<>();
+      if (snapshot.event() != EditorMemoryPressureMonitor.Event.LOW_MAX_HEAP) {
+        actions.add(EditorDialogs.ActionSpec.accent(
+            "release", "Release Preview Caches", this::releasePreviewMemoryCaches));
+        actions.add(EditorDialogs.ActionSpec.neutral(
+            "diagnostics", "Save Diagnostics...", () -> Platform.runLater(() ->
+                DeveloperDiagnosticsExporter.chooseAndExport(
+                    dialogOwner(), "JVN Editor", this::developerLogRoots))));
+      }
+      actions.add(EditorDialogs.ActionSpec.neutral(
+          "settings", "Open JVM Settings", () -> Platform.runLater(this::openHubJvmMemorySettings)));
+      actions.add(EditorDialogs.ActionSpec.neutral("dismiss", "Dismiss", null));
+      EditorDialogs.show(
+          dialogOwner(),
+          title,
+          message,
+          details,
+          actions.toArray(EditorDialogs.ActionSpec[]::new));
+    } finally {
+      memoryPressureDialogShowing = false;
+    }
+  }
+
+  private void releasePreviewMemoryCaches() {
+    int trimmed = 0;
+    if (filesTabs != null) {
+      for (Tab tab : filesTabs.getTabs()) {
+        if (tab.getContent() instanceof FileEditorTab fileEditorTab) {
+          fileEditorTab.trimPreviewMemoryCaches();
+          trimmed++;
+        }
+      }
+    }
+    ManagementFactory.getMemoryMXBean().gc();
+    if (status != null) {
+      status.setText("Released reloadable preview caches in " + trimmed + " editor tab"
+          + (trimmed == 1 ? "" : "s") + "; requested GC");
+    }
+  }
+
+  private void openHubJvmMemorySettings() {
+    File workspace = resolveWorkspaceRoot();
+    if (workspace == null || !workspace.isDirectory()) {
+      EditorDialogs.warning(
+          dialogOwner(),
+          "JVM Memory Settings",
+          "Open Engine Hub, then choose Tools > JVM Memory Settings. Restart the editor after applying changes.");
+      return;
+    }
+    try {
+      List<String> command = new ArrayList<>();
+      String os = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
+      if (os.contains("win")) {
+        command.add(new File(workspace, "gradlew.bat").getAbsolutePath());
+        command.add("--console=plain");
+        command.add(":hub:run");
+        command.add("--args=--jvm-memory-settings");
+      } else {
+        command.add(new File(workspace, "scripts/launch-hub.sh").getAbsolutePath());
+        command.add("--jvm-memory-settings");
+      }
+      new ProcessBuilder(command)
+          .directory(workspace)
+          .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+          .redirectError(ProcessBuilder.Redirect.DISCARD)
+          .start();
+      if (status != null) status.setText("Opening Engine Hub JVM Memory Settings");
+    } catch (Exception error) {
+      EditorDialogs.error(
+          dialogOwner(),
+          "JVM Memory Settings",
+          "Could not open Engine Hub JVM Memory Settings.",
+          error,
+          "Open Engine Hub manually, then choose Tools > JVM Memory Settings.");
+    }
   }
 
   private void autoWriteDeveloperDiagnostics(

--- a/modules/editor/src/main/java/com/jvn/editor/EditorCrashSupport.java
+++ b/modules/editor/src/main/java/com/jvn/editor/EditorCrashSupport.java
@@ -23,6 +23,7 @@ final class EditorCrashSupport {
   private static final Logger log = LoggerFactory.getLogger(EditorCrashSupport.class);
   private static final AtomicBoolean INSTALLED = new AtomicBoolean(false);
   private static final AtomicBoolean SHOWING_ALERT = new AtomicBoolean(false);
+  private static volatile byte[] emergencyMemoryReserve = new byte[2 * 1024 * 1024];
   private static final DateTimeFormatter FILE_TIME = DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss");
   private static final DateTimeFormatter DISPLAY_TIME = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
@@ -95,16 +96,18 @@ final class EditorCrashSupport {
           thread != null ? thread.getName() : "unknown");
       return;
     }
+    boolean outOfMemory = containsOutOfMemory(throwable);
+    if (outOfMemory) emergencyMemoryReserve = null;
     Path logFile = writeCrashLog(throwable, thread);
     if (throwable != null) {
       log.error("Uncaught exception on thread {}", thread.getName(), throwable);
     }
     if (Platform.isFxApplicationThread()) {
-      showCrashAlert(thread, throwable, logFile);
+      showCrashAlert(thread, throwable, logFile, outOfMemory);
       return;
     }
     try {
-      Platform.runLater(() -> showCrashAlert(thread, throwable, logFile));
+      Platform.runLater(() -> showCrashAlert(thread, throwable, logFile, outOfMemory));
     } catch (IllegalStateException ignored) {
             // reason: JavaFX state race on shutdown; not actionable at call site
       // JavaFX toolkit is not available; stderr/log file are the fallback.
@@ -128,7 +131,21 @@ final class EditorCrashSupport {
     return toolbarSelect && focusCleanup;
   }
 
-  private static void showCrashAlert(Thread thread, Throwable throwable, Path logFile) {
+  static boolean containsOutOfMemory(Throwable throwable) {
+    Throwable current = throwable;
+    for (int depth = 0; current != null && depth < 32; depth++) {
+      if (current instanceof OutOfMemoryError) return true;
+      current = current.getCause();
+    }
+    return false;
+  }
+
+  private static void showCrashAlert(
+      Thread thread,
+      Throwable throwable,
+      Path logFile,
+      boolean outOfMemory
+  ) {
     if (!SHOWING_ALERT.compareAndSet(false, true)) return;
     try {
       String pathLine = logFile != null
@@ -137,13 +154,19 @@ final class EditorCrashSupport {
       EditorDialogs.error(
           null,
           "JVN Editor",
-          "An unexpected editor error occurred on thread "
-              + (thread != null ? thread.getName() : "<unknown>")
-              + ".",
+          outOfMemory
+              ? "The editor exhausted its JVM memory on thread "
+                  + (thread != null ? thread.getName() : "<unknown>") + "."
+              : "An unexpected editor error occurred on thread "
+                  + (thread != null ? thread.getName() : "<unknown>") + ".",
           throwable,
           pathLine,
-          "Save any recoverable work in other windows before continuing.",
-          "Restart the editor if the UI behaves inconsistently after this error.");
+          outOfMemory
+              ? "Restart through Engine Hub and review Tools > JVM Memory Settings; enable an OOM heap dump if this repeats."
+              : "Save any recoverable work in other windows before continuing.",
+          outOfMemory
+              ? "Use the crash log and diagnostics bundle to distinguish a retained-object leak from a legitimately undersized heap."
+              : "Restart the editor if the UI behaves inconsistently after this error.");
     } catch (Exception ex) {
       log.error("Failed to show crash alert", ex);
     } finally {

--- a/modules/editor/src/main/java/com/jvn/editor/EditorMemoryPressureMonitor.java
+++ b/modules/editor/src/main/java/com/jvn/editor/EditorMemoryPressureMonitor.java
@@ -1,0 +1,132 @@
+package com.jvn.editor;
+
+import java.util.Optional;
+
+/** Stateful, throttled classifier for editor heap and garbage-collection pressure. */
+final class EditorMemoryPressureMonitor {
+  static final long MIB = 1024L * 1024L;
+  static final long LOW_HEAP_BYTES = 768L * MIB;
+  static final double HIGH_RATIO = 0.84;
+  static final double CRITICAL_RATIO = 0.94;
+
+  private static final long HIGH_SUSTAIN_NS = 15_000_000_000L;
+  private static final long CRITICAL_SUSTAIN_NS = 3_000_000_000L;
+  private static final long GC_WINDOW_NS = 10_000_000_000L;
+  private static final long HIGH_COOLDOWN_NS = 20L * 60L * 1_000_000_000L;
+  private static final long CRITICAL_COOLDOWN_NS = 5L * 60L * 1_000_000_000L;
+  private static final long GC_COOLDOWN_NS = 15L * 60L * 1_000_000_000L;
+
+  enum Event {
+    LOW_MAX_HEAP,
+    SUSTAINED_HIGH_HEAP,
+    CRITICAL_HEAP,
+    GC_THRASHING
+  }
+
+  record Snapshot(
+      Event event,
+      long heapUsedBytes,
+      long heapMaxBytes,
+      double heapRatio,
+      long windowGcCount,
+      long windowGcTimeMs
+  ) {}
+
+  private boolean lowHeapChecked;
+  private long highSinceNs = -1L;
+  private long criticalSinceNs = -1L;
+  private long gcWindowStartNs = -1L;
+  private long gcWindowCount;
+  private long gcWindowTimeMs;
+  private long lastHighAlertNs = Long.MIN_VALUE;
+  private long lastCriticalAlertNs = Long.MIN_VALUE;
+  private long lastGcAlertNs = Long.MIN_VALUE;
+
+  Optional<Snapshot> sample(
+      long nowNs,
+      long heapUsedBytes,
+      long heapMaxBytes,
+      long gcCountDelta,
+      long gcTimeDeltaMs
+  ) {
+    long safeMax = Math.max(1L, heapMaxBytes);
+    long safeUsed = Math.max(0L, heapUsedBytes);
+    double ratio = Math.max(0.0, Math.min(1.0, (double) safeUsed / safeMax));
+
+    if (!lowHeapChecked) {
+      lowHeapChecked = true;
+      if (safeMax < LOW_HEAP_BYTES) {
+        return Optional.of(snapshot(Event.LOW_MAX_HEAP, safeUsed, safeMax, ratio));
+      }
+    }
+
+    if (ratio >= CRITICAL_RATIO) {
+      if (criticalSinceNs < 0L) criticalSinceNs = nowNs;
+    } else {
+      criticalSinceNs = -1L;
+    }
+    if (ratio >= HIGH_RATIO) {
+      if (highSinceNs < 0L) highSinceNs = nowNs;
+    } else {
+      highSinceNs = -1L;
+    }
+
+    accumulateGcWindow(nowNs, gcCountDelta, gcTimeDeltaMs);
+
+    if (criticalSinceNs >= 0L
+        && nowNs - criticalSinceNs >= CRITICAL_SUSTAIN_NS
+        && cooldownElapsed(nowNs, lastCriticalAlertNs, CRITICAL_COOLDOWN_NS)) {
+      lastCriticalAlertNs = nowNs;
+      lastHighAlertNs = nowNs;
+      return Optional.of(snapshot(Event.CRITICAL_HEAP, safeUsed, safeMax, ratio));
+    }
+
+    if (gcWindowStartNs >= 0L && nowNs - gcWindowStartNs >= GC_WINDOW_NS) {
+      long windowCount = gcWindowCount;
+      long windowTime = gcWindowTimeMs;
+      resetGcWindow(nowNs);
+      if (ratio >= 0.78
+          && windowCount >= 4L
+          && windowTime >= 2_000L
+          && cooldownElapsed(nowNs, lastGcAlertNs, GC_COOLDOWN_NS)) {
+        lastGcAlertNs = nowNs;
+        lastHighAlertNs = nowNs;
+        return Optional.of(new Snapshot(
+            Event.GC_THRASHING, safeUsed, safeMax, ratio, windowCount, windowTime));
+      }
+    }
+
+    if (highSinceNs >= 0L
+        && nowNs - highSinceNs >= HIGH_SUSTAIN_NS
+        && cooldownElapsed(nowNs, lastHighAlertNs, HIGH_COOLDOWN_NS)) {
+      lastHighAlertNs = nowNs;
+      return Optional.of(snapshot(Event.SUSTAINED_HIGH_HEAP, safeUsed, safeMax, ratio));
+    }
+    return Optional.empty();
+  }
+
+  private void accumulateGcWindow(long nowNs, long countDelta, long timeDeltaMs) {
+    if (gcWindowStartNs < 0L) gcWindowStartNs = nowNs;
+    gcWindowCount = saturatedAdd(gcWindowCount, Math.max(0L, countDelta));
+    gcWindowTimeMs = saturatedAdd(gcWindowTimeMs, Math.max(0L, timeDeltaMs));
+  }
+
+  private void resetGcWindow(long nowNs) {
+    gcWindowStartNs = nowNs;
+    gcWindowCount = 0L;
+    gcWindowTimeMs = 0L;
+  }
+
+  private Snapshot snapshot(Event event, long used, long max, double ratio) {
+    return new Snapshot(event, used, max, ratio, gcWindowCount, gcWindowTimeMs);
+  }
+
+  private static boolean cooldownElapsed(long nowNs, long lastNs, long cooldownNs) {
+    return lastNs == Long.MIN_VALUE || nowNs - lastNs >= cooldownNs;
+  }
+
+  private static long saturatedAdd(long left, long right) {
+    if (right > Long.MAX_VALUE - left) return Long.MAX_VALUE;
+    return left + right;
+  }
+}

--- a/modules/editor/src/main/java/com/jvn/editor/ui/DeveloperToolsMenu.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/DeveloperToolsMenu.java
@@ -126,9 +126,27 @@ public final class DeveloperToolsMenu {
   }
 
   public static List<String> configuredEditorJvmArgs() {
+    List<String> managed = managedJvmArgs();
     Optional<Integer> heapMb = configuredEditorHeapMb();
-    if (heapMb.isEmpty()) return List.of();
-    return List.of("-Xmx" + heapMb.get() + "m");
+    if (heapMb.isEmpty() || managed.stream().anyMatch(argument -> argument.startsWith("-Xmx"))) {
+      return managed;
+    }
+    List<String> combined = new ArrayList<>(managed);
+    combined.add("-Xmx" + heapMb.get() + "m");
+    return List.copyOf(combined);
+  }
+
+  private static List<String> managedJvmArgs() {
+    Path file = Path.of(System.getProperty("user.home", "."), ".jvn", "jvm-launch.args");
+    if (!Files.isRegularFile(file)) return List.of();
+    try {
+      return Files.readAllLines(file, java.nio.charset.StandardCharsets.UTF_8).stream()
+          .map(String::trim)
+          .filter(line -> !line.isEmpty())
+          .toList();
+    } catch (IOException ignored) {
+      return List.of();
+    }
   }
 
   public static boolean isCaptureEditorProcessOutputEnabled() {

--- a/modules/editor/src/main/java/com/jvn/editor/ui/EditorDialogs.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/EditorDialogs.java
@@ -51,6 +51,7 @@ public final class EditorDialogs {
     PROCESS("Process / Gradle"),
     ASSET("Asset"),
     AUDIO("Audio"),
+    MEMORY("JVM memory"),
     VALIDATION("Validation"),
     CLIPBOARD("Clipboard"),
     UNKNOWN("Unknown");
@@ -359,6 +360,10 @@ public final class EditorDialogs {
       case PROCESS -> hints.add("Check the run console or terminal output for the process exit reason.");
       case ASSET -> hints.add("Verify referenced assets exist under the project folder and paths are relative to the project root.");
       case AUDIO -> hints.add("Verify the audio file exists, uses a supported format, and is referenced by the correct channel.");
+      case MEMORY -> {
+        hints.add("Close unused previews or release their caches, then retry the action.");
+        hints.add("Use Engine Hub > Tools > JVM Memory Settings for the next launch and save a heap dump if pressure returns.");
+      }
       case VALIDATION -> hints.add("Correct the highlighted field or invalid value, then try the action again.");
       case CLIPBOARD -> hints.add("Focus the editor window and try copying again.");
       case UNKNOWN -> hints.add("Check the selected project, file, or folder and try the action again.");
@@ -391,6 +396,11 @@ public final class EditorDialogs {
     }
     if (haystack.contains("timeline") || haystack.contains("puppeteer")) {
       hints.add("Run Puppeteer verification and fix errors before exporting or registering the timeline.");
+    }
+    if (haystack.contains("memory") || haystack.contains("heap") || haystack.contains("outofmemory")
+        || haystack.contains("garbage collection") || haystack.contains(" gc ")) {
+      hints.add("Close unused previews or release their caches before retrying.");
+      hints.add("Configure the next launch under Engine Hub > Tools > JVM Memory Settings.");
     }
     if (hints.isEmpty()) {
       hints.add("Check the selected project, file, or folder and try the action again.");
@@ -433,6 +443,12 @@ public final class EditorDialogs {
         + (root == null || root.getMessage() == null ? "" : root.getMessage()) + " "
         + (root == null ? "" : root.getClass().getSimpleName()))
         .toLowerCase(Locale.ROOT);
+    if (haystack.contains("outofmemory") || haystack.contains("out of memory")
+        || haystack.contains("heap space") || haystack.contains("heap pressure")
+        || haystack.contains("garbage collection") || haystack.contains("gc overhead")
+        || haystack.contains("memory limit")) {
+      return ErrorType.MEMORY;
+    }
     if (haystack.contains("workspace root") || haystack.contains("project root")
         || haystack.contains("jvn.project") || haystack.contains("manifest")) {
       return ErrorType.PROJECT_CONTEXT;

--- a/modules/editor/src/main/java/com/jvn/editor/ui/FileEditorTab.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/FileEditorTab.java
@@ -744,6 +744,10 @@ public class FileEditorTab extends BorderPane {
   public void stopPreviewAudio() {
     if (vnPreview != null) vnPreview.stopAudio();
   }
+  public void trimPreviewMemoryCaches() {
+    if (vnPreview != null) vnPreview.trimMemoryCaches();
+    if (viewport != null) viewport.trimMemoryCaches();
+  }
   public void dispose() {
     if (disposed) return;
     disposed = true;

--- a/modules/editor/src/main/java/com/jvn/editor/ui/ViewportView.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/ViewportView.java
@@ -218,6 +218,7 @@ public class ViewportView extends StackPane {
     blitter.clearCache();
     blitter.setProjectRoot(null);
   }
+  public void trimMemoryCaches() { blitter.clearCache(); }
   public void setShowGrid(boolean b) { this.showGrid = b; }
   public void setSize(double w, double h) {
     double sw = sanitizeCanvasDimension(w);

--- a/modules/editor/src/main/java/com/jvn/editor/ui/VnPreviewView.java
+++ b/modules/editor/src/main/java/com/jvn/editor/ui/VnPreviewView.java
@@ -1834,6 +1834,14 @@ public class VnPreviewView extends StackPane {
     }
   }
 
+  /** Releases reloadable preview caches without closing the editor tab. */
+  public void trimMemoryCaches() {
+    renderer.clearCache();
+    menuRenderer.clearImageCache();
+    menuRenderer.clearTextMeasureCache();
+    phoneRenderer.clearAssetCache();
+  }
+
   public void dispose() {
     playbackActive = false;
     stopAudio();

--- a/modules/editor/src/test/java/com/jvn/editor/EditorCrashSupportTest.java
+++ b/modules/editor/src/test/java/com/jvn/editor/EditorCrashSupportTest.java
@@ -62,4 +62,11 @@ class EditorCrashSupportTest {
     assertFalse(EditorCrashSupport.isRecoverableJavaFxToolbarTraversalBug(
         new IllegalStateException("not the upstream NPE")));
   }
+
+  @Test
+  void recognizesWrappedOutOfMemoryFailures() {
+    assertTrue(EditorCrashSupport.containsOutOfMemory(
+        new RuntimeException("preview failed", new OutOfMemoryError("Java heap space"))));
+    assertFalse(EditorCrashSupport.containsOutOfMemory(new RuntimeException("ordinary failure")));
+  }
 }

--- a/modules/editor/src/test/java/com/jvn/editor/EditorMemoryPressureMonitorTest.java
+++ b/modules/editor/src/test/java/com/jvn/editor/EditorMemoryPressureMonitorTest.java
@@ -1,0 +1,68 @@
+package com.jvn.editor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class EditorMemoryPressureMonitorTest {
+
+  @Test
+  void warnsOnceWhenConfiguredHeapIsTooSmall() {
+    EditorMemoryPressureMonitor monitor = new EditorMemoryPressureMonitor();
+
+    assertEquals(EditorMemoryPressureMonitor.Event.LOW_MAX_HEAP,
+        monitor.sample(0L, 100L, 512L * EditorMemoryPressureMonitor.MIB, 0L, 0L)
+            .orElseThrow().event());
+    assertTrue(monitor.sample(1_000_000_000L, 100L, 512L * EditorMemoryPressureMonitor.MIB, 0L, 0L)
+        .isEmpty());
+  }
+
+  @Test
+  void ignoresShortAllocationSpikeButReportsSustainedHighHeap() {
+    EditorMemoryPressureMonitor monitor = new EditorMemoryPressureMonitor();
+    long max = 1024L * EditorMemoryPressureMonitor.MIB;
+    monitor.sample(0L, max / 2L, max, 0L, 0L);
+    assertTrue(monitor.sample(1_000_000_000L, (long) (max * 0.86), max, 0L, 0L).isEmpty());
+    assertTrue(monitor.sample(5_000_000_000L, max / 2L, max, 1L, 30L).isEmpty());
+
+    monitor.sample(10_000_000_000L, (long) (max * 0.86), max, 0L, 0L);
+    Optional<EditorMemoryPressureMonitor.Snapshot> event =
+        monitor.sample(25_000_000_000L, (long) (max * 0.87), max, 0L, 0L);
+
+    assertEquals(EditorMemoryPressureMonitor.Event.SUSTAINED_HIGH_HEAP, event.orElseThrow().event());
+  }
+
+  @Test
+  void criticalPressureWinsAndIsThrottled() {
+    EditorMemoryPressureMonitor monitor = new EditorMemoryPressureMonitor();
+    long max = 1024L * EditorMemoryPressureMonitor.MIB;
+    monitor.sample(0L, max / 2L, max, 0L, 0L);
+    monitor.sample(1_000_000_000L, (long) (max * 0.96), max, 0L, 0L);
+
+    assertEquals(EditorMemoryPressureMonitor.Event.CRITICAL_HEAP,
+        monitor.sample(4_000_000_000L, (long) (max * 0.97), max, 0L, 0L)
+            .orElseThrow().event());
+    assertTrue(monitor.sample(8_000_000_000L, (long) (max * 0.98), max, 0L, 0L).isEmpty());
+  }
+
+  @Test
+  void reportsGcThrashingOnlyWhenGcTimeAndRetainedHeapAreBothHigh() {
+    EditorMemoryPressureMonitor monitor = new EditorMemoryPressureMonitor();
+    long max = 2048L * EditorMemoryPressureMonitor.MIB;
+    monitor.sample(0L, max / 2L, max, 0L, 0L);
+    for (int second = 1; second <= 9; second++) {
+      assertTrue(monitor.sample(
+          second * 1_000_000_000L,
+          (long) (max * 0.80),
+          max,
+          1L,
+          250L).isEmpty());
+    }
+
+    assertEquals(EditorMemoryPressureMonitor.Event.GC_THRASHING,
+        monitor.sample(10_000_000_000L, (long) (max * 0.81), max, 1L, 250L)
+            .orElseThrow().event());
+  }
+}

--- a/modules/hub/src/main/java/com/jvn/hub/JvmLaunchSettings.java
+++ b/modules/hub/src/main/java/com/jvn/hub/JvmLaunchSettings.java
@@ -1,0 +1,293 @@
+package com.jvn.hub;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Properties;
+
+/** Persistent JVM memory policy for applications launched by Engine Hub. */
+final class JvmLaunchSettings {
+  static final int MIN_HEAP_MB = 128;
+  static final int MAX_HEAP_MB = 131_072;
+
+  private static final String KEY_INITIAL_HEAP_MB = "heap.initialMb";
+  private static final String KEY_MAX_HEAP_MB = "heap.maxMb";
+  private static final String KEY_COLLECTOR = "gc.collector";
+  private static final String KEY_HEAP_DUMP = "oom.heapDump";
+  private static final String KEY_EXIT_ON_OOM = "oom.exit";
+  private static final String KEY_STRING_DEDUPLICATION = "memory.stringDeduplication";
+  private static final String KEY_EXTRA_ARGS = "jvm.extraArgs";
+
+  enum Collector {
+    DEFAULT("JDK default", ""),
+    G1("G1 (balanced)", "-XX:+UseG1GC"),
+    ZGC("ZGC (low pause)", "-XX:+UseZGC"),
+    SERIAL("Serial (low footprint)", "-XX:+UseSerialGC");
+
+    private final String displayName;
+    private final String argument;
+
+    Collector(String displayName, String argument) {
+      this.displayName = displayName;
+      this.argument = argument;
+    }
+
+    String argument() { return argument; }
+
+    @Override public String toString() { return displayName; }
+
+    static Collector parse(String raw) {
+      if (raw == null || raw.isBlank()) return DEFAULT;
+      try {
+        return valueOf(raw.trim().toUpperCase(Locale.ROOT));
+      } catch (IllegalArgumentException ignored) {
+        return DEFAULT;
+      }
+    }
+  }
+
+  private final int initialHeapMb;
+  private final int maxHeapMb;
+  private final Collector collector;
+  private final boolean heapDumpOnOutOfMemory;
+  private final boolean exitOnOutOfMemory;
+  private final boolean stringDeduplication;
+  private final String extraJvmArgs;
+
+  JvmLaunchSettings(
+      int initialHeapMb,
+      int maxHeapMb,
+      Collector collector,
+      boolean heapDumpOnOutOfMemory,
+      boolean exitOnOutOfMemory,
+      boolean stringDeduplication,
+      String extraJvmArgs
+  ) {
+    this.initialHeapMb = initialHeapMb;
+    this.maxHeapMb = maxHeapMb;
+    this.collector = collector == null ? Collector.DEFAULT : collector;
+    this.heapDumpOnOutOfMemory = heapDumpOnOutOfMemory;
+    this.exitOnOutOfMemory = exitOnOutOfMemory;
+    this.stringDeduplication = stringDeduplication;
+    this.extraJvmArgs = extraJvmArgs == null ? "" : extraJvmArgs.trim();
+  }
+
+  static JvmLaunchSettings defaults() {
+    return new JvmLaunchSettings(0, 0, Collector.DEFAULT, false, false, false, "");
+  }
+
+  static Path defaultSettingsFile() {
+    return Paths.get(System.getProperty("user.home", "."), ".jvn", "jvm-launch.properties");
+  }
+
+  static Path defaultArgumentsFile() {
+    return Paths.get(System.getProperty("user.home", "."), ".jvn", "jvm-launch.args");
+  }
+
+  static Path defaultHeapDumpDirectory() {
+    return Paths.get(System.getProperty("user.home", "."), ".jvn", "heap-dumps");
+  }
+
+  static JvmLaunchSettings load(Path file) {
+    JvmLaunchSettings defaults = defaults();
+    if (file == null || !Files.isRegularFile(file)) return defaults;
+    Properties properties = new Properties();
+    try (InputStream input = Files.newInputStream(file)) {
+      properties.load(input);
+    } catch (IOException | IllegalArgumentException ignored) {
+      return defaults;
+    }
+    JvmLaunchSettings loaded = new JvmLaunchSettings(
+        parseHeap(properties.getProperty(KEY_INITIAL_HEAP_MB), 0),
+        parseHeap(properties.getProperty(KEY_MAX_HEAP_MB), 0),
+        Collector.parse(properties.getProperty(KEY_COLLECTOR)),
+        parseBoolean(properties.getProperty(KEY_HEAP_DUMP), false),
+        parseBoolean(properties.getProperty(KEY_EXIT_ON_OOM), false),
+        parseBoolean(properties.getProperty(KEY_STRING_DEDUPLICATION), false),
+        properties.getProperty(KEY_EXTRA_ARGS, ""));
+    return loaded.validationError().isEmpty() ? loaded : defaults;
+  }
+
+  void save(Path file) throws IOException {
+    Optional<String> error = validationError();
+    if (error.isPresent()) throw new IllegalArgumentException(error.get());
+    if (file == null) throw new IllegalArgumentException("Settings file is required.");
+    Files.createDirectories(file.toAbsolutePath().getParent());
+    Properties properties = new Properties();
+    properties.setProperty(KEY_INITIAL_HEAP_MB, Integer.toString(initialHeapMb));
+    properties.setProperty(KEY_MAX_HEAP_MB, Integer.toString(maxHeapMb));
+    properties.setProperty(KEY_COLLECTOR, collector.name().toLowerCase(Locale.ROOT));
+    properties.setProperty(KEY_HEAP_DUMP, Boolean.toString(heapDumpOnOutOfMemory));
+    properties.setProperty(KEY_EXIT_ON_OOM, Boolean.toString(exitOnOutOfMemory));
+    properties.setProperty(KEY_STRING_DEDUPLICATION, Boolean.toString(stringDeduplication));
+    properties.setProperty(KEY_EXTRA_ARGS, extraJvmArgs);
+    try (var output = Files.newBufferedWriter(file, StandardCharsets.UTF_8)) {
+      properties.store(output, "JVN application JVM launch settings. Auto-generated.");
+    }
+  }
+
+  void writeArguments(Path file, Path heapDumpDirectory) throws IOException {
+    Optional<String> error = validationError();
+    if (error.isPresent()) throw new IllegalArgumentException(error.get());
+    if (file == null) throw new IllegalArgumentException("Arguments file is required.");
+    Files.createDirectories(file.toAbsolutePath().getParent());
+    Files.write(file, jvmArguments(heapDumpDirectory), StandardCharsets.UTF_8);
+  }
+
+  List<String> jvmArguments(Path heapDumpDirectory) {
+    List<String> arguments = new ArrayList<>();
+    if (initialHeapMb > 0) arguments.add("-Xms" + initialHeapMb + "m");
+    if (maxHeapMb > 0) arguments.add("-Xmx" + maxHeapMb + "m");
+    if (!collector.argument().isBlank()) arguments.add(collector.argument());
+    if (heapDumpOnOutOfMemory) {
+      arguments.add("-XX:+HeapDumpOnOutOfMemoryError");
+      Path directory = heapDumpDirectory == null ? defaultHeapDumpDirectory() : heapDumpDirectory;
+      arguments.add("-XX:HeapDumpPath=" + directory.toAbsolutePath());
+    }
+    if (exitOnOutOfMemory) arguments.add("-XX:+ExitOnOutOfMemoryError");
+    if (stringDeduplication) arguments.add("-XX:+UseStringDeduplication");
+    arguments.addAll(splitArguments(extraJvmArgs));
+    return List.copyOf(arguments);
+  }
+
+  Optional<String> validationError() {
+    if (!validHeap(initialHeapMb)) {
+      return Optional.of("Initial heap must be 0 (automatic) or between "
+          + MIN_HEAP_MB + " and " + MAX_HEAP_MB + " MiB.");
+    }
+    if (!validHeap(maxHeapMb)) {
+      return Optional.of("Maximum heap must be 0 (automatic) or between "
+          + MIN_HEAP_MB + " and " + MAX_HEAP_MB + " MiB.");
+    }
+    if (initialHeapMb > 0 && maxHeapMb > 0 && initialHeapMb > maxHeapMb) {
+      return Optional.of("Initial heap cannot be greater than maximum heap.");
+    }
+    if (stringDeduplication && collector != Collector.G1 && collector != Collector.ZGC) {
+      return Optional.of("String deduplication requires explicitly selecting G1 or ZGC.");
+    }
+    if (extraJvmArgs.indexOf('\n') >= 0 || extraJvmArgs.indexOf('\r') >= 0) {
+      return Optional.of("Extra JVM arguments cannot contain line breaks.");
+    }
+    if (!hasBalancedQuotes(extraJvmArgs)) {
+      return Optional.of("Extra JVM arguments contain an unmatched quote.");
+    }
+    for (String argument : splitArguments(extraJvmArgs)) {
+      if (isManagedArgument(argument)) {
+        return Optional.of("Configure " + argument + " with the dedicated memory controls instead of Extra JVM arguments.");
+      }
+    }
+    return Optional.empty();
+  }
+
+  String summary() {
+    String heap = initialHeapMb == 0 && maxHeapMb == 0
+        ? "Heap automatic"
+        : "Heap " + (initialHeapMb == 0 ? "auto" : initialHeapMb + " MiB")
+            + " → " + (maxHeapMb == 0 ? "auto" : maxHeapMb + " MiB");
+    return heap + " · " + collector + " · OOM dump " + (heapDumpOnOutOfMemory ? "on" : "off");
+  }
+
+  int initialHeapMb() { return initialHeapMb; }
+  int maxHeapMb() { return maxHeapMb; }
+  Collector collector() { return collector; }
+  boolean heapDumpOnOutOfMemory() { return heapDumpOnOutOfMemory; }
+  boolean exitOnOutOfMemory() { return exitOnOutOfMemory; }
+  boolean stringDeduplication() { return stringDeduplication; }
+  String extraJvmArgs() { return extraJvmArgs; }
+
+  static List<String> splitArguments(String raw) {
+    if (raw == null || raw.isBlank()) return List.of();
+    List<String> output = new ArrayList<>();
+    StringBuilder current = new StringBuilder();
+    boolean singleQuoted = false;
+    boolean doubleQuoted = false;
+    boolean escaping = false;
+    for (int index = 0; index < raw.length(); index++) {
+      char character = raw.charAt(index);
+      if (escaping) {
+        current.append(character);
+        escaping = false;
+      } else if (character == '\\' && !singleQuoted) {
+        escaping = true;
+      } else if (character == '\'' && !doubleQuoted) {
+        singleQuoted = !singleQuoted;
+      } else if (character == '"' && !singleQuoted) {
+        doubleQuoted = !doubleQuoted;
+      } else if (Character.isWhitespace(character) && !singleQuoted && !doubleQuoted) {
+        if (current.length() > 0) {
+          output.add(current.toString());
+          current.setLength(0);
+        }
+      } else {
+        current.append(character);
+      }
+    }
+    if (escaping) current.append('\\');
+    if (current.length() > 0) output.add(current.toString());
+    return List.copyOf(output);
+  }
+
+  private static boolean validHeap(int value) {
+    return value == 0 || value >= MIN_HEAP_MB && value <= MAX_HEAP_MB;
+  }
+
+  private static int parseHeap(String raw, int fallback) {
+    try {
+      int value = Integer.parseInt(raw == null ? "" : raw.trim());
+      return validHeap(value) ? value : fallback;
+    } catch (NumberFormatException ignored) {
+      return fallback;
+    }
+  }
+
+  private static boolean parseBoolean(String raw, boolean fallback) {
+    if (raw == null || raw.isBlank()) return fallback;
+    return switch (raw.trim().toLowerCase(Locale.ROOT)) {
+      case "true", "1", "yes", "on" -> true;
+      case "false", "0", "no", "off" -> false;
+      default -> fallback;
+    };
+  }
+
+  private static boolean isManagedArgument(String argument) {
+    String normalized = argument == null ? "" : argument.trim();
+    return normalized.startsWith("-Xms")
+        || normalized.startsWith("-Xmx")
+        || normalized.startsWith("-XX:InitialHeapSize=")
+        || normalized.startsWith("-XX:MaxHeapSize=")
+        || normalized.matches("-XX:[+-]Use[A-Za-z0-9]+GC")
+        || normalized.startsWith("-XX:HeapDumpPath=")
+        || normalized.equals("-XX:+HeapDumpOnOutOfMemoryError")
+        || normalized.equals("-XX:-HeapDumpOnOutOfMemoryError")
+        || normalized.equals("-XX:+ExitOnOutOfMemoryError")
+        || normalized.equals("-XX:-ExitOnOutOfMemoryError")
+        || normalized.equals("-XX:+UseStringDeduplication")
+        || normalized.equals("-XX:-UseStringDeduplication");
+  }
+
+  private static boolean hasBalancedQuotes(String raw) {
+    boolean singleQuoted = false;
+    boolean doubleQuoted = false;
+    boolean escaping = false;
+    for (int index = 0; raw != null && index < raw.length(); index++) {
+      char character = raw.charAt(index);
+      if (escaping) {
+        escaping = false;
+      } else if (character == '\\' && !singleQuoted) {
+        escaping = true;
+      } else if (character == '\'' && !doubleQuoted) {
+        singleQuoted = !singleQuoted;
+      } else if (character == '"' && !singleQuoted) {
+        doubleQuoted = !doubleQuoted;
+      }
+    }
+    return !singleQuoted && !doubleQuoted;
+  }
+}

--- a/modules/hub/src/main/java/com/jvn/hub/JvnHub.java
+++ b/modules/hub/src/main/java/com/jvn/hub/JvnHub.java
@@ -203,6 +203,9 @@ public final class JvnHub {
   private final Path renderPipelinePreferencesFile;
   private final Path renderPipelineTuningFile;
   private final Path projectIconSettingsFile;
+  private final Path jvmLaunchSettingsFile;
+  private final Path jvmLaunchArgumentsFile;
+  private final Path heapDumpDirectory;
   private final JFrame frame = new JFrame("JVN Engine Hub");
   private final JLabel statusLabel = new JLabel("Idle");
   private final JLabel footerBranchLabel = new JLabel("No branch");
@@ -256,6 +259,8 @@ public final class JvnHub {
   private RenderPipelineSettings.Options renderPipelineOptions;
   /** Project-tree icon profile shared with editor processes launched by the Hub. */
   private ProjectIconThemeSettings.Options projectIconOptions;
+  /** Memory and GC policy applied to every Hub-managed JVN application process. */
+  private JvmLaunchSettings jvmLaunchSettings;
   /** Header shortcut for a lightweight local environment report. */
   private HeaderIconButton diagnosticsButton;
   /** Header shortcut for version, source, install, and update details. */
@@ -274,9 +279,14 @@ public final class JvnHub {
     this.renderPipelinePreferencesFile = RenderPipelineSettings.defaultPreferencesFile();
     this.renderPipelineTuningFile = RenderPipelineSettings.defaultTuningFile();
     this.projectIconSettingsFile = ProjectIconThemeSettings.defaultFile();
+    this.jvmLaunchSettingsFile = JvmLaunchSettings.defaultSettingsFile();
+    this.jvmLaunchArgumentsFile = JvmLaunchSettings.defaultArgumentsFile();
+    this.heapDumpDirectory = JvmLaunchSettings.defaultHeapDumpDirectory();
     this.renderPipelineMode = RenderPipelineSettings.load(renderPipelinePreferencesFile);
     this.renderPipelineOptions = RenderPipelineSettings.loadOptions(renderPipelineTuningFile);
     this.projectIconOptions = ProjectIconThemeSettings.load(projectIconSettingsFile);
+    this.jvmLaunchSettings = JvmLaunchSettings.load(jvmLaunchSettingsFile);
+    writeJvmLaunchArguments(jvmLaunchSettings, false);
     configureToolTipManager(tooltipsEnabled);
     buildUi();
     checkIncomingUpdates(true);
@@ -285,6 +295,7 @@ public final class JvnHub {
   /** Entry point. Can be invoked directly or via the {@code :hub:run} Gradle task. */
   public static void main(String[] args) {
     Path root = resolveProjectRoot(args);
+    boolean openJvmMemorySettings = hasArgument(args, "--jvm-memory-settings");
     // Keep the cross-platform (Metal) L&F — Aqua on macOS tints custom backgrounds
     // with system chrome we cannot override per-component. Cross-platform L&F honors
     // setBackground/setForeground verbatim, which is what the custom theme needs.
@@ -298,6 +309,9 @@ public final class JvnHub {
         hub.frame.setVisible(true);
         signalRelaunchReady();
         splash.closeAfter(320, null);
+        if (openJvmMemorySettings) {
+          SwingUtilities.invokeLater(hub::showJvmMemorySettingsDialog);
+        }
       });
       launchDelay.setRepeats(false);
       launchDelay.start();
@@ -862,7 +876,17 @@ public final class JvnHub {
         busy ? "Background task active" : "Tooling ready",
         busy ? firstNonBlank(activeStepLabel, "Working") : "No background task is running",
         ACCENT_TOOLS));
+    tools.add(menuStatusCard(
+        "Application JVM",
+        jvmLaunchSettings.summary(),
+        ACCENT_TOOLS));
     tools.addSeparator();
+    tools.add(hubMenuItem(
+        "JVM Memory Settings...",
+        "Set real heap, garbage collector, and out-of-memory options for managed application launches.",
+        VectorIcon.Kind.SLIDERS,
+        ACCENT_TOOLS,
+        this::showJvmMemorySettingsDialog));
     tools.add(hubMenuItem(
         "Run Diagnostics",
         "Run lightweight workspace, toolchain, and repository checks.",
@@ -3620,6 +3644,221 @@ public final class JvnHub {
     dialog.setVisible(true);
   }
 
+  private void showJvmMemorySettingsDialog() {
+    JDialog dialog = new JDialog(frame, "JVM Memory Settings", true);
+    dialog.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
+
+    JPanel root = new JPanel(new BorderLayout(0, ui(14)));
+    root.setBackground(BG);
+    root.setBorder(uiPadding(16, 16, 16, 16));
+    root.add(dialogHeader(
+        "JVM Memory Settings",
+        "Applied at process startup to Editor, Launcher, previews, and game runtime launches."),
+        BorderLayout.NORTH);
+
+    JCheckBox customInitial = optionCheckBox(
+        "Set initial heap (-Xms)",
+        "Reserve an exact initial Java heap. Automatic is normally best unless startup allocation is known.",
+        jvmLaunchSettings.initialHeapMb() > 0);
+    JSpinner initialHeap = new JSpinner(new SpinnerNumberModel(
+        jvmLaunchSettings.initialHeapMb() > 0 ? jvmLaunchSettings.initialHeapMb() : 512,
+        JvmLaunchSettings.MIN_HEAP_MB,
+        JvmLaunchSettings.MAX_HEAP_MB,
+        128));
+    initialHeap.setEnabled(customInitial.isSelected());
+    customInitial.addActionListener(event -> initialHeap.setEnabled(customInitial.isSelected()));
+
+    JCheckBox customMaximum = optionCheckBox(
+        "Set maximum heap (-Xmx)",
+        "Set the exact Java heap ceiling. This does not include native JavaFX textures or process overhead.",
+        jvmLaunchSettings.maxHeapMb() > 0);
+    JSpinner maximumHeap = new JSpinner(new SpinnerNumberModel(
+        jvmLaunchSettings.maxHeapMb() > 0 ? jvmLaunchSettings.maxHeapMb() : 4096,
+        JvmLaunchSettings.MIN_HEAP_MB,
+        JvmLaunchSettings.MAX_HEAP_MB,
+        128));
+    maximumHeap.setEnabled(customMaximum.isSelected());
+    customMaximum.addActionListener(event -> maximumHeap.setEnabled(customMaximum.isSelected()));
+
+    JComboBox<JvmLaunchSettings.Collector> collector =
+        new JComboBox<>(JvmLaunchSettings.Collector.values());
+    collector.setSelectedItem(jvmLaunchSettings.collector());
+    collector.setToolTipText("G1 is balanced, ZGC favors low pauses, and Serial minimizes collector overhead for small heaps.");
+
+    JCheckBox heapDump = optionCheckBox(
+        "Write heap dump on OutOfMemoryError",
+        "Writes an HPROF file under ~/.jvn/heap-dumps for real retained-object diagnosis.",
+        jvmLaunchSettings.heapDumpOnOutOfMemory());
+    JCheckBox exitOnOom = optionCheckBox(
+        "Exit process after OutOfMemoryError",
+        "Terminates a corrupted or unusable process promptly after the JVM reports an OOM.",
+        jvmLaunchSettings.exitOnOutOfMemory());
+    JCheckBox stringDedup = optionCheckBox(
+        "Enable string deduplication",
+        "Allows G1/ZGC to merge duplicate String backing arrays; useful for text-heavy projects at a small GC cost.",
+        jvmLaunchSettings.stringDeduplication());
+
+    JTextField extraArguments = gradleTextField(jvmLaunchSettings.extraJvmArgs());
+    extraArguments.setToolTipText(
+        "Advanced JVM options. Quotes preserve spaces. Heap, GC, OOM, and deduplication flags belong in the controls above.");
+
+    JPanel options = new JPanel(new GridBagLayout());
+    options.setBackground(PANEL_BG);
+    options.setBorder(BorderFactory.createCompoundBorder(
+        BorderFactory.createLineBorder(BORDER_NEUTRAL),
+        uiPadding(12, 14, 12, 14)));
+    GridBagConstraints gbc = new GridBagConstraints();
+    gbc.gridx = 0;
+    gbc.weightx = 1.0;
+    gbc.fill = GridBagConstraints.HORIZONTAL;
+    gbc.anchor = GridBagConstraints.WEST;
+    gbc.insets = new java.awt.Insets(0, 0, ui(7), 0);
+    int row = 0;
+    gbc.gridy = row++;
+    options.add(memorySpinnerRow(customInitial, initialHeap), gbc);
+    gbc.gridy = row++;
+    options.add(memorySpinnerRow(customMaximum, maximumHeap), gbc);
+    gbc.gridy = row++;
+    options.add(labeledJvmControl("Garbage collector", collector), gbc);
+    for (JCheckBox checkBox : List.of(heapDump, exitOnOom, stringDedup)) {
+      gbc.gridy = row++;
+      options.add(checkBox, gbc);
+    }
+    gbc.gridy = row++;
+    gbc.insets = new java.awt.Insets(ui(7), 0, ui(5), 0);
+    JLabel extraLabel = new JLabel("Extra JVM arguments (advanced)");
+    extraLabel.setForeground(TEXT_MUTED);
+    extraLabel.setFont(extraLabel.getFont().deriveFont(Font.BOLD, uiFont(10f)));
+    options.add(extraLabel, gbc);
+    gbc.gridy = row;
+    gbc.insets = new java.awt.Insets(0, 0, 0, 0);
+    options.add(extraArguments, gbc);
+    root.add(options, BorderLayout.CENTER);
+
+    FlatButton reset = new FlatButton("Reset to JDK Defaults", null, null);
+    reset.addActionListener(event -> {
+      JvmLaunchSettings defaults = JvmLaunchSettings.defaults();
+      customInitial.setSelected(false);
+      initialHeap.setEnabled(false);
+      initialHeap.setValue(512);
+      customMaximum.setSelected(false);
+      maximumHeap.setEnabled(false);
+      maximumHeap.setValue(4096);
+      collector.setSelectedItem(defaults.collector());
+      heapDump.setSelected(defaults.heapDumpOnOutOfMemory());
+      exitOnOom.setSelected(defaults.exitOnOutOfMemory());
+      stringDedup.setSelected(defaults.stringDeduplication());
+      extraArguments.setText("");
+    });
+
+    FlatButton cancel = new FlatButton("Cancel", null, null);
+    cancel.addActionListener(event -> dialog.dispose());
+
+    FlatButton apply = new FlatButton(
+        "Apply to Next Launch", uiIcon(VectorIcon.Kind.CHECK, 14, ACCENT_TOOLS), ACCENT_TOOLS);
+    apply.addActionListener(event -> {
+      JvmLaunchSettings candidate = new JvmLaunchSettings(
+          customInitial.isSelected() ? ((Number) initialHeap.getValue()).intValue() : 0,
+          customMaximum.isSelected() ? ((Number) maximumHeap.getValue()).intValue() : 0,
+          (JvmLaunchSettings.Collector) collector.getSelectedItem(),
+          heapDump.isSelected(),
+          exitOnOom.isSelected(),
+          stringDedup.isSelected(),
+          extraArguments.getText());
+      Optional<String> validationError = candidate.validationError();
+      if (validationError.isPresent()) {
+        javax.swing.JOptionPane.showMessageDialog(
+            dialog, validationError.get(), "Invalid JVM Settings", javax.swing.JOptionPane.WARNING_MESSAGE);
+        return;
+      }
+      if (!writeJvmLaunchArguments(candidate, true)) return;
+      dialog.dispose();
+      refreshModeMenus();
+      setStatus("JVM memory settings saved", ACCENT_TOOLS);
+      setActivity(
+          "JVM settings ready for next launch",
+          candidate.summary(),
+          false,
+          ACCENT_TOOLS);
+    });
+
+    JPanel footer = new JPanel(new FlowLayout(FlowLayout.RIGHT, ui(8), 0));
+    footer.setOpaque(false);
+    footer.add(reset);
+    footer.add(cancel);
+    footer.add(apply);
+    root.add(footer, BorderLayout.SOUTH);
+
+    dialog.setContentPane(root);
+    Dimension minimum = uiDimension(680, 560);
+    dialog.setMinimumSize(minimum);
+    dialog.pack();
+    if (dialog.getWidth() < minimum.width || dialog.getHeight() < minimum.height) {
+      dialog.setSize(minimum);
+    }
+    dialog.setLocationRelativeTo(frame);
+    dialog.getRootPane().setDefaultButton(apply);
+    dialog.setVisible(true);
+  }
+
+  private JPanel memorySpinnerRow(JCheckBox checkBox, JSpinner spinner) {
+    JPanel row = new JPanel(new BorderLayout(ui(10), 0));
+    row.setOpaque(false);
+    row.add(checkBox, BorderLayout.CENTER);
+    JPanel value = new JPanel(new FlowLayout(FlowLayout.RIGHT, ui(6), 0));
+    value.setOpaque(false);
+    spinner.setPreferredSize(uiDimension(110, 30));
+    JLabel unit = new JLabel("MiB");
+    unit.setForeground(TEXT_MUTED);
+    value.add(spinner);
+    value.add(unit);
+    row.add(value, BorderLayout.EAST);
+    return row;
+  }
+
+  private JPanel labeledJvmControl(String label, JComponent control) {
+    JPanel row = new JPanel(new BorderLayout(ui(10), 0));
+    row.setOpaque(false);
+    JLabel text = new JLabel(label);
+    text.setForeground(TEXT_SOFT);
+    row.add(text, BorderLayout.CENTER);
+    control.setPreferredSize(uiDimension(230, 30));
+    row.add(control, BorderLayout.EAST);
+    return row;
+  }
+
+  private boolean writeJvmLaunchArguments(JvmLaunchSettings settings, boolean persistSettings) {
+    try {
+      if (persistSettings) settings.save(jvmLaunchSettingsFile);
+      if (settings.heapDumpOnOutOfMemory()) Files.createDirectories(heapDumpDirectory);
+      settings.writeArguments(jvmLaunchArgumentsFile, heapDumpDirectory);
+      jvmLaunchSettings = settings;
+      return true;
+    } catch (IOException | IllegalArgumentException error) {
+      if (frame.isShowing()) {
+        javax.swing.JOptionPane.showMessageDialog(
+            frame,
+            "Could not save JVM launch settings:\n" + exceptionMessage(error),
+            "JVM Settings Error",
+            javax.swing.JOptionPane.ERROR_MESSAGE);
+      }
+      return false;
+    }
+  }
+
+  private Map<String, String> managedApplicationEnvironment(String taskOrApp) {
+    String value = taskOrApp == null ? "" : taskOrApp.trim().toLowerCase(Locale.ROOT);
+    boolean managedApplication = value.equals("editor")
+        || value.equals("launcher")
+        || value.equals("runtime")
+        || value.equals(":editor:run")
+        || value.equals(":editor:runlauncher")
+        || value.equals(":runtime:run");
+    if (!managedApplication) return Map.of();
+    writeJvmLaunchArguments(jvmLaunchSettings, false);
+    return Map.of("JVN_APP_JAVA_OPTS_FILE", jvmLaunchArgumentsFile.toAbsolutePath().toString());
+  }
+
   private JCheckBox optionCheckBox(String label, String tooltip, boolean selected) {
     JCheckBox box = new HelpCheckBox(label, selected);
     box.setUI(new BasicCheckBoxUI());
@@ -4159,7 +4398,7 @@ public final class JvnHub {
     completeCurrentStep("Gradle command assembled.");
     advanceStep(modeLaunchDetail());
     appendLog("$ " + String.join(" ", cmd));
-    startProcess(cmd, label);
+    startProcess(cmd, label, managedApplicationEnvironment(task));
   }
 
   private void runFastApp(String app, String label) {
@@ -4176,7 +4415,7 @@ public final class JvnHub {
     completeCurrentStep("Cache-first launch command assembled.");
     advanceStep(modeLaunchDetail());
     appendLog("$ " + String.join(" ", cmd));
-    startProcess(cmd, label);
+    startProcess(cmd, label, managedApplicationEnvironment(app));
   }
 
   private void runProfiledEditor() {
@@ -4198,7 +4437,9 @@ public final class JvnHub {
     completeCurrentStep("Profiled launch command assembled.");
     advanceStep("Starting the editor with Java Flight Recorder.");
     appendLog("$ " + String.join(" ", cmd));
-    startProcess(cmd, "Profile Editor", Map.of("JVN_PROFILE_JFR", "1"));
+    startProcess(cmd, "Profile Editor", Map.of(
+        "JVN_PROFILE_JFR", "1",
+        "JVN_APP_JAVA_OPTS_FILE", jvmLaunchArgumentsFile.toAbsolutePath().toString()));
   }
 
   private String modeLaunchDetail() {
@@ -6708,6 +6949,14 @@ public final class JvnHub {
       probe = probe.getParent();
     }
     return cwd;
+  }
+
+  static boolean hasArgument(String[] args, String expected) {
+    if (args == null || expected == null || expected.isBlank()) return false;
+    for (String argument : args) {
+      if (expected.equalsIgnoreCase(argument == null ? "" : argument.trim())) return true;
+    }
+    return false;
   }
 
   private static boolean looksLikeProjectRoot(Path dir) {

--- a/modules/hub/src/test/java/com/jvn/hub/JvmLaunchSettingsTest.java
+++ b/modules/hub/src/test/java/com/jvn/hub/JvmLaunchSettingsTest.java
@@ -1,0 +1,106 @@
+package com.jvn.hub;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class JvmLaunchSettingsTest {
+
+  @Test
+  void producesExactUsefulJdk21Arguments(@TempDir Path temporaryDirectory) {
+    Path dumpDirectory = temporaryDirectory.resolve("heap dumps");
+    JvmLaunchSettings settings = new JvmLaunchSettings(
+        512, 4096, JvmLaunchSettings.Collector.ZGC, true, true, true,
+        "-XX:MaxGCPauseMillis=75 '-Dexample=a value'");
+
+    assertEquals(List.of(
+        "-Xms512m",
+        "-Xmx4096m",
+        "-XX:+UseZGC",
+        "-XX:+HeapDumpOnOutOfMemoryError",
+        "-XX:HeapDumpPath=" + dumpDirectory.toAbsolutePath(),
+        "-XX:+ExitOnOutOfMemoryError",
+        "-XX:+UseStringDeduplication",
+        "-XX:MaxGCPauseMillis=75",
+        "-Dexample=a value"), settings.jvmArguments(dumpDirectory));
+  }
+
+  @Test
+  void persistsSettingsAndOneArgumentPerLine(@TempDir Path temporaryDirectory) throws Exception {
+    Path settingsFile = temporaryDirectory.resolve("jvm.properties");
+    Path argumentsFile = temporaryDirectory.resolve("jvm.args");
+    JvmLaunchSettings original = new JvmLaunchSettings(
+        256, 2048, JvmLaunchSettings.Collector.G1, true, false, true, "-Dfile.encoding=UTF-8");
+
+    original.save(settingsFile);
+    JvmLaunchSettings loaded = JvmLaunchSettings.load(settingsFile);
+    loaded.writeArguments(argumentsFile, temporaryDirectory.resolve("dumps with spaces"));
+
+    assertEquals(256, loaded.initialHeapMb());
+    assertEquals(2048, loaded.maxHeapMb());
+    assertEquals(JvmLaunchSettings.Collector.G1, loaded.collector());
+    assertEquals(loaded.jvmArguments(temporaryDirectory.resolve("dumps with spaces")),
+        Files.readAllLines(argumentsFile));
+  }
+
+  @Test
+  void rejectsContradictoryOrDuplicatedMemoryControls() {
+    JvmLaunchSettings reversed = new JvmLaunchSettings(
+        4096, 1024, JvmLaunchSettings.Collector.G1, true, true, false, "");
+    JvmLaunchSettings duplicate = new JvmLaunchSettings(
+        0, 2048, JvmLaunchSettings.Collector.DEFAULT, true, true, false, "-Xmx8g");
+    JvmLaunchSettings unsupportedDedup = new JvmLaunchSettings(
+        0, 0, JvmLaunchSettings.Collector.SERIAL, true, true, true, "");
+    JvmLaunchSettings alternateHeapFlag = new JvmLaunchSettings(
+        0, 2048, JvmLaunchSettings.Collector.DEFAULT, false, false, false,
+        "-XX:MaxHeapSize=8g");
+    JvmLaunchSettings alternateCollector = new JvmLaunchSettings(
+        0, 0, JvmLaunchSettings.Collector.DEFAULT, false, false, false,
+        "-XX:+UseEpsilonGC");
+
+    assertTrue(reversed.validationError().isPresent());
+    assertTrue(duplicate.validationError().isPresent());
+    assertTrue(unsupportedDedup.validationError().isPresent());
+    assertTrue(alternateHeapFlag.validationError().isPresent());
+    assertTrue(alternateCollector.validationError().isPresent());
+  }
+
+  @Test
+  void rejectsMalformedAdvancedArguments() {
+    JvmLaunchSettings unmatchedQuote = new JvmLaunchSettings(
+        0, 0, JvmLaunchSettings.Collector.DEFAULT, false, false, false,
+        "-Dexample='unfinished");
+    JvmLaunchSettings lineBreak = new JvmLaunchSettings(
+        0, 0, JvmLaunchSettings.Collector.DEFAULT, false, false, false,
+        "-Dfirst=true\n-Dsecond=true");
+
+    assertTrue(unmatchedQuote.validationError().isPresent());
+    assertTrue(lineBreak.validationError().isPresent());
+  }
+
+  @Test
+  void defaultsPreserveJdkLaunchBehavior() {
+    JvmLaunchSettings defaults = JvmLaunchSettings.defaults();
+
+    assertEquals(0, defaults.initialHeapMb());
+    assertEquals(0, defaults.maxHeapMb());
+    assertEquals(JvmLaunchSettings.Collector.DEFAULT, defaults.collector());
+    assertFalse(defaults.heapDumpOnOutOfMemory());
+    assertFalse(defaults.exitOnOutOfMemory());
+    assertFalse(defaults.stringDeduplication());
+  }
+
+  @Test
+  void recognizesDirectSettingsLaunchFlag() {
+    assertTrue(JvnHub.hasArgument(
+        new String[] {"--project-root=/tmp/jvn", " --JVM-MEMORY-SETTINGS "},
+        "--jvm-memory-settings"));
+    assertFalse(JvnHub.hasArgument(new String[] {"--safe-mode"}, "--jvm-memory-settings"));
+  }
+}

--- a/modules/runtime/build.gradle.kts
+++ b/modules/runtime/build.gradle.kts
@@ -2,6 +2,7 @@ import java.io.File
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.Properties
+import org.gradle.process.CommandLineArgumentProvider
 
 plugins {
   application
@@ -57,6 +58,21 @@ fun JavaExec.configureFlightRecordingForLaunch() {
   logger.lifecycle("JVN Java Flight Recorder: ${recording.absolutePath}")
 }
 
+fun JavaExec.configureManagedJvmLaunchSettings() {
+  val defaultFile = File(System.getProperty("user.home", "."), ".jvn/jvm-launch.args")
+  val argumentsFile = providers.environmentVariable("JVN_APP_JAVA_OPTS_FILE")
+    .map(::File)
+    .orElse(defaultFile)
+  inputs.file(argumentsFile)
+    .withPropertyName("jvnManagedJvmArguments")
+    .optional()
+  jvmArgumentProviders.add(CommandLineArgumentProvider {
+    val file = argumentsFile.get()
+    if (!file.isFile) emptyList()
+    else file.readLines().map(String::trim).filter(String::isNotEmpty)
+  })
+}
+
 fun requestedGraphicsModeForLaunch(): String {
   val explicitProperty = System.getProperty("jvn.graphics.mode")?.trim().orEmpty()
   if (explicitProperty.isNotEmpty()) return explicitProperty
@@ -78,6 +94,7 @@ fun requestedGraphicsModeForLaunch(): String {
 
 tasks.named<JavaExec>("run") {
   configureFlightRecordingForLaunch()
+  configureManagedJvmLaunchSettings()
   when (requestedGraphicsModeForLaunch().lowercase()) {
     "gpu", "hardware", "accelerated", "prefer-gpu" -> {
       systemProperty("jvn.graphics.mode", "hardware")

--- a/scripts/launch-app.sh
+++ b/scripts/launch-app.sh
@@ -26,6 +26,7 @@ Usage: scripts/launch-app.sh editor|launcher|runtime [options] [-- app arguments
   --jfr               Record the launched Java process with Java Flight Recorder.
 
 Environment: JVN_APP_LAUNCH_MODE=auto|direct|gradle
+             JVN_APP_JAVA_OPTS_FILE=<one-JVM-option-per-line file>
              JVN_APP_JAVA_OPTS="<additional JVM options>"
              JVN_DISABLE_GLX_FALLBACK=1 disables Linux Mesa GLX recovery
              JVN_DISABLE_GPU_OFFLOAD=1 disables Linux discrete-GPU selection
@@ -351,6 +352,12 @@ if [[ "$JFR_PROFILE" -eq 1 ]]; then
   JAVA_ARGS+=("-XX:StartFlightRecording=filename=$JFR_FILE,settings=profile,dumponexit=true" \
     "-Dprism.verbose=true")
   echo "[jvn] Java Flight Recorder: $JFR_FILE" >&2
+fi
+JAVA_OPTS_FILE="${JVN_APP_JAVA_OPTS_FILE:-${HOME:-.}/.jvn/jvm-launch.args}"
+if [[ -r "$JAVA_OPTS_FILE" ]]; then
+  while IFS= read -r option || [[ -n "$option" ]]; do
+    [[ -n "$option" ]] && JAVA_ARGS+=("$option")
+  done < "$JAVA_OPTS_FILE"
 fi
 if [[ -n "${JVN_APP_JAVA_OPTS:-}" ]]; then
   read -r -a USER_JAVA_OPTS <<< "$JVN_APP_JAVA_OPTS"


### PR DESCRIPTION
## What changed

Adds real Engine Hub JVM launch settings for exact initial and maximum heap, collector selection, OOM heap dumps, exit-on-OOM, string deduplication, and validated advanced JVM arguments. The settings propagate through cache-first, Gradle, launcher, editor, and runtime launch paths.

Adds proactive editor memory alerts for low heap, sustained pressure, critical pressure, and GC thrashing. Alerts can release reloadable preview caches, save diagnostics, or open the JVM settings. Out-of-memory crashes now release an emergency reserve and provide memory-specific recovery guidance.

## Why

The preview crash was caused by retained raster cache entries, not a failed garbage collector. The bounded-cache fix is already on stable; this follow-up makes memory pressure recoverable, diagnosable, and explicitly configurable.

## Validation

- Fresh rerun of Hub JVM-settings tests
- Fresh rerun of editor pressure-monitor, crash-support, and preview tests
- Fresh rerun of bounded-image-cache stress tests and JavaFX cache tests
- Shell launch-script syntax validation
- Direct and Gradle launch probes verified exact heap propagation, including Gradle configuration-cache reuse